### PR TITLE
feat(pump): bump to v0.2.5 (adversarial-review batch)

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.4@sha256:207490e7716e7c378557e62ac4d36d3dfb0220fbd8bdd8a7d863eb97d691aad4
+              tag: v0.2.5@sha256:b780d27c729f9b2ebcb5dcd9677643cb6f7e4940c2e50801c835c2b720d760c3
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls the pump server to `ghcr.io/rwlove/pump:v0.2.5` (digest `sha256:b780d27c…d760c3`).

Ships the adversarial-review batch from [PUMP #129](https://github.com/rwlove/PUMP/pull/129):
- Weight-ingest validation parity (manual form was persisting 0-lb weigh-ins)
- Voltra load now gated on a successful arm (motor-safety)
- Wall calibration empty-captures `Math.min`→`Infinity` fix
- All-time streaks (were truncated to the display window)
- Period-filter timezone off-by-one fix
- Pie slice contrast + a `confirm()` on set delete

No schema migration. Rolling update; StatefulSet with reloader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)