### PR TITLE
ci: authenticate ghcr.io pulls in flate + image-registry jobs

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -55,11 +55,26 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - filter-changes
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # Authenticate to ghcr.io so flate's chart/image pulls use the
+      # authenticated rate-limit tier, not the shared-egress anonymous one
+      # that trips `429 toomanyrequests` (see the cache note below). flate
+      # honors ~/.docker/config.json, which docker/login-action writes; the
+      # built-in GITHUB_TOKEN authenticates to ghcr.io — no secret needed.
+      - name: Login to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup flate
         uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0
@@ -104,6 +119,7 @@ jobs:
       - filter-changes
     permissions:
       contents: read
+      packages: read
       pull-requests: write
     steps:
       - name: Checkout Pull Request Branch
@@ -118,6 +134,14 @@ jobs:
           ref: "${{ github.event.repository.default_branch }}"
           path: default
           persist-credentials: false
+
+      # Authenticated ghcr.io pulls (see the `test` job). No secret needed.
+      - name: Login to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup flate
         uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0

--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - filter-changes
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         branches:
@@ -56,6 +59,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: "${{ matrix.branches == 'default' && github.event.repository.default_branch || '' }}"
+
+      # Authenticated ghcr.io pulls (see flate.yaml). No secret needed.
+      - name: Login to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup flate
         uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0


### PR DESCRIPTION
## What

Add a `docker/login-action` step to ghcr.io in each flate-rendering job —
`flate test`, `flate diff`, and Image Registry Check's `extract-images`.

## Why

These jobs render the tree on GitHub-hosted runners by pulling charts and
image manifests from public registries. The pulls are **anonymous**, and
GitHub's shared egress pool trips ghcr.io's `429 toomanyrequests` — the same
failure that took down main twice on 2026-07-31 (see the existing cache note
in `flate.yaml`). `cache: true` mitigates warm runs, but a cold cache
(new/evicted chart) still pulls anonymously.

flate honors `~/.docker/config.json`, which `docker/login-action` writes, so
after login its pulls use the **authenticated** rate-limit tier.

## How

- `docker/login-action@v4.6.0` → `ghcr.io`, using the built-in `GITHUB_TOKEN`
  (`github.actor` / `secrets.GITHUB_TOKEN`). **No new secret** — the token is
  provided to every job automatically.
- `packages: read` added to each flate-running job so the token can read
  packages.

## Notes

- CI-only. No cluster impact, no maintenance window. Independent of #13630.
- Self-testing: this PR edits both workflows, so both run here and exercise
  the new login step.
- docker.io pulls stay anonymous for now — the Docker Hub PAT exists only
  in-cluster (1Password → Renovate operator), not as a GitHub secret. ghcr.io
  is where the 429s actually are; a docker.io login can be added later via the
  existing `OP_SERVICE_ACCOUNT_TOKEN` if Docker Hub limits ever bite.