### PR TITLE
feat(cilium): return ICMP unreachable on policy-denied egress

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -38,6 +38,14 @@ bpfClockProbe: true
 
 l7Proxy: true
 
+# Return ICMP "destination unreachable" for egress denied by network policy
+# instead of silently black-holing it (chart default `none`). Without this,
+# a denied connection presents as a TCP connect *timeout*, not a clean
+# rejection — apps hang for the full timeout and the drop is easy to
+# misread as a service outage. Cilium 1.19+ ("Actively Deny Connections").
+# Enforced denies only; audit-mode policies are unaffected.
+policyDenyResponse: icmp
+
 ipam:
   mode: "kubernetes"
 


### PR DESCRIPTION
Sets `policyDenyResponse: icmp` on the Cilium HelmRelease values (chart default is `none`). Follow-up from the 1.20.1 upgrade (#13381) — this is a Cilium 1.19+ feature ("Actively Deny Connections") now available to us.

## What & why
Today a connection blocked by network policy is a **silent BPF black-hole** — no ICMP is returned, so the client sees a full TCP **connect timeout**, not a rejection. That reads like a service outage and has cost real debugging time (memory: `reference_cilium_bpf_drop_presents_as_timeout`). With `policyDenyResponse: icmp`, denied egress returns ICMP destination-unreachable and the app **fails fast**.

- Enforced denies only — audit-mode policies are unaffected.
- Pairs with the egress default-deny / FQDN-baselining work; makes those denials debuggable instead of mysterious hangs.

## Blast radius / why draft
Applying this regenerates the datapath, so Flux will **roll the cilium-agent DaemonSet** (~6 waves, `maxUnavailable=2`, no node reboot) — the same DNS-proxy disruption profile as the 1.20.1 upgrade, since we run embedded Envoy + `l7Proxy`. That touches the Renee-facing `toFQDNs` consumers (Home Assistant, Frigate, ESPHome).

**Held as draft for the Tuesday 02:00–04:00 ET window** per AGENTS.md. Behavior change to watch after rollout: apps that previously *tolerated* a denied path by timing out will now get an immediate ICMP error — this is the intended improvement, but worth confirming nothing was silently relying on the slow-fail.

## Verification after merge
- `cilium-agent` rolls cleanly, 0 restarts, CPU normal (as in #13381).
- Trigger a known-denied egress and confirm fast ICMP failure vs prior timeout.
- Hubble drops unchanged in shape; home-namespace drop rate steady.