### PR TITLE
feat(observability): alert on Cilium config drift

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./prometheusrule-admission-webhooks.yaml
+  - ./prometheusrule-cilium-config-drift.yaml
   - ./prometheusrule-cilium-drops.yaml
   - ./prometheusrule-egress-detection.yaml
   - ./prometheusrule-node-disk-io.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-cilium-config-drift.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-cilium-config-drift.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cilium-config-drift
+spec:
+  groups:
+    # Cilium config-drift visibility. We drive Cilium's config entirely via
+    # `valuesFrom` into the cilium-config ConfigMap. A ConfigMap change only
+    # takes effect once the agents pick it up (many settings are read at
+    # startup, so they need `rollOutCiliumPods` / an agent restart). Until
+    # then the agent runs stale config silently — the exact failure mode
+    # that makes a "merged the PR but nothing changed" bug hard to spot.
+    #
+    # Metric: `cilium_drift_checker_config_delta` (cilium-agent, port 9962)
+    # is the count of config keys where the agent's active setting differs
+    # from the cilium-config ConfigMap. Shipped by the drift checker that is
+    # enabled by default as of Cilium 1.20 (`configDriftDetection.driftChecker`).
+    # 0 = agent matches ConfigMap. Verified live 2026-08-21: all 11 agents 0.
+    #
+    # A non-zero delta is expected briefly while a config rollout is in
+    # flight; the 30m `for` tolerates a normal rollout while catching config
+    # that is stuck unapplied (e.g. a change that needed a pod roll that
+    # never happened).
+    - name: cilium-config-drift
+      rules:
+        - alert: CiliumConfigDrift
+          annotations:
+            description: >-
+              cilium-agent on {{ $labels.node }} ({{ $labels.pod }}) has
+              {{ $value | humanize }} config key(s) that differ from the
+              cilium-config ConfigMap for 30m+. A cilium-config change has
+              not been applied to this agent — roll the Cilium DaemonSet
+              (rollOutCiliumPods) or restart the agent to converge.
+            summary: Cilium agent config drift on {{ $labels.node }}.
+          expr: |
+            max by (node, pod) (cilium_drift_checker_config_delta) > 0
+          for: 30m
+          labels:
+            severity: warning


### PR DESCRIPTION
## What

Adds a `PrometheusRule` (`cilium-config-drift`) that alerts when a
cilium-agent's active config diverges from the `cilium-config` ConfigMap
for 30m+.

## Why

Cilium 1.20 (adopted in #13381) enables the config-drift checker by
default (`configDriftDetection.driftChecker`). The
`cilium_drift_checker_config_delta` metric is **already scraped** on all
11 agents and currently reads `0` — but nothing alerts on it.

We drive Cilium's config entirely via `valuesFrom` into the
`cilium-config` ConfigMap. Many settings are read only at agent startup,
so a ConfigMap change doesn't take effect until the agents are rolled
(`rollOutCiliumPods`) or restarted. Until then the agent silently runs
stale config — the "merged the PR but nothing changed" failure mode.
This alert closes that loop.

## Behavior

- `expr: max by (node, pod) (cilium_drift_checker_config_delta) > 0`
- `for: 30m` — tolerates a normal config rollout in flight while catching
  config that is stuck unapplied.
- `severity: warning`

## Verification

- `flate test ks kube-prometheus-stack` → passed.
- Confirmed the rule renders (`flate build ks kube-prometheus-stack`).
- Confirmed the underlying metric is live and reads `0` across all agents
  via Prometheus before wiring the alert.

Surfaced while mining recent-upgrade release notes for adoptable features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)