### PR TITLE
feat(mcp-grafana): run read-only with --disable-write

### DIFF
--- a/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
@@ -32,6 +32,11 @@ spec:
               - streamable-http
               - --address
               - 0.0.0.0:8000
+              # Read/query-only: this MCP is used for observability, not for
+              # mutating Grafana. --disable-write drops the create/update
+              # tools (dashboards, alert rules, snapshots, etc.), shrinking
+              # the tool blast radius. Added mcp-grafana 1.x.
+              - --disable-write
             env:
               GRAFANA_URL: http://grafana.observability.svc.cluster.local
             envFrom:


### PR DESCRIPTION
## What

Adds `--disable-write` to the grafana-mcp container args, dropping
mcp-grafana's write tool surface (create/update dashboards, alert rules,
snapshots, etc.).

## Why

This MCP server is used for observability **queries**, not for mutating
Grafana. Running it read-only shrinks the tool blast radius behind the
MCP gateway. Confirmed no Claude/opencode workflow relies on the write
tools.

Flag verified present in the deployed mcp-grafana 1.1.0.

## Verification

- `flate test ks grafana-mcp` → passed.
- Confirmed `--disable-write` renders into the container args.

Surfaced while mining recent-upgrade release notes for adoptable features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)