### PR TITLE
feat(observability): alert on mcp-gateway tool-call failures

### DIFF
--- a/kubernetes/apps/observability/loki/app/configmap.yaml
+++ b/kubernetes/apps/observability/loki/app/configmap.yaml
@@ -101,3 +101,28 @@ data:
               category: logs
             annotations:
               summary: "Node-Red is unable to connect to Home Assistant"
+
+      # Kuadrant mcp-gateway per-tool-call audit trail (broker v0.9.0+ emits
+      # `level=INFO msg="tool call" ... audit=true ... status=<code>`). A
+      # sustained burst of non-200 tool calls means an MCP backend is down /
+      # erroring, or the tool surface is being probed. Line-filter style (not
+      # `| logfmt`) mirrors the other rules here and is robust to the Loki
+      # sink's json event encoding. status=200 is the success case; anything
+      # else is a failed call. Verified live 2026-08-21: broker on v0.9.0,
+      # stream is {app="mcp-gateway", namespace="mcp-system"}.
+      - name: mcp-gateway
+        rules:
+          - alert: MCPGatewayToolCallFailures
+            expr: |
+              sum(count_over_time({app="mcp-gateway", namespace="mcp-system"} |= "audit=true" != "status=200" [5m])) > 5
+            for: 5m
+            labels:
+              severity: warning
+              category: logs
+            annotations:
+              summary: "mcp-gateway: sustained failed MCP tool calls"
+              description: >-
+                {{ $value | humanize }} MCP tool calls returned a non-200
+                status in the last 5m. Check the mcp-gateway broker logs
+                (audit=true lines) for the failing tool/server/status — a
+                backend MCP server is likely down or erroring.


### PR DESCRIPTION
## What

Adds a Loki ruler alert (`MCPGatewayToolCallFailures`) that fires when
mcp-gateway logs a sustained burst of non-200 MCP tool calls.

## Why

Kuadrant mcp-gateway v0.9.0 emits a structured per-tool-call audit trail
(`level=INFO msg="tool call" component=router audit=true tool=... server=...
status=<code> ...`). We had no signal on it. A sustained run of non-200
tool calls means a backend MCP server is down/erroring, or the tool
surface is being probed (pairs with the tool-flood-guard concern in
#13622/#13625).

## Rule

- `sum(count_over_time({app="mcp-gateway", namespace="mcp-system"} |= "audit=true" != "status=200" [5m])) > 5`
- `for: 5m`, `severity: warning`, `category: logs`
- Line-filter style (not `| logfmt`) matches the other LogQL rules in this
  ConfigMap and is robust to the Loki sink's json event encoding.

## Verification

- Confirmed live: broker pod on `ghcr.io/kuadrant/mcp-gateway:v0.9.0` is
  emitting `audit=true` lines (all `status=200` in the sampled window).
- Confirmed the Loki stream labels: Vector maps `app` from
  `app.kubernetes.io/name` (= `mcp-gateway`) and `namespace`, with no
  namespace exclusion — so mcp-system logs reach Loki.
- `flate test ks loki` → passed; rule renders.

Surfaced while mining recent-upgrade release notes for adoptable features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)