### PR TITLE
feat(observability): scrape Envoy Gateway control plane + alert on xDS NACKs

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/config/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
   - ./envoy.yaml
   - ./external.yaml
   - ./internal.yaml
+  - ./podmonitor-controller.yaml
   - ./podmonitor.yaml
+  - ./prometheusrule.yaml
   - ./securitypolicy-external.yaml

--- a/kubernetes/apps/network/envoy-gateway/config/podmonitor-controller.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/podmonitor-controller.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-gateway
+spec:
+  # The envoy-gateway CONTROL PLANE (operator) pod, distinct from the
+  # data-plane proxy pods scraped by the `envoy-proxy` PodMonitor. The
+  # controller exposes Prometheus metrics on the named `metrics` port
+  # (19001) at /metrics — enabled by default in Envoy Gateway. Ingress on
+  # 19001 is already permitted by the `envoy-gateway-allow` CNP.
+  jobLabel: envoy-gateway
+  namespaceSelector:
+    matchNames:
+      - network
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      honorLabels: true
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway

--- a/kubernetes/apps/network/envoy-gateway/config/prometheusrule.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/prometheusrule.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: envoy-gateway-xds
+spec:
+  groups:
+    # Envoy Gateway xDS push health. `xds_nack_total` (added in Envoy
+    # Gateway 1.9.0, exposed by the controller on :19001/metrics) counts
+    # config pushes the data-plane Envoys REJECTED. A NACK means a
+    # translated resource (HTTPRoute / SecurityPolicy / *Policy) was
+    # invalid and the running Envoys kept their old config — a change that
+    # looks merged in Git but never took effect on the data plane. This is
+    # otherwise invisible: EG's own resources can look healthy while the
+    # push silently fails.
+    #
+    # Requires the `envoy-gateway` PodMonitor (this dir) scraping the
+    # controller. `xds_nack_total` does not exist until the controller is
+    # scraped; the alert stays inactive while the series is absent/zero.
+    - name: envoy-gateway-xds
+      rules:
+        - alert: EnvoyGatewayXdsNACK
+          annotations:
+            description: >-
+              Envoy Gateway received {{ $value | humanize }} xDS NACK(s) from
+              the data-plane Envoys in the last 10m — a translated resource
+              was rejected and the proxies are running stale config. Check
+              the envoy-gateway controller logs and the most recent
+              HTTPRoute / SecurityPolicy / *Policy change.
+            summary: Envoy Gateway xDS config push is being NACKed.
+          expr: |
+            sum(increase(xds_nack_total[10m])) > 0
+          for: 10m
+          labels:
+            severity: warning


### PR DESCRIPTION
## What

- Adds a `PodMonitor` (`envoy-gateway`) scraping the Envoy Gateway
  **control-plane** pod on the `metrics` port (19001, `/metrics`).
- Adds a `PrometheusRule` (`EnvoyGatewayXdsNACK`) alerting on sustained
  xDS NACKs.

## Why

Envoy Gateway 1.9.0 adds `xds_nack_total` — config pushes the data-plane
Envoys **rejected**. A NACK means a translated resource
(HTTPRoute/SecurityPolicy/*Policy) was invalid and the proxies kept
running stale config: a change that looks merged in Git but never took
effect on the data plane, and is otherwise invisible.

The control plane exposes metrics by default, but we weren't scraping it
(no `envoy_gateway_*`/`xds_*` series in Prometheus — only the data-plane
proxy PodMonitor existed). Ingress on 19001 is already permitted by the
`envoy-gateway-allow` CNP, so no network-policy change is needed.

## Alert

- `sum(increase(xds_nack_total[10m])) > 0`, `for: 10m`, `severity: warning`.
- `xds_nack_total` does not exist until the controller is scraped; the
  alert stays inactive while the series is absent/zero.

## Verification

- Confirmed the controller (`mirror.gcr.io/envoyproxy/gateway:v1.9.0`)
  exposes the named `metrics` port 19001; metric name `xds_nack_total`
  per upstream docs.
- Confirmed no `envoy_gateway_*` series exist today (control plane
  unscraped).
- `flate test ks envoy-gateway-config` → passed; both resources render.

Post-merge: confirm `xds_nack_total` appears in Prometheus once the
PodMonitor is active (guards against a silent no-match).

Surfaced while mining recent-upgrade release notes for adoptable features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)