### PR TITLE
fix(loki): pin OSS image to 3.7.6 (chart default is stale 3.6.11)

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -25,6 +25,14 @@ spec:
       auth_enabled: false
       analytics:
         reporting_enabled: false
+      image:
+        # Chart 7.3.0 is the FINAL OSS release of the grafana/loki chart —
+        # it went GEL-maintenance-only on 2026-03-16 (grafana/loki#20705)
+        # and defaults to a stale Loki 3.6.11. Pin the OSS image to a
+        # current 3.7.x explicitly until we migrate to the actively
+        # maintained grafana-community fork chart.
+        # renovate: datasource=docker depName=docker.io/grafana/loki
+        tag: 3.7.6
       podAnnotations:
         configmap.reloader.stakater.com/reload: loki-chunks-bucket-v1
       commonConfig:


### PR DESCRIPTION
## What

Pins `loki.image.tag` to **3.7.6** (Renovate-tracked). We currently run
`docker.io/grafana/loki:3.6.11`.

## Why

The `grafana/loki` Helm chart went **GEL-maintenance-only** on
2026-03-16 (grafana/loki#20705). Chart **7.3.0 is its final OSS
release** and defaults to a stale Loki **3.6.11**, while current OSS is
3.7.x. We set no image override → silently frozen on 3.6.11, and
Renovate can't move us within the frozen chart line.

This is the **stop-gap**. The durable fix — migrating the OCIRepository
to the actively-maintained `grafana-community` fork chart
(`oci://ghcr.io/grafana-community/helm-charts/loki`, currently
`loki-18.11.0` / appVersion 3.7.6) — is tracked as a follow-up for a
maintenance window (needs a StatefulSet name/selector diff first).

## Safety

Verified against Loki 3.7.0's release notes: its three breaking changes
are all query-engine internals (scheduler capacity, structured-metadata
label precedence, worker-thread sharing) — **none touch storage/S3/ruler/
schema config**. The AWS SDK v2 / stricter S3 endpoint validation landed
in 3.6.0, already baked into our running 3.6.11.

## Verification

- `flate test ks loki` → passed.
- `flate build hr loki` renders `image: docker.io/grafana/loki:3.7.6`.

## ⚠️ Merge note

Merging restarts the single-binary Loki pod → **brief internal
log-ingestion gap** (Vector retries; not Renee-facing). Suggest merging
in a routine maintenance window (any night 02:00–05:00 ET), not
auto-merged. Source-of-truth log data lives in the S3/ceph bucket, not
the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)