### PR TITLE
chore(security): app-template SA-token hardening — canary (it-tools/bentopdf/nametag)

### DIFF
--- a/kubernetes/apps/collab/bentopdf/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/bentopdf/app/helmrelease.yaml
@@ -11,6 +11,9 @@ spec:
 
   interval: 30m
   values:
+    defaultPodOptions:
+      # No k8s API access needed — don't mount a ServiceAccount token.
+      automountServiceAccountToken: false
     controllers:
       bentopdf:
         pod:

--- a/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
@@ -11,6 +11,9 @@ spec:
 
   interval: 30m
   values:
+    defaultPodOptions:
+      # No k8s API access needed — don't mount a ServiceAccount token.
+      automountServiceAccountToken: false
     controllers:
       it-tools:
         annotations:

--- a/kubernetes/apps/collab/nametag/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/nametag/app/helmrelease.yaml
@@ -11,6 +11,9 @@ spec:
 
   interval: 30m
   values:
+    defaultPodOptions:
+      # No k8s API access needed — don't mount a ServiceAccount token.
+      automountServiceAccountToken: false
     controllers:
       nametag:
         pod:


### PR DESCRIPTION
## What

Sets `defaultPodOptions.automountServiceAccountToken: false` on three
app-template releases that make no Kubernetes API calls: `it-tools`,
`bentopdf`, `nametag`.

## Why

common 5.1.0 makes SA-token mounting controllable. Most of our
app-template apps never touch the k8s API, so mounting a ServiceAccount
token is pure blast-radius. The same mechanism already runs in prod on
other app-template releases.

## Rollout

**This is the canary** (batch 1) of a staged sweep across the ~99
app-template releases that don't use the API. The apps that do (in-repo
RBAC, values `serviceAccount`/`rbac` blocks, already-hardened, or
device-plugin adjacency) are **excluded**. Remaining batches roll out
per-namespace after this canary is confirmed healthy.

## Verification

- `flate build hr` renders `automountServiceAccountToken: false` at the
  pod level for all three.
- `flate test ks` → passed for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)