### PR TITLE
Revert app-template SA-token hardening canary (no-op)

### DIFF
--- a/kubernetes/apps/collab/bentopdf/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/bentopdf/app/helmrelease.yaml
@@ -11,9 +11,6 @@ spec:
 
   interval: 30m
   values:
-    defaultPodOptions:
-      # No k8s API access needed — don't mount a ServiceAccount token.
-      automountServiceAccountToken: false
     controllers:
       bentopdf:
         pod:

--- a/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
@@ -11,9 +11,6 @@ spec:
 
   interval: 30m
   values:
-    defaultPodOptions:
-      # No k8s API access needed — don't mount a ServiceAccount token.
-      automountServiceAccountToken: false
     controllers:
       it-tools:
         annotations:

--- a/kubernetes/apps/collab/nametag/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/nametag/app/helmrelease.yaml
@@ -11,9 +11,6 @@ spec:
 
   interval: 30m
   values:
-    defaultPodOptions:
-      # No k8s API access needed — don't mount a ServiceAccount token.
-      automountServiceAccountToken: false
     controllers:
       nametag:
         pod:


### PR DESCRIPTION
## What

Reverts #13650, removing the explicit
`defaultPodOptions.automountServiceAccountToken: false` from `it-tools`,
`bentopdf`, `nametag`.

## Why

#13650 was a **verified no-op**. Investigation (the pods never rolled)
showed the app-template chart already renders these pods with
`automountServiceAccountToken: false` by default — the explicit setting
produced an identical pod template, so no rollout occurred.

A cluster-wide check confirmed **every** app-template candidate pod
already runs with the token unmounted; the only pods mounting a token
are the expected k8s-API users. So there was nothing to harden, and the
three explicit settings were just redundant noise inconsistent with the
other ~97 releases that rely on the chart default. Removing them.

## Verification

- `flate test ks` → passed for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)