### PR TITLE
revert(searxng-mcp): roll back to 1.16.0 — 2.0.0 breaks mcp-gateway broker federation

### DIFF
--- a/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: docker.io/isokoliuk/mcp-searxng
-              tag: "2.0.0@sha256:485544ea18394c8c971f3db0f4f75d61422f7a95aae64fc72ca86118f4f05ce4"
+              tag: "1.16.0@sha256:d892b5aede28ab6476ba7ab3ce6b7e2e564ee43888e9c39ac5df52b74e1ca74d"
             env:
               SEARXNG_URL: http://searxng.collab.svc.cluster.local:8080
               # MCP_HTTP_HOST defaults to 127.0.0.1 (loopback-only), so the


### PR DESCRIPTION
Reverts #13679.

**Canary-tested and failed.** mcp-searxng 2.0.0 introduces strict HTTP protocol enforcement that rejects the Kuadrant mcp-gateway broker's session handshake (server logs `POST request rejected - invalid request: hasInitializeRequest=false, sessionId=undefined`). The broker hit its failure threshold and de-federated the search tools.

Rolling back to the known-good 1.16.0 pin to restore search federation. Re-attempt needs an upstream-compatible broker handshake (stateful session / MCP-Protocol-Version negotiation) before 2.0.0 can be adopted.