### PR TITLE
fix(mcp): grant searxng-mcp world egress so url_read works

### DIFF
--- a/kubernetes/apps/mcp-system/searxng-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/cnp-allow.yaml
@@ -23,3 +23,15 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # search_web_url_read does a DIRECT fetch from this pod to arbitrary
+    # result URLs (not via searxng), so it needs world egress or it aborts
+    # on every external host. Same pattern as github-mcp / chrome-mcp;
+    # mirrors searxng's own egress in collab/searxng/app/cnp-allow.yaml.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP


### PR DESCRIPTION
## Problem

`search_web_url_read` (one of the four searxng MCP tools) fetches result URLs **directly from the `searxng-mcp` pod** — not via searxng. Under the `mcp-system` namespace default-deny, the pod's CNP only allowed egress to `searxng:8080`, so every external fetch aborted (`operation was aborted`). The search tools work because they route through searxng, which has its own world egress.

Verified live: `web_search` returns results; `url_read` fails on `example.com`, GitHub raw, and `github.com`.

## Fix

Add `toEntities: [world]` :443/:80 egress to `searxng-mcp-allow`, mirroring searxng's own egress and the established `github-mcp` / `chrome-mcp` pattern. Additive rule; no existing rules changed; no pod restart required.

## Verify after reconcile

Re-run `search_web_url_read` against any external URL — should return markdown instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)