### PR TITLE
build(renovate): pin mcp-searxng <2.0.0 + annotate workaround

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -99,6 +99,21 @@
       matchDatasources: ["docker"],
       matchPackageNames: ["docker.io/ollama/ollama"],
       schedule: ["after 2am and before 5am"],
+    },
+    {
+      // Hold mcp-searxng below 2.0.0. 2.0.0 introduced strict streamable-HTTP
+      // enforcement that rejects the Kuadrant mcp-gateway broker's session-less
+      // ping (`hasInitializeRequest=false, sessionId=undefined`), so the broker
+      // hits its failure threshold and de-federates the search tools. Canary
+      // #13679 failed and was reverted (#13680). Re-attempt needs a broker-
+      // compatible handshake first — track ihor-sokoliuk/mcp-searxng#256 and
+      // Kuadrant/mcp-gateway#1419. See workaround annotation in
+      // kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml and memory
+      // reference_mcp_searxng_20_breaks_kuadrant_broker.
+      description: "Hold mcp-searxng <2.0.0 — 2.0.0 breaks Kuadrant mcp-gateway broker federation (#13680)",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/isokoliuk/mcp-searxng"],
+      allowedVersions: "<2.0.0",
     }
   ]
 }

--- a/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
@@ -26,6 +26,7 @@ spec:
           app:
             image:
               repository: docker.io/isokoliuk/mcp-searxng
+              # workaround: https://github.com/ihor-sokoliuk/mcp-searxng/issues/256 — remove when 2.0.0 accepts the Kuadrant mcp-gateway broker session handshake (or the broker adds stateless-ping support, Kuadrant/mcp-gateway#1419). 2.0.0's strict streamable-HTTP enforcement de-federates the search tools; held at 1.16.0. Renovate pinned <2.0.0 in .github/renovate/packageRules.json5.
               tag: "1.16.0@sha256:d892b5aede28ab6476ba7ab3ce6b7e2e564ee43888e9c39ac5df52b74e1ca74d"
             env:
               SEARXNG_URL: http://searxng.collab.svc.cluster.local:8080


### PR DESCRIPTION
## Why

The 2.0.0 bump (#13679) was reverted (#13680) because 2.0.0's strict streamable-HTTP enforcement rejects the Kuadrant mcp-gateway broker's session-less ping, de-federating the search tools. Nothing currently stops Renovate from re-opening the same 2.0.0 bump and regressing federation.

## Change

- **`.github/renovate/packageRules.json5`** — `allowedVersions: "<2.0.0"` for `docker.io/isokoliuk/mcp-searxng` so Renovate holds the line (same pattern as the music-assistant pin).
- **`searxng-mcp/app/helmrelease.yaml`** — `# workaround:` annotation on the pinned image per `.agents/instructions/workarounds.md`, so the upstream-watcher can retire it when upstream catches up.

## Tracking

- Tracking issue: #13682 (label `workaround`) — **not** closed by this PR; closes when the pin is removed after upstream compatibility lands.
- Upstream: ihor-sokoliuk/mcp-searxng#256, Kuadrant/mcp-gateway#1419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)