### PR TITLE
fix(rook-ceph): rotate CephX keys to aes256k (CVE-2025-30156)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -133,6 +133,20 @@ spec:
             cpu: 100m
             memory: 4Gi
 
+      # Rotate CephX daemon keys (mon/mgr/osd/mds, RGW, and Rook's admin key)
+      # from legacy AES to the aes256k cipher — the fix for CVE-2025-30156. This
+      # clears the AUTH_INSECURE_SERVICE_KEY_TYPE + AUTH_INSECURE_SERVICE_TICKETS
+      # HEALTH_ERR. Rook drives the rotation and the OSD bluestore-label + keyring
+      # Secret sync; it triggers a rolling daemon restart (PVCs stay active). CSI
+      # and other client keys stay on AES for now (aes256k needs node kernel
+      # >= 7.0) — that residual is HEALTH_WARN only and tracked separately. Bump
+      # keyGeneration to rotate again in the future.
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+
       storage:
         config:
           osdsPerDevice: "1"


### PR DESCRIPTION
## What

Retires the Ceph `HEALTH_ERR` caused by CVE-2025-30156 by rotating CephX daemon keys to the new `aes256k` cipher.

## Why

The cluster runs the **patched Ceph `v20.2.4`** binary, but its CephX keys are still **generation-1 AES**, minted under 19.2.3. That mismatch is the *entire* cause of the current `HEALTH_ERR`:

- `AUTH_INSECURE_SERVICE_KEY_TYPE` (ERR) — 12 service entities on insecure key types
- `AUTH_INSECURE_SERVICE_TICKETS` (ERR) — mons issuing insecure service tickets

## Change (`cluster/helmrelease.yaml`)

`cephClusterSpec.security.cephx.daemon` → `keyRotationPolicy: KeyGeneration`, `keyGeneration: 2` — rotates mon/mgr/osd/mds (+RGW) + Rook admin key to `aes256k`. Rook drives the rotation, OSD bluestore-label update, and keyring Secret sync.

No image pin: the `rook-ceph-cluster` v1.20.6 chart already defaults `cephVersion.image` to `v20.2.4` (an earlier attempt to pin it duplicated the chart's own `cephVersion` key and broke rendering — CI caught it).

## Safety pre-flight — PASSED ✅

`ceph mon dump` confirms the mons already allow **`aes,aes256k`**, so the rotated keys authenticate cleanly (no daemon lockout).

## Blast radius / disruption

Rolling restart of all core Ceph daemons (mon/mgr/osd/mds). PVCs stay active throughout (per Rook advisory). Maintenance window waived by Rob.

## Expected outcome

`HEALTH_ERR` clears → drops to `HEALTH_WARN`. Residual warnings are the **documented transition state**, safe to mute:

- `AUTH_INSECURE_CLIENT_KEY_TYPE` — CSI/client keys stay AES (aes256k needs node kernel ≥ 7.0)
- `AUTH_INSECURE_KEYS_ALLOWED` / `_CREATABLE` — clear only after all clients rotated
- `AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` — self-clears as tickets age out

`RECENT_MGR_MODULE_CRASH` is unrelated (known mgr prometheus-module leak, handled by mgr-recycle).

Ref: https://rook.io/docs/rook/latest-release/Storage-Configuration/Advanced/cephx-key-rotation/

🤖 Generated with [Claude Code](https://claude.com/claude-code)