### PR TITLE
fix(rook-ceph): raise HelmRelease timeout to 30m + stop auto-rollback

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -9,6 +9,20 @@ spec:
     kind: OCIRepository
     name: rook-ceph-cluster
   interval: 1h
+  # A Ceph point-release bump rolls all OSDs one at a time; on this 8-OSD
+  # cluster that can exceed 15m. The default 15m timeout expiring mid-upgrade
+  # is what wedged the v1.20.6 bump (#13662): Helm rolled the CephCluster spec
+  # back to the old cephVersion while Rook kept the daemons on the new one,
+  # leaving Rook stuck "waiting for upgrade to finish" indefinitely. Give the
+  # upgrade room, and do NOT auto-rollback the terminal failure — a chart
+  # rollback that reverts cephVersion is never safe on a live cluster.
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: false
   postRenderers:
     # The rook-ceph cluster chart ships CephNodeDiskspaceWarning with
     # `device=~"/.*"` — which matches every block device on the node,
@@ -279,4 +293,4 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
-  timeout: 15m
+  timeout: 30m


### PR DESCRIPTION
## Why

The `v1.20.6` Renovate bump (#13662) wedged the `rook-ceph-cluster` HelmRelease at 13:36 EDT today. Root cause: an 8-OSD Ceph point-release upgrade rolls each OSD one at a time and **exceeded the 15m Helm `--wait`**, so Flux rolled the CephCluster spec back to the old `cephVersion` (`v20.2.2`) while Rook kept the daemons on the new one (`v20.2.4`). Rook then parked reconcile — `waiting for ceph monitors upgrade to finish. current: 20.2.4 != expected: 20.2.2` — indefinitely, so CephCluster never reported Ready and every Helm op timed out (`UpgradeFailed` → `RollbackFailed` → pending-rollback).

No data/service outage (265/265 PGs `active+clean`), but GitOps reconcile is frozen for everything gated on rook-ceph-cluster.

## Change

- `timeout` 15m → **30m** so a full daemon roll fits inside the Helm wait.
- `upgrade.remediation.remediateLastFailure: false` — a terminal upgrade failure is left `failed` for the next reconcile to retry, instead of a **chart rollback that reverts `cephVersion` out from under running daemons** (the mechanism that created the wedge).

Part of unwedging the HelmRelease so the merged CephX key-rotation (#13684) can finally apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)