### PR TITLE
fix(goldilocks): raise controller memory limit 200Mi→512Mi (OOMKilled)

### DIFF
--- a/kubernetes/apps/observability/goldilocks/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/helmrelease.yaml
@@ -18,11 +18,10 @@ spec:
         enableArgoproj: false
       resources:
         limits:
-          memory: 200Mi
-
+          memory: 512Mi
         requests:
           cpu: 25m
-          memory: 200Mi
+          memory: 256Mi
     dashboard:
       # Same rationale as controller above.
       rbac:


### PR DESCRIPTION
## What

Raise the `goldilocks-controller` memory limit from `200Mi` to `512Mi`, and lift the request from `200Mi` to `256Mi` (Burstable).

## Why

`goldilocks-controller` was OOMKilled — restarted twice and back at ~83% of the `200Mi` limit and climbing — firing a critical `OOMKilled` alert. The controller's memory footprint scales with the number of workloads it watches across the cluster, so a `200Mi` Guaranteed limit is too tight during full-cluster resyncs.

Dashboard resources are untouched (it wasn't OOMing).

## Verification

- Local pre-submit passed (yamllint, schema, secret checks).
- Post-merge: confirm `goldilocks-controller` stops restarting and the `OOMKilled` alert clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)