### PR TITLE
fix(gpu-operator): skip cuda-validation on the Pascal P40 (CUDA 13 dropped sm_61)

### DIFF
--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/gpu-operator-pascal-validator-skip.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/gpu-operator-pascal-validator-skip.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/nfd.k8s-sigs.io/nodefeaturerule_v1alpha1.json
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: gpu-operator-pascal-validator-skip
+spec:
+  # workaround: https://github.com/NVIDIA/gpu-operator/issues/389 — remove when gpu-operator makes cuda-validation architecture-aware (skips GPUs the bundled CUDA can't target) OR restores a per-validation disable toggle
+  # Tracking: home-ops#13689
+  #
+  # gpu-operator's `nvidia-operator-validator` runs a `cuda-validation`
+  # initContainer (`vectorAdd`) built against the operator image's CUDA
+  # toolkit. As of v26.7.0 that is CUDA 13, which dropped code generation
+  # for Pascal (sm_61). The Tesla P40 (compute capability 6.1) therefore
+  # has no kernel image in the sample and the validation fails:
+  #
+  #   Failed to launch vectorAdd kernel (error code named symbol not found)!
+  #
+  # The validator pod stays Init:Error, so the DaemonSet is perpetually
+  # not-ready on the P40 node (desired=2, ready=1 — the Spark / Blackwell
+  # node validates fine), firing KubeDaemonSetRolloutStuck +
+  # KubeContainerWaiting + KubePodNotReady forever.
+  #
+  # This is a FALSE NEGATIVE, not a real fault: the device-plugin is
+  # healthy, nvidia.com/gpu:8 (time-sliced) is allocatable, the HelmRelease
+  # is Ready, and real CUDA-12 workloads (ollama etc.) run on the P40. The
+  # validator is testing the card with a CUDA version that cannot target it.
+  #
+  # The gpu-operator chart exposes no per-check disable (validator values
+  # cover only env/args/plugin.env/image), and pinning the operator is a
+  # dead end — CUDA 13 dropped Pascal permanently and R580 is NVIDIA's last
+  # driver branch to support it, so every future version fails identically.
+  #
+  # Fix: opt the P40 out of the operator-validator DaemonSet via the
+  # documented gpu-operator label `nvidia.com/gpu.deploy.operator-validator
+  # =false`. The operator honors an externally-set deploy label and stops
+  # scheduling the operand there — the same mechanism this repo already uses
+  # to skip the container-toolkit DS on CRI-O nodes
+  # (gpu-operator-runtime-override.yaml). The DaemonSet's desired count
+  # drops to 1 (Spark only), goes fully ready, and the alerts clear at the
+  # source. The device-plugin, GFD, DCGM and node-status-exporter operands
+  # are unaffected — none depend on the validator, and P40 serving is
+  # already independently monitored (device-plugin health + ollama probe).
+  #
+  # Scoped precisely to the P40 by PCI id (10de:1b38) rather than by runtime
+  # so a future non-Pascal GPU on any node still gets validated normally.
+  rules:
+    - name: gpu-operator-pascal-validator-skip
+      labels:
+        nvidia.com/gpu.deploy.operator-validator: "false"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["10de"]}
+            device: {op: In, value: ["1b38"]}

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/kustomization.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./barcode-device.yaml
   - ./coral-device.yaml
+  - ./gpu-operator-pascal-validator-skip.yaml
   - ./gpu-operator-runtime-override.yaml
   - ./intel-gpu.yaml
   - ./nvidia-gpu.yaml


### PR DESCRIPTION
## What

Add a `NodeFeatureRule` that sets `nvidia.com/gpu.deploy.operator-validator=false` on the Tesla P40 (matched by PCI id `10de:1b38`), so the gpu-operator stops scheduling the `nvidia-operator-validator` DaemonSet on that node.

## Why

The validator's `cuda-validation` initContainer runs a **CUDA-13** `vectorAdd` sample. CUDA 13 dropped code generation for **Pascal (sm_61)**, so on the P40 it fails with:

```
Failed to launch vectorAdd kernel (error code named symbol not found)!
```

The validator pod stays `Init:Error` → the DaemonSet is perpetually not-ready on worker8 (desired=2, ready=1; the Spark/Blackwell node passes) → three alerts fire continuously: `KubeDaemonSetRolloutStuck`, `KubeContainerWaiting`, `KubePodNotReady`.

It's a **false negative**: the device-plugin is healthy, `nvidia.com/gpu: 8` (time-sliced) is allocatable, the HelmRelease is `Ready`, and real CUDA-12 workloads (Ollama etc.) run on the P40. The card is being tested with a CUDA version that can't target it.

## Approach

Uses the operator's own component-gating label — the **same mechanism** the repo already uses to skip the container-toolkit DS on CRI-O nodes (`gpu-operator-runtime-override.yaml`). The operator honors an externally-set `deploy.<component>` label and stops scheduling that operand. The DaemonSet's desired count drops to 1 (Spark only), goes fully ready, and the alerts clear **at the source** — this resolves the stuck rollout rather than silencing it. Device-plugin / GFD / DCGM / node-status-exporter operands are untouched (none depend on the validator).

Scoped by PCI id (`10de:1b38`) so a future non-Pascal GPU still validates normally.

### Rejected alternatives
- **Chart per-check disable** — not exposed.
- **Pin gpu-operator** — dead end; CUDA 13 dropped Pascal permanently.
- **Silence the alert** — hides the stuck rollout instead of resolving it.
- **Standalone device-plugin (operator → Spark-only)** — more moving parts (taint + plugin + redeploy GFD/DCGM), no longevity gain (both ride the R580 driver, NVIDIA's last Pascal branch).

## Verification

- Local pre-submit passed (yamllint, schema, secret checks).
- Post-merge: confirm worker8 gets `nvidia.com/gpu.deploy.operator-validator=false`, the `nvidia-operator-validator` pod on worker8 terminates, the DaemonSet reports desired==ready==1, and the three alerts clear. Device-plugin stays 2/2 with `nvidia.com/gpu: 8` allocatable.

Closes #13689

🤖 Generated with [Claude Code](https://claude.com/claude-code)