### PR TITLE
test(searxng-mcp): canary 2.0.0 + MCP_HTTP_STATELESS=true (mcp-searxng#256)

### DIFF
--- a/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
@@ -26,8 +26,8 @@ spec:
           app:
             image:
               repository: docker.io/isokoliuk/mcp-searxng
-              # workaround: https://github.com/ihor-sokoliuk/mcp-searxng/issues/256 — remove when 2.0.0 accepts the Kuadrant mcp-gateway broker session handshake (or the broker adds stateless-ping support, Kuadrant/mcp-gateway#1419). 2.0.0's strict streamable-HTTP enforcement de-federates the search tools; held at 1.16.0. Renovate pinned <2.0.0 in .github/renovate/packageRules.json5.
-              tag: "1.16.0@sha256:d892b5aede28ab6476ba7ab3ce6b7e2e564ee43888e9c39ac5df52b74e1ca74d"
+              # workaround: https://github.com/ihor-sokoliuk/mcp-searxng/issues/256 — 2.0.0 CANARY testing MCP_HTTP_STATELESS=true, the maintainer's suggested compat mode for the Kuadrant mcp-gateway broker's session-less request (bare ping). Stateless mode is POST-only: no legacy GET/DELETE /mcp, cross-request subscriptions, resumability, or server->client notifications — acceptable for a request/response search tool. Remove the env + this note once 2.0.0 federates cleanly (or the broker ships the stateful 2026-07-28 handshake, Kuadrant/mcp-gateway#1419). Renovate still pinned <2.0.0 in .github/renovate/packageRules.json5.
+              tag: "2.0.0@sha256:485544ea18394c8c971f3db0f4f75d61422f7a95aae64fc72ca86118f4f05ce4"
             env:
               SEARXNG_URL: http://searxng.collab.svc.cluster.local:8080
               # MCP_HTTP_HOST defaults to 127.0.0.1 (loopback-only), so the
@@ -35,6 +35,11 @@ spec:
               # interfaces for cluster traffic to reach it.
               MCP_HTTP_HOST: "0.0.0.0"
               MCP_HTTP_PORT: "3000"
+              # CANARY (mcp-searxng#256): POST-only stateless mode so 2.0.0
+              # accepts the broker's session-less request instead of rejecting
+              # it (hasInitializeRequest=false, sessionId=undefined). Remove
+              # with the 1.16.0 pin if the canary is reverted.
+              MCP_HTTP_STATELESS: "true"
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## What

Canary of **mcp-searxng 2.0.0** with the maintainer-suggested compat lever `MCP_HTTP_STATELESS: "true"`, per [ihor-sokoliuk/mcp-searxng#256](https://github.com/ihor-sokoliuk/mcp-searxng/issues/256). Re-treads #13679 (reverted #13680) but with the stateless env this time.

- Image digest → `2.0.0@sha256:485544ea…` (same immutable digest as #13679)
- New env `MCP_HTTP_STATELESS: "true"` (POST-only mode)
- Workaround annotation refreshed to describe the canary

## Why

Maintainer reproduced against 2.0.0:
- bare session-less `ping` → **rejected** in default stateful mode
- same `ping` with `MCP_HTTP_STATELESS=true` → **succeeds**

He also **corrected our root cause**: 1.16.0 *also* rejects bare session-less pings in stateful mode, so the real 1.16↔2.0 difference is protocol negotiation / header preservation, not a newly-added ping restriction. Our memory + prior annotation had claimed "1.16.0 tolerated the bare ping" (unverified) and that stateless was "a long-shot" (wrong — it's the lever).

Relevant to his lost-headers hypothesis: there **is** a mesh in our path (broker → Istio → backend, backend has an Istio sidecar) and our HTTPRoute strips `Authorization`.

## ⚠️ Do not merge outside a window

Merging deploys via Flux. A failed canary **de-federates the `search_*` tools** through the shared mcp-gateway (blast radius on the live MCP tool surface). Merge **only** in a Routine maintenance window (any night 02:00–05:00 ET). Draft until then.

## Verification checklist (run right after merge)

- [ ] Broker keeps searxng tools federated for ≥3 health-check cycles (`mcp-check-interval=60` → ~3 min)
- [ ] Tool discovery lists `search_*`
- [ ] One real `search_web_search` call succeeds
- [ ] Capture broker debug (`negotiated-protocol`, `uses-stateless`) + header presence for the #256 reply — **regardless of pass/fail**

## Revert path

Same as #13680: revert this commit → Flux restores 1.16.0. Renovate `<2.0.0` pin and workaround tracking issue #13682 stay in place until the canary is proven, then a follow-up PR unpins + closes #13682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)