### PR TITLE
feat(downloads): adopt in-place resizePolicy on two download apps

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -63,6 +63,18 @@ spec:
               QBT_TORRENTING_PORT: ${WIREGUARD_FORWARD_PORT:-24589}
               QBT_WEBUI_PORT: &httpPort 8080
 
+            # In-place resize (k8s 1.35 GA): let a live memory/CPU bump apply
+            # without restarting the container, so an OOM-risk memory raise
+            # doesn't drop active torrents. Note: QBT_Application__MemoryWorkingSetLimit
+            # is read from limits.memory at start and won't track a live resize
+            # until the next restart — the cgroup limit does change live, which
+            # is what prevents the OOMKill.
+            resizePolicy:
+              - resourceName: cpu
+                restartPolicy: NotRequired
+              - resourceName: memory
+                restartPolicy: NotRequired
+
             resources:
               requests:
                 cpu: 35m

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -61,6 +61,15 @@ spec:
               startup:
                 enabled: false
 
+            # In-place resize (k8s 1.35 GA): apply a live memory/CPU bump
+            # without restarting the container, so raising memory under a heavy
+            # unpack/repair load doesn't interrupt in-flight jobs.
+            resizePolicy:
+              - resourceName: cpu
+                restartPolicy: NotRequired
+              - resourceName: memory
+                restartPolicy: NotRequired
+
             resources:
               requests:
                 cpu: 15m


### PR DESCRIPTION
## What
Adds container `resizePolicy` (cpu + memory: `NotRequired`) to two apps in the `downloads` namespace (see diff).

## Why
Kubernetes 1.35 GA'd in-place pod resize. With `resizePolicy: NotRequired`, a live CPU/memory change applies **without restarting the container** — so memory can be raised under load without dropping in-flight work.

## Scope / verification
- Pilot: two restart-costly, **non-Renee-facing** apps.
- app-template `5.1.0` schema accepts `resizePolicy` (verified against the bundled k8s-api schema); CRI-O `1.35.2` supports in-place resize.
- **One-time rollout** when applied (adds a container field → new pod); future memory bumps are then live.

## Caveat
One of the two reads its internal memory soft-cap from `limits.memory` at start and won't track a live resize until the next restart. The **cgroup** limit still changes live, which is what prevents the OOMKill — only the app-internal soft cap lags.

## Firefighting (manual `kubectl`, not GitOps)
```
kubectl patch pod <pod> --subresource resize \
  -p '{"spec":{"containers":[{"name":"app","resources":{"requests":{"memory":"Xi"},"limits":{"memory":"Xi"}}}]}}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)