### PR TITLE
feat(media): supplementalGroupsPolicy Strict on four media-pipeline apps

### DIFF
--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
             runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
+            # Strict: effective groups = only what's declared here (drops the
+            # linuxserver image's implicit groups). Media access is via primary
+            # GID 1001, so this is safe. Verify via pod status .user.linux after
+            # the next CronJob run. (k8s 1.35 GA)
+            supplementalGroupsPolicy: Strict
         cronjob:
           schedule: "0 */12 * * *"
           concurrencyPolicy: Forbid

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -20,6 +20,11 @@ spec:
             runAsGroup: 1001
             runAsNonRoot: true
             runAsUser: 1103
+            # Strict: effective groups = only what's declared here (drops any
+            # implicit image /etc/group groups). Media access is via primary GID
+            # 1001, so this is safe. Verify via pod status .user.linux after
+            # rollout. (k8s 1.35 GA)
+            supplementalGroupsPolicy: Strict
 
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -20,6 +20,11 @@ spec:
             runAsGroup: 1001
             runAsNonRoot: true
             runAsUser: 1102
+            # Strict: effective groups = only what's declared here (drops any
+            # implicit image /etc/group groups). Media access is via primary GID
+            # 1001, so this is safe. Verify via pod status .user.linux after
+            # rollout. (k8s 1.35 GA)
+            supplementalGroupsPolicy: Strict
 
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
             runAsGroup: 1001
             runAsUser: 1101
+            # Strict: effective groups = only what's declared here (drops any
+            # implicit image /etc/group groups). Media access is via primary GID
+            # 1001, so this is safe. Verify via pod status .user.linux after
+            # rollout. (k8s 1.35 GA)
+            supplementalGroupsPolicy: Strict
 
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## What
Sets `supplementalGroupsPolicy: Strict` on the pod securityContext of four apps in the `media` namespace (see diff).

## Why
Kubernetes 1.35 GA'd fine-grained supplemental groups control. `Strict` makes a pod's effective group set **exactly what's declared** in the manifest and **drops any groups implicitly granted by the container image's `/etc/group`**. Result: deterministic group membership and auditability via `pod.status...user.linux.supplementalGroups`.

## Scope / safety
- Pilot: four routine, **non-Renee-facing** apps that reach shared media via their **primary GID 1001** (`runAsGroup`/`fsGroup`) and need no hardware-device groups — so `Strict` cannot remove access they depend on.
- Deliberately **excluded**: the media server (needs `render`/`video` groups for hardware transcode), the two music services that read via the world-readable bit (handled by separate ACL read-only-group work), and the photo app (no pod securityContext today).
- Chart `app-template 5.1.0` accepts `supplementalGroupsPolicy`; runtimes CRI-O `1.35.2` / containerd `2.2.1` support it.

## Verification
After rollout, confirm effective groups are exactly `{1001}` (+ fsGroup):
```
kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[0].user.linux.supplementalGroups}'
```
One target applies on its next scheduled run. If any app needs an image group, add it explicitly under `supplementalGroups:` before widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)