### PR TITLE
fix(github-mcp): disable broker registration (stateless upstream loops v0.9.0)

### DIFF
--- a/kubernetes/apps/mcp-system/github-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/mcp/mcpserverregistration.yaml
@@ -7,6 +7,15 @@ metadata:
   labels:
     mcp.kuadrant.io/managed: "true"
 spec:
+  # workaround: https://github.com/Kuadrant/mcp-gateway/issues/1382 — remove when the broker tolerates stateless streamable-HTTP upstreams
+  # github-mcp-server v1.10.1 http transport is stateless by design (adopted
+  # the MCP 2026-07-28 stateless core — github.blog 2026-07-23): sessions
+  # carry an empty Mcp-Session-Id. The v0.9.0 broker requires a stateful
+  # session + subscriptions/listen channel, so it hard-loops (many
+  # reconnects/sec, "session not found") and federates zero github tools —
+  # pure CPU/log churn on the broker + github-mcp. Same root as windmill-mcp
+  # (#13627). Disabled until the upstream issue lands; re-enable then.
+  state: Disabled
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute


### PR DESCRIPTION
Surfaced while verifying the searxng-mcp 2.0.0 canary (#13694) — **not** caused by it.

## Problem

The Kuadrant mcp-gateway broker is stuck in a tight reconnect-loop against **github-mcp**: the github-mcp-server container churns sessions many times per 100 ms with an **empty `Mcp-Session-Id`**, and the broker logs a continuous stream of `sending "subscriptions/listen": failed to connect (session ID: ): session not found` / `failed to list tools`. Net effect: **zero github tools federated** + wasted CPU/log on the broker and github-mcp.

## Root cause

github-mcp-server v1.10.1's http transport is **stateless by design** — it adopted the MCP 2026-07-28 stateless core ([github.blog, 2026-07-23](https://github.blog/changelog/2026-07-23-github-mcp-server-supports-the-next-mcp-specification/)). The v0.9.0 broker requires a stateful session + `subscriptions/listen` channel, so it can't consume a stateless upstream. There is no stateful-mode flag to flip — GitHub went stateless deliberately.

This is the **identical root cause** to windmill-mcp (#13626 / Kuadrant/mcp-gateway#1382).

## Fix

Mirror the windmill fix: `state: Disabled` on the `github-tools` MCPServerRegistration + `# workaround:` annotation pointing at Kuadrant/mcp-gateway#1382.

- **No functional loss** — the tools were already de-federated by the loop. This stops the churn.
- **Reversible** — re-enable when the broker tolerates stateless upstreams.
- Tracked in **#13627** (shared upstream item, not a new issue — one issue per upstream bug per `.agents/instructions/workarounds.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)