### PR TITLE
fix(paperless-mcp): add --no-auth so v2.0.0 uses the env token (broker 401s)

### DIFF
--- a/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
@@ -31,6 +31,15 @@ spec:
               # `kubectl describe pod` on 2026-05-20); the `latest` tag
               # portion is decorative — the @sha256 enforces.
               tag: latest@sha256:f80bd21542a64f51828eb7fd26e9e1d5b84a66500c2c472ac75b336551d501d0
+            # v2.0.0 made a per-request `Authorization: Bearer <paperless
+            # token>` mandatory and dropped the env-token fallback, so every
+            # broker request 401s (the mcp-gateway route strips Authorization
+            # so backends use their own env cred). --no-auth restores the
+            # env-token fallback (PAPERLESS_API_KEY, set by the ExternalSecret).
+            # Safe here: CNP-gated to broker-only access behind Authelia — the
+            # "trusted network" the flag documents. Appends to the image
+            # entrypoint `node build/index.js --http --port 3000`.
+            args: ["--no-auth"]
             env:
               PAPERLESS_URL: https://paperless.${SECRET_DOMAIN}
             envFrom:


### PR DESCRIPTION
## Problem

`paperless-tools` is de-federated from the mcp-gateway broker — every `initialize` returns `Unauthorized` (~7,900 consecutive failures). The paperless-mcp pod log is explicit and repeating:

> `Rejected request with no 'Authorization: Bearer <paperless-ngx-api-token>' header. As of v2.0.0, HTTP mode requires a per-request Bearer token and no longer falls back to the server-configured token... or restart the server with --no-auth`.

## Root cause

`baruchiro/paperless-mcp` **v2.0.0** made per-request `Authorization: Bearer` mandatory and **dropped the env-token fallback**. Our fleet does the opposite — the mcp-gateway HTTPRoute **strips** inbound `Authorization` so each backend uses its **own env credential**. v2.0.0 removed exactly that fallback → 401 on every request.

The pinned `latest@sha256:f80bd21` digest is a ≥2.0.0 build — a **silent major bump** via the floating `latest` tag + Renovate digest, the same class as the searxng 2.0.0 / github stateless breakage this session.

## Fix

`args: ["--no-auth"]` on the app container. In k8s, args append to the image entrypoint (`node build/index.js --http --port 3000`) → `… --no-auth`, which restores the v1.x env-token fallback. `PAPERLESS_API_KEY` is already provided by the ExternalSecret. The flag is **CLI-only** (no env-var form).

**Security:** `--no-auth` is documented for "trusted/local networks only" — satisfied here: paperless-mcp is CNP-gated to broker-only access behind Authelia, and the route strips `Authorization` anyway. Identical to how github/windmill/searxng already authenticate (env-cred + Authorization-strip).

**Rejected alternatives:** pinning a pre-2.0.0 digest (no semver, forward-incompatible); an nginx token-injection front (more moving parts than one flag).

## Verify after merge
- [ ] paperless-mcp pod rolls; log stops printing the "Rejected request" line
- [ ] broker stops logging `paperless-tools … initialize: Unauthorized`
- [ ] `paperless_*` tools re-federate + a real tool call succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)