### PR TITLE
fix(grafana-mcp): allow broker Host so 1.1.0 stops 403ing (host not allowed)

### DIFF
--- a/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
@@ -37,6 +37,16 @@ spec:
               # tools (dashboards, alert rules, snapshots, etc.), shrinking
               # the tool blast radius. Added mcp-grafana 1.x.
               - --disable-write
+              # mcp-grafana 1.1.0 added Host-header allowlisting (DNS-rebinding
+              # protection); the default allows only loopback variants of
+              # --address, so the mcp-gateway broker's `Host: grafana-mcp.mcp.local`
+              # is rejected with 403 "host not allowed" and grafana-tools
+              # de-federates. Allow all Host values — cnp-allow.yaml restricts
+              # ingress to the broker only (the trusted reverse proxy the flag's
+              # own docs require for "*"), so DNS-rebinding isn't reachable. The
+              # other MCP backends don't validate Host at all.
+              - --allowed-hosts
+              - "*"
             env:
               GRAFANA_URL: http://grafana.observability.svc.cluster.local
             envFrom:


### PR DESCRIPTION
## Root cause (confirmed by direct probe)

`grafana-tools` has been de-federated (~8,000 consecutive broker `Forbidden`s). Probing the mcp-grafana pod directly returns:

```
http=403
forbidden: host not allowed
```

**mcp-grafana 1.1.0 added Host-header allowlisting** (DNS-rebinding protection). Its default allowlist is only the loopback variants of `--address`, so the mcp-gateway broker's `Host: grafana-mcp.mcp.local` is rejected at the transport — **before any Grafana call**.

### It was *not* the token
The service account was genuinely missing (orphaned token) and we fixed that — created an Editor SA `mcp-grafana`, put a fresh token in 1Password, verified it returns **200 on every Grafana endpoint**, and confirmed the pod is running it (`secret == new token ✓`). The 403 persisted anyway, which is what pinned it to Host validation. The token fix is still required — grafana-mcp needs a valid token to reach Grafana *once the broker can connect*.

## Fix

`--allowed-hosts "*"`. Per the flag's own docs, `*` is "only safe behind a trusted reverse proxy" — which we are: `cnp-allow.yaml` restricts ingress to the mcp-gateway broker only, so DNS-rebinding is unreachable. This mirrors the other MCP backends (searxng/paperless/etc.), which don't validate Host at all.

## Verify after merge
- [ ] broker stops logging `grafana-tools … initialize: Forbidden`
- [ ] `grafana_*` tools re-federate + a real tool call succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)