### PR TITLE
docs(paperless-mcp): note image self-reports v2.0.1; keep latest tag

### DIFF
--- a/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
@@ -26,10 +26,12 @@ spec:
           app:
             image:
               repository: ghcr.io/baruchiro/paperless-mcp
-              # Upstream uses sha-prefixed tags + floating `latest`. No
-              # semver. Pin the digest currently running (verified via
-              # `kubectl describe pod` on 2026-05-20); the `latest` tag
-              # portion is decorative — the @sha256 enforces.
+              # Upstream publishes only `latest` + `sha-<commit>` digest tags —
+              # no `2.0.x` docker tag exists (`2.0.1` → HTTP 404 on ghcr), so the
+              # `latest` portion is decorative; the @sha256 enforces. This digest
+              # self-reports serverInfo v2.0.1 (verified via tools/list 2026-08-22).
+              # Keep `latest` (NOT a fake `2.0.1` tag) so Renovate keeps tracking
+              # digest bumps — that's how we'll learn the #138 schema fix shipped.
               tag: latest@sha256:f80bd21542a64f51828eb7fd26e9e1d5b84a66500c2c472ac75b336551d501d0
             # v2.0.0 made a per-request `Authorization: Bearer <paperless
             # token>` mandatory and dropped the env-token fallback, so every


### PR DESCRIPTION
Comment-only. Upstream publishes no `2.0.x` docker tag (`2.0.1` → HTTP 404 on ghcr) — only `latest` + `sha-<commit>`. The pinned digest self-reports `serverInfo` v2.0.1; documenting that instead of pinning a fictional `2.0.1` tag (which would break Renovate digest tracking — our signal for when the #138 schema fix ships). No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)