### PR TITLE
build(loki): migrate chart to grafana-community fork (loki-18.11.0)

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -19,20 +19,15 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    deploymentMode: SingleBinary
+    deploymentMode: Monolithic
 
     loki:
       auth_enabled: false
       analytics:
         reporting_enabled: false
-      image:
-        # Chart 7.3.0 is the FINAL OSS release of the grafana/loki chart —
-        # it went GEL-maintenance-only on 2026-03-16 (grafana/loki#20705)
-        # and defaults to a stale Loki 3.6.11. Pin the OSS image to a
-        # current 3.7.x explicitly until we migrate to the actively
-        # maintained grafana-community fork chart.
-        # renovate: datasource=docker depName=docker.io/grafana/loki
-        tag: 3.7.6
+      # No explicit image pin: the grafana-community fork chart is actively
+      # maintained, so its appVersion drives the Loki image (currently
+      # 3.7.6). Renovate bumps the OCIRepository chart tag → image follows.
       podAnnotations:
         configmap.reloader.stakater.com/reload: loki-chunks-bucket-v1
       commonConfig:
@@ -134,12 +129,6 @@ spec:
         enabled: false
       serviceMonitor:
         enabled: true
-        metricsInstance:
-          enabled: false
-      selfMonitoring:
-        enabled: false
-        grafanaAgent:
-          installOperator: false
     lokiCanary:
       enabled: false
     test:
@@ -148,7 +137,10 @@ spec:
     # Sidecar still needed for ruler config discovery
     sidecar:
       image:
-        repository: ghcr.io/kiwigrid/k8s-sidecar
+        # The fork chart splits registry from repository; a full-path
+        # repository would render as docker.io/ghcr.io/... — set both.
+        registry: ghcr.io
+        repository: kiwigrid/k8s-sidecar
       rules:
         searchNamespace: ALL
         folder: /rules/fake

--- a/kubernetes/apps/observability/loki/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/loki/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 7.3.0
-  url: oci://ghcr.io/grafana/helm-charts/loki
+    tag: 18.11.0
+  url: oci://ghcr.io/grafana-community/helm-charts/loki


### PR DESCRIPTION
## What

Migrate the Loki Helm chart from the frozen upstream `grafana/loki` (7.3.0, its final OSS release — went GEL-maintenance-only 2026-03-16, grafana/loki#20705) to the actively-maintained community fork `oci://ghcr.io/grafana-community/helm-charts/loki` (**loki-18.11.0**, appVersion 3.7.6, Renovate/GPG-signed). Retires the stopgap image pin from #13647.

## Changes

| File | Change |
|---|---|
| `ocirepository.yaml` | url → `grafana-community/helm-charts/loki`, tag `7.3.0` → `18.11.0` |
| `helmrelease.yaml` | drop explicit `loki.image.tag` pin (fork appVersion drives it, same 3.7.6); `SingleBinary` → `Monolithic`; drop dead `metricsInstance`/`selfMonitoring`/`grafanaAgent`; fix sidecar `registry`/`repository` split |

## Why each

- **Drop image pin** — the pin existed only because the *old chart* was frozen on a stale image. The maintained fork's appVersion tracks Loki releases and renders the identical `docker.io/grafana/loki:3.7.6` today; Renovate bumps the chart tag going forward. One thing to bump, not two.
- **`Monolithic`** — renders **byte-identical** to `SingleBinary` against the fork; `SingleBinary` is a deprecated alias.
- **Dead monitoring keys** — `metricsInstance`, `selfMonitoring`, `grafanaAgent` are gone from the fork's values schema (would be silently-ignored config).
- **Sidecar fix** — the fork **splits `registry` from `repository`**. The old full-path `repository: ghcr.io/kiwigrid/k8s-sidecar` rendered as the broken `docker.io/ghcr.io/kiwigrid/k8s-sidecar`. Now `registry: ghcr.io` + `repository: kiwigrid/k8s-sidecar` → `ghcr.io/kiwigrid/k8s-sidecar:2.10.1`.

## Prereq verification (StatefulSet replace ruled out)

`helm template` old 7.3.0 vs fork 18.11.0 with our values — StatefulSet identity is **identical**, so no forced replace and the existing `storage-loki-0` PVC is reused:

| field | value (both) |
|---|---|
| `metadata.name` | `loki` |
| `spec.serviceName` | `loki-headless` |
| `spec.selector.matchLabels` | name/instance=loki, component=single-binary |
| `volumeClaimTemplates[0]` | `storage` / ceph-block / RWO / 30Gi |

Log source-of-truth is the S3/ceph bucket, not the pod PVC, so even a PVC reset would be non-destructive.

## Rollout

Deploy in a **routine maintenance window** (internal service, not Renee-facing: any night 02:00–05:00 ET). Flux applies; the StatefulSet updates in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)