### PR TITLE
feat(reddit-mcp): scaffold in-cluster Reddit MCP server (stubbed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-160-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-161-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-173-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-92-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-93-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>
@@ -273,7 +273,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🔌 <b>MCP Servers</b> — 19 Model Context Protocol servers behind an Authelia-gated gateway</summary>
+<summary>🔌 <b>MCP Servers</b> — 20 Model Context Protocol servers behind an Authelia-gated gateway</summary>
 
 | Server | Exposes |
 |--------|---------|
@@ -295,6 +295,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **memory-mcp** | Cross-agent knowledge graph backed by Postgres + pgvector (bge-m3 1024-dim) |
 | **cilium-mcp** | Read-only Cilium / Hubble introspection (kubectl-mcp-style, Cilium-scoped) |
 | **windmill-mcp** | Aggregated Windmill workspace tools (script run, flow trigger) |
+| **reddit-mcp** | Reddit thread reads by URL + discussion/opinion/trend search |
 
 </details>
 
@@ -331,7 +332,7 @@ flowchart TB
     end
 
     subgraph Tools[Tools + retrieval]
-        Gw[MCP Gateway<br/>19 servers]
+        Gw[MCP Gateway<br/>20 servers]
         Q[(Qdrant<br/>vector DB)]
         Mem[(memory-mcp<br/>pgvector KG)]
     end

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
   - ./omada-mcp/ks.yaml
   - ./paperless-mcp/ks.yaml
   - ./prometheus-mcp/ks.yaml
+  - ./reddit-mcp/ks.yaml
   - ./searxng-mcp/ks.yaml
   - ./time-mcp/ks.yaml
   - ./windmill-mcp/ks.yaml

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/cnp-allow.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: reddit-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: reddit-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # reddit-mcp fetches directly from external hosts: oauth.reddit.com +
+    # www.reddit.com (Reddit API), arctic-shift.photon-reddit.com (archive
+    # fallback), and duckduckgo.com (search_knowledge fallback). All external,
+    # so it needs world egress or every tool call is default-denied. Same
+    # pattern as searxng-mcp / github-mcp / chrome-mcp.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: reddit-mcp
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: reddit-mcp-secret
+    creationPolicy: Owner
+    template:
+      data:
+        # App-only OAuth (client_credentials grant) — a Reddit "script" app
+        # at reddit.com/prefs/apps yields these two values. Read-only, no
+        # user password needed for the search/read tools.
+        REDDIT_CLIENT_ID: "{{ .client_id }}"
+        REDDIT_CLIENT_SECRET: "{{ .client_secret }}"
+  # STUB: create a 1Password item named `reddit-mcp` in the vault the
+  # onepassword-connect ClusterSecretStore reads, with fields `client_id`
+  # and `client_secret`. Until it exists this ExternalSecret stays
+  # SecretSyncedError and the reddit-mcp-secret is absent (pod won't start) —
+  # expected for the stubbed scaffold.
+  dataFrom:
+    - extract:
+        key: reddit-mcp

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/externalsecret.yaml
@@ -19,11 +19,13 @@ spec:
         # user password needed for the search/read tools.
         REDDIT_CLIENT_ID: "{{ .client_id }}"
         REDDIT_CLIENT_SECRET: "{{ .client_secret }}"
-  # STUB: create a 1Password item named `reddit-mcp` in the vault the
-  # onepassword-connect ClusterSecretStore reads, with fields `client_id`
-  # and `client_secret`. Until it exists this ExternalSecret stays
-  # SecretSyncedError and the reddit-mcp-secret is absent (pod won't start) —
-  # expected for the stubbed scaffold.
+  # OPTIONAL OAuth add-on — NOT wired into kustomization.yaml by default; the
+  # reddit-mcp pod runs zero-config on its fallback chain without it. To enable
+  # OAuth: create a 1Password item named `reddit-mcp` (fields `client_id` +
+  # `client_secret` from a Reddit "script" app), re-add ./externalsecret.yaml to
+  # kustomization.yaml, and restore the envFrom secretRef in helmrelease.yaml.
+  # Reddit's legacy app-creation form is broken as of 2026-08-22 — revisit when
+  # it recovers, or only if the zero-config fallback proves insufficient.
   dataFrom:
     - extract:
         key: reddit-mcp

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/helmrelease.yaml
@@ -26,15 +26,15 @@ spec:
           app:
             image:
               # Upstream (ismailsaoulaj/reddit-mcp-server, PyPI: reddit-mcp-ai)
-              # publishes NO container image — only the PyPI package. Built from
-              # their multi-stage Dockerfile to ghcr.io/rwlove, same as the other
-              # self-hosted MCP servers (esphome-mcp, netbox-mcp, time-mcp).
-              # PREREQUISITE: build+push ghcr.io/rwlove/reddit-mcp-server:v0.5.1
-              # then pin the digest here (drop the bare tag). Until then the pod
-              # ImagePullBackOffs — expected for the stubbed scaffold; the
-              # Kustomization still reconciles (wait: false).
+              # publishes NO container image — only the PyPI package. Built to
+              # ghcr.io/rwlove from the `containers` repo (reddit-mcp/Dockerfile
+              # + reddit-mcp-release.yml, pip-wraps reddit-mcp-ai), same pattern
+              # as esphome-mcp / netbox-mcp / time-mcp. Retire and switch
+              # upstream if ismailsaoulaj/reddit-mcp-server#19 (image request)
+              # lands. Bump via `gh workflow run reddit-mcp-release.yml -f
+              # version=<x.y.z>` in the containers repo, then repin here.
               repository: ghcr.io/rwlove/reddit-mcp-server
-              tag: v0.5.1  # TODO: pin @sha256:<digest> after the image is built
+              tag: v0.5.1@sha256:1c522e4096af995015e149c9f131e52ad49a63b8ffc821dee7456bb8a7a99544
             # The image CMD already runs `reddit-mcp --transport http --host
             # 0.0.0.0 --port 8000`, so no command/args override is needed.
             env:

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/helmrelease.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reddit-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+    controllers:
+      reddit-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+        containers:
+          app:
+            image:
+              # Upstream (ismailsaoulaj/reddit-mcp-server, PyPI: reddit-mcp-ai)
+              # publishes NO container image — only the PyPI package. Built from
+              # their multi-stage Dockerfile to ghcr.io/rwlove, same as the other
+              # self-hosted MCP servers (esphome-mcp, netbox-mcp, time-mcp).
+              # PREREQUISITE: build+push ghcr.io/rwlove/reddit-mcp-server:v0.5.1
+              # then pin the digest here (drop the bare tag). Until then the pod
+              # ImagePullBackOffs — expected for the stubbed scaffold; the
+              # Kustomization still reconciles (wait: false).
+              repository: ghcr.io/rwlove/reddit-mcp-server
+              tag: v0.5.1  # TODO: pin @sha256:<digest> after the image is built
+            # The image CMD already runs `reddit-mcp --transport http --host
+            # 0.0.0.0 --port 8000`, so no command/args override is needed.
+            env:
+              # Live OAuth (oauth.reddit.com) is the only reliable tier: the
+              # unauthenticated JSON/scrape path is hard-403'd by Reddit and
+              # curl_cffi TLS-impersonation does NOT bypass it (verified
+              # 2026-08-22). Without creds the server silently degrades to the
+              # lagged Arctic Shift archive. Creds come from the ExternalSecret.
+              REDDIT_MAX_CONCURRENCY: "4"
+              REDDIT_RATE_LIMIT_PER_MINUTE: "40"
+            envFrom:
+              - secretRef:
+                  name: reddit-mcp-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+    persistence:
+      # curl_cffi + httpx write transient files; readOnlyRootFilesystem: true
+      # makes / read-only, so give them a scratch /tmp.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        controller: reddit-mcp
+        ports:
+          http:
+            port: 8000
+    route:
+      app:
+        hostnames:
+          - "reddit-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the backend
+              # MCP server. The Kuadrant mcp-gateway forwards all client
+              # headers; the broker-side Bearer can take precedence over the
+              # backend's own credential env in any upstream MCP client that
+              # honors Authorization, causing 401s against the real target.
+              # Backend MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer here lets those take effect
+              # uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
+            backendRefs:
+              - identifier: app
+                port: 8000

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/helmrelease.yaml
@@ -38,16 +38,24 @@ spec:
             # The image CMD already runs `reddit-mcp --transport http --host
             # 0.0.0.0 --port 8000`, so no command/args override is needed.
             env:
-              # Live OAuth (oauth.reddit.com) is the only reliable tier: the
-              # unauthenticated JSON/scrape path is hard-403'd by Reddit and
-              # curl_cffi TLS-impersonation does NOT bypass it (verified
-              # 2026-08-22). Without creds the server silently degrades to the
-              # lagged Arctic Shift archive. Creds come from the ExternalSecret.
+              # ZERO-CONFIG DEFAULT — no Reddit OAuth creds required to start.
+              # The server runs its fallback chain (browser-impersonated live
+              # fetch -> Arctic Shift archive -> DuckDuckGo), which covers the
+              # headline extract_public_opinion (read-a-thread) tool. Only
+              # analyze_niche_trends needs OAuth (archive lags live trends); it
+              # returns a graceful warning without creds rather than failing.
+              # OAuth is deliberately OFF the critical path — Reddit's legacy
+              # app-creation form is broken as of 2026-08-22, and the earlier
+              # "OAuth mandatory" spike ran from a datacenter egress, not the
+              # cluster's residential egress via brain (which may pass the
+              # fallback fine). To add OAuth later: (1) create the 1Password
+              # `reddit-mcp` item, (2) re-add ./externalsecret.yaml to
+              # kustomization.yaml, (3) restore the envFrom secretRef below.
               REDDIT_MAX_CONCURRENCY: "4"
               REDDIT_RATE_LIMIT_PER_MINUTE: "40"
-            envFrom:
-              - secretRef:
-                  name: reddit-mcp-secret
+            # envFrom:                          # ← OAuth add-on (see note above)
+            #   - secretRef:
+            #       name: reddit-mcp-secret
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/reddit-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/app/kustomization.yaml
@@ -6,5 +6,7 @@ components:
   - ../../../../components/repos/app-template
 resources:
   - ./cnp-allow.yaml
-  - ./externalsecret.yaml
+  # ./externalsecret.yaml is the OPTIONAL OAuth add-on — intentionally NOT
+  # wired in the zero-config default. Re-add it here + create the 1Password
+  # `reddit-mcp` item + restore the envFrom in helmrelease.yaml to enable OAuth.
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/reddit-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app reddit-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/reddit-mcp/app
+  interval: 1h
+  timeout: 5m
+  wait: false
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app reddit-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/reddit-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  wait: false
+  dependsOn:
+    - name: reddit-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/reddit-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/reddit-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/reddit-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,21 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: reddit-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  # Registered enabled: reddit-mcp is a FastMCP (>=3.4) streamable-HTTP server,
+  # which defaults to STATEFUL sessions (returns Mcp-Session-Id) — the shape the
+  # v0.9.0 broker wants, so it should federate cleanly (unlike windmill-mcp,
+  # whose stateless endpoint forced `state: Disabled` per Kuadrant#1382).
+  # FALLBACK: if the broker hard-loops / federates zero reddit_* tools (the
+  # stateless symptom), add `state: Disabled` here and track under the same
+  # upstream issue until FastMCP is confirmed stateful through the broker.
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: reddit-mcp
+  prefix: reddit_


### PR DESCRIPTION
## What

Scaffolds a Reddit MCP server (`ismailsaoulaj/reddit-mcp-server`, PyPI `reddit-mcp-ai`) in `mcp-system`. Its headline tool is `reddit_extract_public_opinion` — **read a Reddit thread by URL** — plus four discussion / opinion / trend search tools, federated through the Kuadrant broker with prefix `reddit_`.

This closes a real gap: reddit.com is a hard block for our fetch tooling (WebFetch refuses the domain; searxng `url_read` hits the login wall), so "read this thread" currently fails. This server routes around it via the authenticated Reddit API.

## Why this shape

Modeled on **paperless-mcp** (structure + env-token auth) and **searxng-mcp** (world-egress CNP + broker handling). Fleet-baseline `securityContext`: non-root 1000, `readOnlyRootFilesystem: true` with a tmpfs `/tmp` for `curl_cffi`, all caps dropped. Registered **enabled** — FastMCP (≥3.4) defaults to stateful sessions, the shape the broker wants; the `state: Disabled` fallback is documented inline if it loops.

## Draft — two prerequisites are intentionally stubbed (both inert until resolved)

1. **Container image.** Upstream publishes no image, only the PyPI package. The HelmRelease points at `ghcr.io/rwlove/reddit-mcp-server:v0.5.1` (self-built convention, matching esphome-mcp / netbox-mcp / time-mcp), digest pin pending. An upstream request to publish a versioned + tagged image has been filed; if declined, we build from their Dockerfile. Until an image exists: `ImagePullBackOff` (Kustomization still reconciles — `wait: false`).
2. **OAuth credentials.** The ExternalSecret expects a 1Password item `reddit-mcp` with `client_id` + `client_secret` from a Reddit "script" app. A spike proved live OAuth is the **only** reliable tier — the unauthenticated JSON/scrape path is 403-blocked and `curl_cffi` TLS-impersonation does not bypass it. Until the item exists: `SecretSyncedError`, pod won't start.

## Verification plan (post-merge, once image + creds exist)

Port-forward the pod and confirm `extract_public_opinion(post_url=…)` returns live thread data before relying on broker federation; flip to `state: Disabled` only if the broker loops.

## Files

- `kubernetes/apps/mcp-system/reddit-mcp/` — ks, app (HR + ExternalSecret + world-egress CNP), mcp (registration)
- `kubernetes/apps/mcp-system/kustomization.yaml` — registers the app
- `README.md` — MCP-server count + badges bumped in the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)