### PR TITLE
feat(ai): revive claude-runner as subscription-auth cron workflows (suspended)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-159-blue?style=for-the-badge)
+![apps](https://img.shields.io/badge/apps-160-blue?style=for-the-badge)
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-91-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-92-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/claude-runner/README.md
+++ b/kubernetes/apps/ai/claude-runner/README.md
@@ -1,0 +1,68 @@
+# claude-runner — cron-driven Claude Code workflows (subscription)
+
+A revival of the retired `automation/claude-runner`, re-homed to the `ai`
+namespace and updated for **subscription auth** (never the API). It runs
+headless `claude --print` workflows on a schedule so "check for events
+occasionally and act" work doesn't depend on a laptop.
+
+Design decisions live in the plan (`moonlit-brewing-dijkstra`). The load-bearing
+ones:
+
+- **Subscription only, never the API.** Auth is `CLAUDE_CODE_OAUTH_TOKEN` from
+  `claude setup-token` (rides Max). No `ANTHROPIC_API_KEY` anywhere.
+- **No MCP broker.** The Kuadrant broker has no enforceable per-tool authz and
+  fronts mutating backends; its own note says do not point an unattended loop
+  at it. This runner reads cluster state the enforceable way — **read-only
+  Prometheus** (`cnp-allow.yaml`). Future API needs get scoped read-only RBAC,
+  never the broker.
+- **Two-tier routing.** Summarize / classify / triage / log-triage belong on
+  **local models** (`sgpt`), per HOMELAB-SPEC Layer 6 — not here. This runner
+  hosts only workflows that need Claude's reasoning + tool-use.
+
+## Activation (shipped suspended — Gate 0)
+
+The Flux `ks.yaml` ships `suspend: true`. Activate in order:
+
+1. **Token.** On nomad: `claude setup-token` → copy the value →
+   `op item edit "claude-runner" --vault Kubernetes claude_code_oauth_token=<token>`
+   (item also needs `gh_token`). Subscription token only — never an API key.
+2. **Image.** Confirm `ghcr.io/rwlove/claude-runner` is published and current
+   (plan D3: add `tmux`, bump `CLAUDE_CODE_VERSION`); set the tag in the app
+   manifests. Ships suspended, so nothing pulls until step 3.
+3. **Unsuspend the ks** (remove `spec.suspend`). Flux creates the
+   `claude-runner-secret` ExternalSecret and runs the **auth-spike Job**.
+   Confirm: `kubectl -n ai logs job/claude-runner-auth-spike` prints
+   `SUBSCRIPTION-HEADLESS-OK`. **If it fails or demands an API key, stop** —
+   the subscription-headless assumption is void; re-decide per the plan.
+4. **Unsuspend the CronJob** (remove `spec.suspend` from
+   `cronjob-flux-longhorn-drift-digest.yaml`). Test once with
+   `kubectl -n ai create job --from=cronjob/claude-runner-flux-longhorn-drift-digest drift-test`.
+
+## Workflows
+
+| Workflow | Schedule (UTC) | Tier | What |
+|---|---|---|---|
+| `flux-longhorn-drift-digest` | `0 13 * * 1` (Mon 09:00 EDT) | Claude | Read Flux/Longhorn health from Prometheus, reason about real drift + a fix, post ONE `drift-digest` GitHub issue. Silent when clean. |
+
+Summarize/triage-style checks (Renovate-PR summaries, log skims, doc-drift)
+do **not** go here — they are the local-model (`sgpt`) tier per HOMELAB-SPEC
+Layer 6.
+
+## Add a Claude-tier workflow
+
+Copy `cronjob-flux-longhorn-drift-digest.yaml`, then:
+
+- Keep the hardening block verbatim (non-root 1000, `readOnlyRootFilesystem`,
+  drop `ALL`, `RuntimeDefault`, tmpfs work dirs, `automountServiceAccountToken:
+  false`, `k8tz.io/inject: "false"`, deadlines, `backoffLimit`, `Forbid`).
+- Reach only what `cnp-allow.yaml` permits (Prometheus + world:443). Need more?
+  Add a **narrow** egress rule + scoped read-only RBAC — never the MCP broker.
+- Set `--allowedTools` explicitly; never `--dangerously-skip-permissions`.
+- Pick a sink: a single GitHub issue/comment, or Pushover — never per-PR spam.
+- Keep the cadence low (shared Max limits).
+
+## Kill criteria
+
+Retire any workflow (delete its CronJob) if: useful-output rate < 30% after
+2 weeks, OR zero acted-upon outputs in 14 days, OR > 5 noise outputs in any
+7-day window.

--- a/kubernetes/apps/ai/claude-runner/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cnp-allow.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: claude-runner-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: claude-runner
+  # Additive — default-deny (ai ns) triggers the lockdown; these punch holes.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Prometheus (observability ns) — READ-ONLY cluster state for the
+    # drift-digest workflow (Flux gotk_* + Longhorn longhorn_* metrics).
+    # Selector matches the known-good prometheus-mcp rule (app.kubernetes.io/
+    # name: prometheus); a wrong label here silent-drops (see
+    # reference_cnp_blackbox_exporter_label_trap).
+    #
+    # DELIBERATELY NOT the MCP broker (mcp-gateway-istio.mcp-system:8080):
+    # opencode/app/cnp-allow.yaml documents the broker has no enforceable
+    # per-tool authz — reachability grants the full MUTATING surface
+    # (kubectl/omada/ha/arr) and the client-side allowlist "is not a security
+    # boundary." Its own note: do not point an unattended loop at it. This
+    # runner is an unattended loop, so it stays on read-only Prometheus.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # External HTTPS: api.anthropic.com (Claude Code subscription runtime) +
+    # api.github.com (gh CLI). matchPattern FQDN pinning is inert here
+    # (A-only records) per project_cilium_matchpattern_fqdn_limits, so this
+    # collapses to world:443 (repo precedent: opencode, khoj, comfyui).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
@@ -1,0 +1,108 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: claude-runner-flux-longhorn-drift-digest
+  labels:
+    app.kubernetes.io/name: claude-runner
+spec:
+  # SECOND gate: stays suspended until the auth-spike Job (Gate 0) prints
+  # SUBSCRIPTION-HEADLESS-OK. Then remove this line to activate.
+  suspend: true
+  # 0 13 * * 1 UTC = Monday 09:00 EDT / 08:00 EST. Weekly on purpose: these
+  # runs draw on Rob's shared Max limits, so keep the cadence low.
+  schedule: "0 13 * * 1"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # 30 min hard cap — Claude reasoning + tool-calls per turn can run long;
+      # backoffLimit:1 + the weekly schedule bound the worst case.
+      activeDeadlineSeconds: 1800
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: claude-runner
+          annotations:
+            k8tz.io/inject: "false"
+        spec:
+          serviceAccountName: claude-runner
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          containers:
+            - name: runner
+              image: ghcr.io/rwlove/claude-runner:0.1.1
+              imagePullPolicy: IfNotPresent
+              command: ["claude"]
+              args:
+                - "--print"
+                - "--max-turns"
+                - "25"
+                # Permission allowlist (D6) — NOT --dangerously-skip-permissions.
+                # curl reaches only Prometheus + world:443 (CNP-bounded); gh
+                # posts the one digest issue.
+                - "--allowedTools"
+                - "Bash(curl:*) Bash(gh:*)"
+                - >-
+                  You are the home-ops drift auditor. Read cluster state
+                  READ-ONLY from Prometheus via curl against
+                  http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/query
+                  Assess two things: (1) Flux health —
+                  gotk_reconcile_condition{type="Ready",status="False"} — list
+                  every non-Ready Kustomization and HelmRelease; distinguish a
+                  transient mass-reconcile (many Progressing at once, converges
+                  in minutes) from a real Stalled/BuildFailed/ApplyFailed root.
+                  (2) Longhorn — longhorn_volume_* health and any backup-age
+                  series indicating a stale or missing backup. For each real
+                  problem, reason about the likely cause and one concrete next
+                  step. Post ONE consolidated GitHub issue to rwlove/home-ops
+                  titled "drift-digest: <YYYY-MM-DD>" with label "drift-digest"
+                  via `gh issue create`. If there are zero real problems, post
+                  nothing and exit 0. Never include secrets, media file names,
+                  internal hostnames, or restricted app names in the issue.
+              env:
+                - name: HOME
+                  value: /workspace
+                - name: TZ
+                  value: America/New_York
+              envFrom:
+                - secretRef:
+                    name: claude-runner-secret
+                    optional: false
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: workspace
+                  mountPath: /workspace
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: workspace
+              emptyDir:
+                medium: Memory
+                sizeLimit: 256Mi
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 64Mi

--- a/kubernetes/apps/ai/claude-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-runner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: claude-runner-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Subscription only — never the API (Rob's hard constraint). Value is
+        # the output of `claude setup-token` (a ~1-year token that rides the
+        # Max subscription). There is deliberately NO ANTHROPIC_API_KEY here.
+        CLAUDE_CODE_OAUTH_TOKEN: "{{ .claude_code_oauth_token }}"
+        # gh CLI token — read the repo + create the drift-digest issue.
+        GH_TOKEN: "{{ .gh_token }}"
+  dataFrom:
+    - extract:
+        # 1P item `claude-runner` in vault `Kubernetes`. Fields:
+        # claude_code_oauth_token (from `claude setup-token`), gh_token.
+        key: claude-runner

--- a/kubernetes/apps/ai/claude-runner/app/job-auth-spike.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/job-auth-spike.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/job-batch-v1.json
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: claude-runner-auth-spike
+  labels:
+    app.kubernetes.io/name: claude-runner
+# GATE 0 (plan D0): proves subscription-headless works IN-CLUSTER before any
+# scheduled workflow is unsuspended. Runs once when the ks is unsuspended;
+# success = a Completed pod whose logs contain SUBSCRIPTION-HEADLESS-OK using
+# ONLY CLAUDE_CODE_OAUTH_TOKEN (no API key). If it fails, stop and re-decide
+# (local-only, per the plan). Delete/`force` the ks to re-run (Job spec is
+# immutable — see reference_flux_job_spec_template_immutable).
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: claude-runner
+      annotations:
+        # k8tz sidecar can't satisfy restricted PSA; the runner sets TZ via env.
+        k8tz.io/inject: "false"
+    spec:
+      serviceAccountName: claude-runner
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: runner
+          # D3: rebuild/confirm this image before activation. Ships suspended,
+          # so no pull happens until the ks is unsuspended.
+          image: ghcr.io/rwlove/claude-runner:0.1.1
+          imagePullPolicy: IfNotPresent
+          command: ["claude"]
+          args:
+            - "--print"
+            - "--max-turns"
+            - "2"
+            - >-
+              Reply with exactly this token and nothing else:
+              SUBSCRIPTION-HEADLESS-OK
+          env:
+            - name: HOME
+              value: /workspace
+          envFrom:
+            - secretRef:
+                name: claude-runner-secret
+                optional: false
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: workspace
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi

--- a/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./cronjob-flux-longhorn-drift-digest.yaml
+  - ./externalsecret.yaml
+  - ./job-auth-spike.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/ai/claude-runner/app/rbac.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/rbac.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: claude-runner
+# Zero Kubernetes API access by design. The runner reads cluster state via
+# the Prometheus HTTP API (read-only), not the k8s API — so there is no Role
+# or RoleBinding. If a future workflow genuinely needs the API, give it a
+# narrowly-scoped read-only Role here (a hard boundary) — never the MCP
+# broker (see ./cnp-allow.yaml and ./README.md).
+automountServiceAccountToken: false

--- a/kubernetes/apps/ai/claude-runner/ks.yaml
+++ b/kubernetes/apps/ai/claude-runner/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app claude-runner
+spec:
+  # GATE 0 — shipped suspended. To activate, in order (see ./app/README.md):
+  #   1. `claude setup-token` on nomad → store the value in 1Password item
+  #      `claude-runner`, field `claude_code_oauth_token` (subscription only,
+  #      never an API key).
+  #   2. Rebuild/confirm ghcr.io/rwlove/claude-runner per plan D3 (add tmux,
+  #      bump CLAUDE_CODE_VERSION); set the tag in the ./app manifests.
+  #   3. Remove this `suspend: true` → Flux creates the ExternalSecret and
+  #      runs the auth-spike Job. Confirm its logs print SUBSCRIPTION-HEADLESS-OK.
+  #   4. Only then remove `suspend: true` from the drift-digest CronJob.
+  suspend: true
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: ./kubernetes/apps/ai/claude-runner/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -14,6 +14,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml
+  - ./claude-runner/ks.yaml
   - ./comfyui/ks.yaml
   - ./comfyui-spark/ks.yaml
   - ./lightrag/ks.yaml


### PR DESCRIPTION
## What

Revives the retired `automation/claude-runner` in the `ai` namespace as a subscription-authed, cron-driven headless Claude Code runner — so "check for events occasionally and act" work no longer depends on a laptop. **Ships suspended**; nothing reconciles until activated.

## Key decisions

- **Subscription only, never the API.** Auth is `CLAUDE_CODE_OAUTH_TOKEN` (`claude setup-token`, rides Max). No `ANTHROPIC_API_KEY`.
- **No MCP-broker egress.** Per `opencode/app/cnp-allow.yaml`, the Kuadrant broker has no enforceable per-tool authz and fronts mutating backends — its own note says don't point an unattended loop at it. This runner reads cluster state **read-only via Prometheus** instead.
- **Two-tier routing** (HOMELAB-SPEC L6): summarize/triage-style checks stay on the local-model (`sgpt`) tier; this runner hosts only reasoning + tool-use workflows.
- **Gate 0:** an auth-spike Job proves subscription-headless in-cluster before the CronJob is unsuspended.

## Workflow shipped

`flux-longhorn-drift-digest` (weekly) — reads Flux/Longhorn health from Prometheus, reasons about real drift + a fix, posts one `drift-digest` GitHub issue; silent when clean.

## Activation (two-stage, see `README.md`)

1. `claude setup-token` → 1P item `claude-runner`.
2. Confirm/rebuild the image (add `tmux`, bump CC version).
3. Unsuspend the ks → auth-spike Job must print `SUBSCRIPTION-HEADLESS-OK`.
4. Unsuspend the CronJob.

## Safety

Suspended at both the Flux Kustomization and CronJob level. Hardening carried over verbatim (non-root 1000, `readOnlyRootFilesystem`, drop `ALL`, `RuntimeDefault`, tmpfs, zero-RBAC SA, `k8tz` skip). Read-only Prometheus + world:443 egress only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)