### PR TITLE
feat(ai): activate claude-runner (Gate 0) — pin image, amd64, unsuspend ks

### DIFF
--- a/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
@@ -31,12 +31,16 @@ spec:
           annotations:
             k8tz.io/inject: "false"
         spec:
+          # amd64 image; ai ns also has arm64 Spark nodes — pin so the pod
+          # can't land on Spark and hit an exec-format error.
+          nodeSelector:
+            kubernetes.io/arch: amd64
           serviceAccountName: claude-runner
           automountServiceAccountToken: false
           restartPolicy: OnFailure
           containers:
             - name: runner
-              image: ghcr.io/rwlove/claude-runner:0.1.1
+              image: ghcr.io/rwlove/claude-runner:v2.1.239
               imagePullPolicy: IfNotPresent
               command: ["claude"]
               args:

--- a/kubernetes/apps/ai/claude-runner/app/job-auth-spike.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/job-auth-spike.yaml
@@ -24,14 +24,17 @@ spec:
         # k8tz sidecar can't satisfy restricted PSA; the runner sets TZ via env.
         k8tz.io/inject: "false"
     spec:
+      # amd64 image; ai ns also has arm64 Spark nodes — pin so the pod can't
+      # land on Spark and hit an exec-format error (mirrors opencode).
+      nodeSelector:
+        kubernetes.io/arch: amd64
       serviceAccountName: claude-runner
       automountServiceAccountToken: false
       restartPolicy: Never
       containers:
         - name: runner
-          # D3: rebuild/confirm this image before activation. Ships suspended,
-          # so no pull happens until the ks is unsuspended.
-          image: ghcr.io/rwlove/claude-runner:0.1.1
+          # Current image (tracks Claude Code CLI releases via Renovate).
+          image: ghcr.io/rwlove/claude-runner:v2.1.239
           imagePullPolicy: IfNotPresent
           command: ["claude"]
           args:

--- a/kubernetes/apps/ai/claude-runner/ks.yaml
+++ b/kubernetes/apps/ai/claude-runner/ks.yaml
@@ -5,16 +5,9 @@ kind: Kustomization
 metadata:
   name: &app claude-runner
 spec:
-  # GATE 0 — shipped suspended. To activate, in order (see ./app/README.md):
-  #   1. `claude setup-token` on nomad → store the value in 1Password item
-  #      `claude-runner`, field `claude_code_oauth_token` (subscription only,
-  #      never an API key).
-  #   2. Rebuild/confirm ghcr.io/rwlove/claude-runner per plan D3 (add tmux,
-  #      bump CLAUDE_CODE_VERSION); set the tag in the ./app manifests.
-  #   3. Remove this `suspend: true` → Flux creates the ExternalSecret and
-  #      runs the auth-spike Job. Confirm its logs print SUBSCRIPTION-HEADLESS-OK.
-  #   4. Only then remove `suspend: true` from the drift-digest CronJob.
-  suspend: true
+  # ACTIVATION (see ./app/README.md): token in 1P ✓, image pinned ✓ — ks
+  # unsuspended so the auth-spike Job runs Gate 0. The drift-digest CronJob
+  # stays `suspend: true` until that Job prints SUBSCRIPTION-HEADLESS-OK.
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app


### PR DESCRIPTION
Activates the claude-runner Gate 0 (follows #13705).

- Pins `ghcr.io/rwlove/claude-runner:v2.1.239` (0.1.1 was retired; image is live, amd64, tracks CC CLI).
- `nodeSelector: kubernetes.io/arch: amd64` on Job + CronJob (ai ns has arm64 Spark nodes).
- Unsuspends the Flux Kustomization → the **auth-spike Job** runs Gate 0. Subscription token (`CLAUDE_CODE_OAUTH_TOKEN`) is in the 1P `claude-runner` item; no API key.

The drift-digest CronJob stays suspended until the spike prints `SUBSCRIPTION-HEADLESS-OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)