### PR TITLE
feat(ai): unsuspend claude-runner drift-digest CronJob (Gate 0 passed)

### DIFF
--- a/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
@@ -7,9 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: claude-runner
 spec:
-  # SECOND gate: stays suspended until the auth-spike Job (Gate 0) prints
-  # SUBSCRIPTION-HEADLESS-OK. Then remove this line to activate.
-  suspend: true
+  # Active — Gate 0 passed 2026-08-22 (auth-spike printed SUBSCRIPTION-HEADLESS-OK).
   # 0 13 * * 1 UTC = Monday 09:00 EDT / 08:00 EST. Weekly on purpose: these
   # runs draw on Rob's shared Max limits, so keep the cadence low.
   schedule: "0 13 * * 1"


### PR DESCRIPTION
Gate 0 passed 2026-08-22 — the auth-spike Job printed `SUBSCRIPTION-HEADLESS-OK` in-cluster (subscription token, no API key). Activates the weekly `flux-longhorn-drift-digest` workflow (Mon 13:00 UTC), read-only Prometheus + gh issue sink.

Follows #13705, #13706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)