### PR TITLE
feat(ai): switch claude-runner drift-digest sink to Pushover (private)

### DIFF
--- a/kubernetes/apps/ai/claude-runner/README.md
+++ b/kubernetes/apps/ai/claude-runner/README.md
@@ -24,8 +24,9 @@ ones:
 The Flux `ks.yaml` ships `suspend: true`. Activate in order:
 
 1. **Token.** On nomad: `claude setup-token` → copy the value →
-   `op item edit "claude-runner" --vault Kubernetes claude_code_oauth_token=<token>`
-   (item also needs `gh_token`). Subscription token only — never an API key.
+   `op item edit "claude-runner" --vault Kubernetes claude_code_oauth_token=<token>`.
+   Subscription token only — never an API key. (Pushover creds are pulled from
+   the separate 1P `Pushover` item; no other fields needed on `claude-runner`.)
 2. **Image.** Confirm `ghcr.io/rwlove/claude-runner` is published and current
    (plan D3: add `tmux`, bump `CLAUDE_CODE_VERSION`); set the tag in the app
    manifests. Ships suspended, so nothing pulls until step 3.
@@ -42,7 +43,7 @@ The Flux `ks.yaml` ships `suspend: true`. Activate in order:
 
 | Workflow | Schedule (UTC) | Tier | What |
 |---|---|---|---|
-| `flux-longhorn-drift-digest` | `0 13 * * 1` (Mon 09:00 EDT) | Claude | Read Flux/Longhorn health from Prometheus, reason about real drift + a fix, post ONE `drift-digest` GitHub issue. Silent when clean. |
+| `flux-longhorn-drift-digest` | `0 13 * * 1` (Mon 09:00 EDT) | Claude | Read Flux/Longhorn health from Prometheus, reason about real drift + a fix, send ONE Pushover digest (private — reuses the alertmanager Pushover app). Silent when clean. |
 
 Summarize/triage-style checks (Renovate-PR summaries, log skims, doc-drift)
 do **not** go here — they are the local-model (`sgpt`) tier per HOMELAB-SPEC

--- a/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
@@ -46,10 +46,10 @@ spec:
                 - "--max-turns"
                 - "25"
                 # Permission allowlist (D6) — NOT --dangerously-skip-permissions.
-                # curl reaches only Prometheus + world:443 (CNP-bounded); gh
-                # posts the one digest issue.
+                # curl reaches only Prometheus + world:443 (CNP-bounded): reads
+                # Prometheus, posts the one Pushover digest.
                 - "--allowedTools"
-                - "Bash(curl:*) Bash(gh:*)"
+                - "Bash(curl:*)"
                 - >-
                   You are the home-ops drift auditor. Read cluster state
                   READ-ONLY from Prometheus via curl against
@@ -62,11 +62,13 @@ spec:
                   (2) Longhorn — longhorn_volume_* health and any backup-age
                   series indicating a stale or missing backup. For each real
                   problem, reason about the likely cause and one concrete next
-                  step. Post ONE consolidated GitHub issue to rwlove/home-ops
-                  titled "drift-digest: <YYYY-MM-DD>" with label "drift-digest"
-                  via `gh issue create`. If there are zero real problems, post
-                  nothing and exit 0. Never include secrets, media file names,
-                  internal hostnames, or restricted app names in the issue.
+                  step. Then send ONE Pushover notification via curl: POST to
+                  https://api.pushover.net/1/messages.json with form fields
+                  token (from the PUSHOVER_TOKEN env var), user (from the
+                  PUSHOVER_USER env var), title "drift-digest <YYYY-MM-DD>", and
+                  message (the digest, under 1024 chars). This is a private
+                  channel to Rob. If there are zero real problems, send nothing
+                  and exit 0. Never put secret values in the message.
               env:
                 - name: HOME
                   value: /workspace

--- a/kubernetes/apps/ai/claude-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/externalsecret.yaml
@@ -12,17 +12,22 @@ spec:
   target:
     name: claude-runner-secret
     creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        # Subscription only — never the API (Rob's hard constraint). Value is
-        # the output of `claude setup-token` (a ~1-year token that rides the
-        # Max subscription). There is deliberately NO ANTHROPIC_API_KEY here.
-        CLAUDE_CODE_OAUTH_TOKEN: "{{ .claude_code_oauth_token }}"
-        # gh CLI token — read the repo + create the drift-digest issue.
-        GH_TOKEN: "{{ .gh_token }}"
-  dataFrom:
-    - extract:
-        # 1P item `claude-runner` in vault `Kubernetes`. Fields:
-        # claude_code_oauth_token (from `claude setup-token`), gh_token.
+  data:
+    # Subscription only — never the API (Rob's hard constraint). Value is the
+    # output of `claude setup-token` (a ~1-year token that rides the Max
+    # subscription). There is deliberately NO ANTHROPIC_API_KEY here.
+    - secretKey: CLAUDE_CODE_OAUTH_TOKEN
+      remoteRef:
         key: claude-runner
+        property: claude_code_oauth_token
+    # Pushover — the digest sink (private). Reuses the same app the
+    # alertmanager path uses (1P item `Pushover`), so digests can safely carry
+    # restricted-tier Kustomization names a public GitHub issue must not.
+    - secretKey: PUSHOVER_TOKEN
+      remoteRef:
+        key: Pushover
+        property: alertmanager_token
+    - secretKey: PUSHOVER_USER
+      remoteRef:
+        key: Pushover
+        property: userkey


### PR DESCRIPTION
The digest reasons over `gotk_reconcile_condition`, which can include restricted-tier (media stack) Kustomization names — those must not land in a public GitHub issue (HOMELAB-SPEC L2 #2/#10). Switch the sink to **Pushover** (private, reuses the alertmanager Pushover app).

- ExternalSecret pulls `PUSHOVER_TOKEN`/`PUSHOVER_USER` from the 1P `Pushover` item; drops unused `GH_TOKEN`.
- CronJob `allowedTools` = `Bash(curl:*)`; prompt posts to the Pushover API.

Follows #13705, #13706, #13708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)