### PR TITLE
fix(ai): claude-runner drift-digest — arg order + Prometheus ingress

### DIFF
--- a/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-flux-longhorn-drift-digest.yaml
@@ -42,14 +42,18 @@ spec:
               imagePullPolicy: IfNotPresent
               command: ["claude"]
               args:
+                # `--allowedTools` is variadic — it MUST be followed by a
+                # single-value flag (here --max-turns), not the positional
+                # prompt, or it swallows the prompt as tool rules and the run
+                # dies with "Input must be provided … when using --print".
                 - "--print"
-                - "--max-turns"
-                - "25"
                 # Permission allowlist (D6) — NOT --dangerously-skip-permissions.
                 # curl reaches only Prometheus + world:443 (CNP-bounded): reads
                 # Prometheus, posts the one Pushover digest.
                 - "--allowedTools"
                 - "Bash(curl:*)"
+                - "--max-turns"
+                - "25"
                 - >-
                   You are the home-ops drift auditor. Read cluster state
                   READ-ONLY from Prometheus via curl against

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
@@ -29,6 +29,10 @@ spec:
     # Path-2 of the tool-binding gap workaround — see
     # [[reference_agent_fleet_tool_binding_gap]] memory and
     # PR #12029 for the windmill-side egress rule).
+    # claude-runner (ai ns) → prometheus:9090 (the flux-longhorn drift
+    # digest CronJob reads Flux/Longhorn state read-only via the Prom
+    # HTTP API; egress side allowed in ai/claude-runner-allow). Same
+    # shape as the windmill drift crons above.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
@@ -39,6 +43,9 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
             app.kubernetes.io/name: prometheus-mcp
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: claude-runner
         - matchExpressions:
             - key: io.kubernetes.pod.namespace
               operator: In


### PR DESCRIPTION
Two bugs found while live-testing the drift-digest workflow in-cluster:

1. **`--allowedTools` swallowed the prompt.** It's variadic; with the prompt as the trailing positional it consumed the prompt as tool-rules and the run died (`Input must be provided … when using --print`). Reordered so `--max-turns` separates `--allowedTools` from the prompt. Verified fixed in a live debug pod.
2. **Prometheus ingress blocked the runner.** `prometheus-allow` is an explicit allowlist; the runner wasn't on it, so `curl` to `prometheus:9090` timed out (exit 28). Added `ai/claude-runner` as an ingress source, mirroring the windmill drift-cron / prometheus-mcp entries.

Follows #13705/#13706/#13708/#13709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)