### PR TITLE
feat(ai): claude-runner-shell — persistent interactive session (Phase 4)

### DIFF
--- a/kubernetes/apps/ai/claude-runner/README.md
+++ b/kubernetes/apps/ai/claude-runner/README.md
@@ -49,6 +49,25 @@ Summarize/triage-style checks (Renovate-PR summaries, log skims, doc-drift)
 do **not** go here — they are the local-model (`sgpt`) tier per HOMELAB-SPEC
 Layer 6.
 
+## Interactive shell (survives laptop sleep)
+
+`deployment-shell.yaml` runs a persistent `claude-runner-shell` Deployment that
+holds a detached `tmux` session on the subscription token. Use it to kick off a
+long interactive task and walk away — the session keeps running in-cluster when
+your laptop sleeps.
+
+```sh
+kubectl -n ai exec -it deploy/claude-runner-shell -- tmux attach -t main
+# then inside: claude
+# detach: Ctrl-b d   (session + any running task persist; reattach anytime)
+```
+
+HOME (`/home/node`) is a `ceph-block` PVC (`claude-shell-data`), so Claude
+transcripts + scratch clones survive pod restarts. Needs the tmux-bearing image
+(`ghcr.io/rwlove/claude-runner:v2.1.240+`, built with `tmux` in the `containers`
+repo). Egress is the same CNP as the cron workflows (read-only Prometheus +
+world:443); attach is via `kubectl exec`, no route.
+
 ## Add a Claude-tier workflow
 
 Copy `cronjob-flux-longhorn-drift-digest.yaml`, then:

--- a/kubernetes/apps/ai/claude-runner/app/deployment-shell.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/deployment-shell.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/deployment-apps-v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: claude-runner-shell
+  labels:
+    app.kubernetes.io/name: claude-runner
+spec:
+  # Persistent interactive Claude Code session that survives laptop sleep.
+  # Attach:  kubectl -n ai exec -it deploy/claude-runner-shell -- tmux attach -t main
+  # then run `claude`. Detach with Ctrl-b d (or just let the connection drop) —
+  # the tmux session, and any task running in it, keeps going in the pod.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: claude-runner
+      app.kubernetes.io/component: shell
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: claude-runner
+        app.kubernetes.io/component: shell
+      annotations:
+        k8tz.io/inject: "false"
+    spec:
+      # amd64 image; ai ns also has arm64 Spark nodes.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      securityContext:
+        # Writable ceph-block PVC at HOME — chown the mount to the non-root gid.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: claude-runner
+      automountServiceAccountToken: false
+      containers:
+        - name: shell
+          image: ghcr.io/rwlove/claude-runner:v2.1.240
+          imagePullPolicy: IfNotPresent
+          # Hold a detached tmux session "main" (running the default bash) alive;
+          # sleep infinity keeps PID 1 up. tini reaps/forwards signals.
+          command:
+            - /sbin/tini
+            - --
+            - bash
+            - -c
+            - tmux new-session -d -s main; exec sleep infinity
+          workingDir: /home/node
+          env:
+            - name: HOME
+              value: /home/node
+            - name: TZ
+              value: America/New_York
+          # Subscription token (CLAUDE_CODE_OAUTH_TOKEN) — same secret as the
+          # cron workflows; PUSHOVER_* come along unused, harmless.
+          envFrom:
+            - secretRef:
+                name: claude-runner-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          volumeMounts:
+            - name: data
+              mountPath: /home/node
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: claude-shell-data
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 512Mi

--- a/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ./cnp-allow.yaml
   - ./cronjob-flux-longhorn-drift-digest.yaml
+  - ./deployment-shell.yaml
   - ./externalsecret.yaml
   - ./job-auth-spike.yaml
+  - ./pvc-shell.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/ai/claude-runner/app/pvc-shell.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/pvc-shell.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: claude-shell-data
+spec:
+  # Rob's interactive shell HOME (/home/node): Claude session transcripts,
+  # config, and scratch repo clones. ceph-block (default) — survives pod
+  # restart + node loss, which is plenty for a dev shell. Switch to
+  # storageClassName: longhorn if this state ever needs cluster-loss
+  # durability (it would then auto-join Longhorn's default backup group).
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
A `claude-runner-shell` Deployment holding a detached `tmux` session on the subscription token, so an interactive `claude` session (and any task running in it) survives a `kubectl exec` disconnect / laptop sleep.

```
kubectl -n ai exec -it deploy/claude-runner-shell -- tmux attach -t main
```

- Image `ghcr.io/rwlove/claude-runner:v2.1.240` (tmux added in containers#305).
- HOME on ceph-block PVC (`claude-shell-data`); fsGroup 1000; survives restarts.
- Reuses `claude-runner-secret` + the existing CNP (read-only Prometheus + world:443). Exec-only, no route.

Closes the original 'don't lose work when the laptop sleeps' ask. Follows #13705/6/8/9/10.