### PR TITLE
feat(ai): local-cron — Ollama-summarized daily Loki error skim (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-161-blue?style=for-the-badge)
+![apps](https://img.shields.io/badge/apps-162-blue?style=for-the-badge)
 ![helmreleases](https://img.shields.io/badge/HelmReleases-173-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-93-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-94-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./comfyui/ks.yaml
   - ./comfyui-spark/ks.yaml
   - ./lightrag/ks.yaml
+  - ./local-cron/ks.yaml
   - ./ollama/ks.yaml
   - ./opencode/ks.yaml
   - ./paperless-ai/ks.yaml

--- a/kubernetes/apps/ai/local-cron/README.md
+++ b/kubernetes/apps/ai/local-cron/README.md
@@ -1,0 +1,106 @@
+# local-cron — local-model (Ollama) cron tier
+
+Phase 2 of the two-tier cron routing established by `ai/claude-runner`.
+Where `claude-runner` hosts workflows that genuinely need Claude's
+reasoning + tool-use, **this app hosts the summarize / classify /
+log-triage work that HOMELAB-SPEC Layer 6 assigns to local models** — so
+those runs cost **zero Anthropic tokens**.
+
+The load-bearing design points:
+
+- **Local model, never Claude.** Summarization runs on the in-cluster
+  Ollama on the P40 (`ollama.ai.svc.cluster.local:11434`, `/api/generate`,
+  model `qwen2.5:7b`). There is **no `ANTHROPIC_API_KEY` and no
+  `CLAUDE_CODE_OAUTH_TOKEN`** anywhere in this app.
+- **No MCP broker, no k8s API.** The job reads log state read-only via the
+  Loki HTTP API, summarizes on Ollama, and posts one Pushover message.
+  None of that touches the k8s API, so the ServiceAccount has zero RBAC
+  and `automountServiceAccountToken: false`. Future API needs get scoped
+  read-only RBAC — never the broker (same rule as `claude-runner`).
+- **Pure curl, no custom image.** The job runs `docker.io/alpine/k8s`
+  (carries `curl` + `jq`), so there is no image to build/publish and no
+  Gate-0 auth spike — unlike `claude-runner`.
+- **Private sink.** The digest goes to Pushover (the same 1P `Pushover`
+  item alertmanager uses), so it can carry namespace/app names a public
+  GitHub artifact must not.
+
+## Workflows
+
+| Workflow | Schedule (UTC) | Tier | What |
+|---|---|---|---|
+| `loki-error-skim` | `0 12 * * *` (08:00 EDT / 07:00 EST, daily) | Local (Ollama) | LogQL-rank the top error/panic/fatal log producers in Loki over 24h, pull a small sample of lines from the top 5, have the local model distill them into a terse pattern digest, send ONE Pushover message. Silent (exit 0, no push) when there are no error lines. |
+
+Query path: `topk(15, sum by (namespace, app) (count_over_time({namespace=~".+"} |~ "(?i)(error|panic|fatal|traceback|exception)" [24h])))`
+against `loki:3100` (Loki stream labels here are `app` / `namespace` /
+`node`, set by the Vector aggregator sink).
+
+## Why Loki (not the PR-summary fallback)
+
+Loki was the clean wire: `auth_enabled: false`, monolithic SingleBinary,
+one Service (`loki.observability:3100`), and a real LogQL metric API that
+does the ranking server-side. The PR-summary fallback would have needed a
+`gh` token + world egress to `api.github.com` for a weaker signal. Loki
+gives a genuine ops-triage digest with no extra credential.
+
+## Network policy
+
+The `ai` namespace is default-deny; `observability` is default-deny
+ingress. Two holes were punched:
+
+- **`ai/local-cron/app/cnp-allow.yaml`** (egress): `loki.observability:3100`
+  plus `world:443` (Pushover). Ollama is **intra-ns** (both in `ai`), so it
+  rides the baseline `allow-intra-namespace` — no rule needed.
+- **`observability/loki/app/cnp-allow.yaml`** (ingress): added
+  `ai/local-cron` as a cross-ns source on `loki:3100`. Loki previously had
+  no ingress rules (only intra-ns Grafana/Vector via baseline), so this
+  cross-ns caller had to be listed explicitly or it would silent-drop.
+
+## Activation (shipped suspended)
+
+Both the Flux `ks.yaml` and the CronJob ship `suspend: true`. Activate in
+order:
+
+1. **Confirm the model is pullable/loadable.** `qwen2.5:7b` is already the
+   khoj default and Open WebUI-selectable on this Ollama, so it is
+   present. (If Ollama has been reset, `ollama pull qwen2.5:7b` on the
+   P40.) No 1P work is required — the `Pushover` item already exists and
+   is shared with alertmanager.
+2. **Unsuspend the ks** — remove `spec.suspend: true` from
+   `local-cron/ks.yaml`. Flux then reconciles the ExternalSecret
+   (`local-cron-secret`), the CNP, the RBAC, and the CronJob object. The
+   CronJob is still `suspend: true`, so nothing fires yet. Verify:
+   `kubectl -n ai get externalsecret local-cron` shows `SecretSynced`.
+3. **Test once, out of band.** With the CronJob still suspended:
+   `kubectl -n ai create job --from=cronjob/local-cron-loki-error-skim skim-test`
+   then `kubectl -n ai logs job/skim-test -f`. Expect the ranked list, the
+   `----- local-model digest -----` block, and `Pushover digest sent`. If
+   Loki returns no error lines it exits 0 with "Nothing to report" and
+   sends nothing — that is success, not failure.
+4. **Unsuspend the CronJob** — remove `spec.suspend: true` from
+   `cronjob-loki-error-skim.yaml`. It now runs daily at 12:00 UTC.
+
+To pause again: re-add `spec.suspend: true` to the CronJob (fast, keeps
+objects) or to the ks (full teardown of the app's objects on next prune).
+
+## Add a local-tier workflow
+
+Copy `cronjob-loki-error-skim.yaml`, then:
+
+- Keep the hardening verbatim (non-root 1000, `readOnlyRootFilesystem`,
+  drop `ALL`, `RuntimeDefault`, tmpfs `/tmp`, `automountServiceAccountToken:
+  false`, `k8tz.io/inject: "false"`, deadlines, `backoffLimit`, `Forbid`).
+- Summarize on **Ollama**, never Claude — that is the whole point of this
+  tier (HOMELAB-SPEC L6).
+- Double every shell `$` as `$$` — Flux postBuild runs envsubst in strict
+  mode over the manifest.
+- Reach only what `cnp-allow.yaml` permits. New destination? Add a narrow
+  egress rule here AND the matching ingress rule on the destination's own
+  CNP (default-deny cuts both directions).
+- Pick a private sink (Pushover) — never per-item spam.
+
+## Kill criteria
+
+Retire a workflow (delete its CronJob) if: useful-output rate < 30% after
+2 weeks, OR zero acted-upon outputs in 14 days, OR > 5 noise digests in
+any 7-day window. Local inference is free, so the bar is *usefulness of
+the digest*, not token cost.

--- a/kubernetes/apps/ai/local-cron/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/local-cron/app/cnp-allow.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: local-cron-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: local-cron
+  # Additive — the ai ns default-deny is what triggers the lockdown; these
+  # rules punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Loki (observability ns) — READ-ONLY log state for the daily
+    # error-pattern skim. Loki is auth_enabled:false / SingleBinary; the
+    # Service is loki.observability:3100 and Loki pods carry
+    # `app.kubernetes.io/name: loki`. A wrong label here silent-drops (see
+    # reference_cnp_blackbox_exporter_label_trap). The INGRESS side is
+    # punched through in observability/loki/app/cnp-allow.yaml — that CNP
+    # otherwise admits only intra-ns Grafana/Vector, so this cross-ns
+    # caller had to be added there explicitly.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: loki
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP
+    # Ollama (ai ns, intra-namespace) — the local-model summarizer. NOT
+    # given its own rule here: local-cron and ollama are both in `ai`, so
+    # this hop is covered by the baseline `allow-intra-namespace` component.
+    # ollama's own cnp-allow.yaml lists cross-ns callers only; intra-ns is
+    # explicitly delegated to the baseline there. Reasoning runs on the P40
+    # local model (qwen2.5:7b) — NOT Claude/Anthropic (HOMELAB-SPEC L6).
+    #
+    # External HTTPS: api.pushover.net (the private digest sink). It is a
+    # canonical FQDN (no CNAME chain), and Cilium matchPattern silently
+    # fails on those through K8s DNS search-domain augmentation (see memory
+    # project_cilium_matchpattern_fqdn_limits), so this collapses to
+    # world:443 — same precedent as the alertmanager→Pushover rule in
+    # observability/kube-prometheus-stack/app/cnp-allow.yaml and the repo's
+    # PRs #11498/#11512/#11517/#11533.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/local-cron/app/cronjob-loki-error-skim.yaml
+++ b/kubernetes/apps/ai/local-cron/app/cronjob-loki-error-skim.yaml
@@ -1,0 +1,212 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: local-cron-loki-error-skim
+  labels:
+    app.kubernetes.io/name: local-cron
+spec:
+  # SHIPPED SUSPENDED (see ./README.md → Activation). Even with the ks
+  # unsuspended, this CronJob does not fire until `spec.suspend` is removed.
+  suspend: true
+  # 0 12 * * * UTC = 08:00 EDT / 07:00 EST, daily. Well after the 00:00 UTC
+  # Longhorn recurring-job window and off the mcp-gateway 04:30 rotation, so
+  # the P40 model load doesn't collide with other scheduled bursts. Local
+  # inference is free (no Anthropic tokens), so daily cadence is fine —
+  # unlike the claude-runner tier which is weekly to spare Max limits.
+  schedule: "0 12 * * *"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # 15 min hard cap: Loki queries are quick; the only slow leg is a
+      # cold qwen2.5:7b GGUF load on the P40 (~seconds) plus generation.
+      activeDeadlineSeconds: 900
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: local-cron
+          annotations:
+            k8tz.io/inject: "false"
+        spec:
+          # amd64 image; ai ns also has arm64 Spark nodes — pin so the pod
+          # can't land on Spark and hit an exec-format error.
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          serviceAccountName: local-cron
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          containers:
+            - name: skim
+              # Carries curl + jq (same image the home-ns/mcp-system
+              # maintenance jobs use). NOTE: `date` is busybox — it accepts
+              # `-d @<epoch>` but not `-d "24 hours ago"`; the epoch math
+              # below is deliberate.
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ceu
+                # Flux postBuild runs envsubst in STRICT mode over this
+                # manifest: a bare ${VAR} is read as a Flux substitution and
+                # fails the whole Kustomization with "variable not set".
+                # Every shell `$` is doubled (`$$`) so the rendered manifest
+                # carries a literal `$` for /bin/sh. Same convention as
+                # home/windmill/app/watchdog-cronjob.yaml (verified there).
+                - |
+                  LOKI="http://loki.observability.svc.cluster.local:3100"
+                  OLLAMA="http://ollama.ai.svc.cluster.local:11434"
+                  MODEL="qwen2.5:7b"
+                  WINDOW_S=86400
+
+                  NOW="$$(date -u +%s)"
+                  START="$$(( (NOW - WINDOW_S) * 1000000000 ))"
+                  END="$$(( NOW * 1000000000 ))"
+                  DAY="$$(date -u +%Y-%m-%d)"
+
+                  # (1) Rank apps by error/panic/fatal log volume over 24h.
+                  # A LogQL metric query: count matching lines per app+ns.
+                  # `|~` is case-insensitive via (?i). We cap the topk so the
+                  # summary stays bounded, and only pull sample lines from
+                  # those apps.
+                  METRIC_Q='topk(15, sum by (namespace, app) (count_over_time({namespace=~".+"} |~ `(?i)(error|panic|fatal|traceback|exception)` [24h])))'
+
+                  RANK="$$(curl -sSG --max-time 60 \
+                            "$${LOKI}/loki/api/v1/query" \
+                            --data-urlencode "query=$${METRIC_Q}" \
+                            --data-urlencode "time=$${END}")" || {
+                    echo "FATAL: Loki metric query failed — cannot skim errors"
+                    exit 1
+                  }
+
+                  # Flatten to "count<TAB>namespace/app" lines. jq -e makes an
+                  # unexpected shape (Loki error payload) a hard failure
+                  # rather than a silent empty pass.
+                  RANKED="$$(printf '%s' "$$RANK" | jq -er '
+                    .data.result
+                    | map({c: (.value[1] | tonumber), ns: .metric.namespace, app: .metric.app})
+                    | sort_by(-.c)
+                    | .[]
+                    | "\(.c)\t\(.ns)/\(.app)"' )" || {
+                    echo "FATAL: could not parse Loki rank response"
+                    printf '%s\n' "$$RANK" | head -c 500
+                    exit 1
+                  }
+
+                  if [ -z "$$RANKED" ]; then
+                    echo "No error/panic/fatal log lines in the last 24h. Nothing to report."
+                    exit 0
+                  fi
+
+                  echo "Top error-log producers (24h):"
+                  printf '%s\n' "$$RANKED"
+
+                  # (2) Pull a small sample of actual error lines from the top
+                  # few apps for the model to distill into patterns. Keep the
+                  # payload small — this is a skim, not a full log export.
+                  # POSIX sh `while read` runs in a subshell, so accumulate
+                  # into a temp file rather than a shell var that would be lost.
+                  : > /tmp/samples.txt
+                  printf '%s\n' "$$RANKED" | head -5 | while IFS="$$(printf '\t')" read -r C NSAPP; do
+                    NS="$${NSAPP%%/*}"
+                    APP="$${NSAPP#*/}"
+                    Q="{namespace=\"$${NS}\", app=\"$${APP}\"} |~ \`(?i)(error|panic|fatal|traceback|exception)\`"
+                    LINES="$$(curl -sSG --max-time 45 \
+                                "$${LOKI}/loki/api/v1/query_range" \
+                                --data-urlencode "query=$${Q}" \
+                                --data-urlencode "start=$${START}" \
+                                --data-urlencode "end=$${END}" \
+                                --data-urlencode "limit=8" \
+                                --data-urlencode "direction=backward" \
+                              | jq -r '.data.result[]?.values[]?[1]' 2>/dev/null \
+                              | head -8 | cut -c1-300)"
+                    {
+                      echo "### $${NSAPP} ($${C} lines/24h)"
+                      printf '%s\n' "$$LINES"
+                      echo
+                    } >> /tmp/samples.txt
+                  done
+
+                  SAMPLES="$$(cat /tmp/samples.txt)"
+
+                  # (3) Summarize with the LOCAL model (Ollama, P40) — never
+                  # Claude. Build the /api/generate body with jq so the log
+                  # text is safely JSON-escaped.
+                  PROMPT="You are a Kubernetes log-triage assistant for a home cluster. Below are the top error-log producers in the last 24h and a few sample lines from each. Produce a terse digest (max 12 short lines, plain text, no markdown): for each notable app, one line naming it and the dominant error pattern, and whether it looks like noise or a real problem. Group obvious flapping. Do not invent apps not listed. Data:\n\n$${SAMPLES}"
+
+                  REQ="$$(jq -n --arg m "$$MODEL" --arg p "$$PROMPT" \
+                          '{model:$$m, prompt:$$p, stream:false, options:{num_predict:400, temperature:0.2}}')"
+
+                  SUMMARY="$$(curl -sSf --max-time 300 \
+                              -H 'Content-Type: application/json' \
+                              -d "$$REQ" \
+                              "$${OLLAMA}/api/generate" \
+                            | jq -r '.response // empty')" || {
+                    echo "FATAL: Ollama summarization failed"
+                    exit 1
+                  }
+
+                  if [ -z "$$SUMMARY" ]; then
+                    echo "FATAL: Ollama returned an empty summary"
+                    exit 1
+                  fi
+
+                  echo "----- local-model digest -----"
+                  printf '%s\n' "$$SUMMARY"
+
+                  # (4) Send ONE Pushover notification (private channel).
+                  # Pushover message limit is 1024 chars; truncate to be safe.
+                  MSG="$$(printf '%s' "$$SUMMARY" | cut -c1-1000)"
+                  HTTP="$$(curl -sS --max-time 30 -o /tmp/pushover.out -w '%{http_code}' \
+                            --form-string "token=$${PUSHOVER_TOKEN}" \
+                            --form-string "user=$${PUSHOVER_USER}" \
+                            --form-string "title=loki-error-skim $${DAY}" \
+                            --form-string "message=$${MSG}" \
+                            https://api.pushover.net/1/messages.json)" || {
+                    echo "FATAL: Pushover request errored"
+                    exit 1
+                  }
+                  case "$$HTTP" in
+                    2??) echo "Pushover digest sent (HTTP $$HTTP)";;
+                    *) echo "FATAL: Pushover returned HTTP $$HTTP"; cat /tmp/pushover.out; exit 1;;
+                  esac
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: TZ
+                  value: America/New_York
+              envFrom:
+                - secretRef:
+                    name: local-cron-secret
+                    optional: false
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 64Mi

--- a/kubernetes/apps/ai/local-cron/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/local-cron/app/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: local-cron
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: local-cron-secret
+    creationPolicy: Owner
+  data:
+    # Pushover — the digest sink (private). Reuses the same 1P `Pushover`
+    # item the alertmanager path uses (see
+    # observability/kube-prometheus-stack/app/externalsecret.yaml). Because
+    # it is a private channel to Rob, the digest can safely carry
+    # namespace/app names that a public GitHub artifact must not.
+    #
+    # There is DELIBERATELY no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN
+    # here — summarization runs on the in-cluster local Ollama, per
+    # HOMELAB-SPEC Layer 6 (the whole point of this tier is to not burn
+    # Anthropic tokens on summarize/classify/log-triage work).
+    - secretKey: PUSHOVER_TOKEN
+      remoteRef:
+        key: Pushover
+        property: alertmanager_token
+    - secretKey: PUSHOVER_USER
+      remoteRef:
+        key: Pushover
+        property: userkey

--- a/kubernetes/apps/ai/local-cron/app/kustomization.yaml
+++ b/kubernetes/apps/ai/local-cron/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./cronjob-loki-error-skim.yaml
+  - ./externalsecret.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/ai/local-cron/app/rbac.yaml
+++ b/kubernetes/apps/ai/local-cron/app/rbac.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-cron
+# Zero Kubernetes API access by design. This job reads log state via the
+# Loki HTTP API (read-only), summarizes with the in-cluster Ollama HTTP
+# API, and posts one Pushover notification — none of which touch the k8s
+# API. So there is no Role or RoleBinding. If a future workflow genuinely
+# needs the k8s API, give it a narrowly-scoped read-only Role here (a hard
+# boundary) — never the MCP broker (see ./cnp-allow.yaml and ./README.md).
+automountServiceAccountToken: false

--- a/kubernetes/apps/ai/local-cron/ks.yaml
+++ b/kubernetes/apps/ai/local-cron/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app local-cron
+spec:
+  # SHIPPED SUSPENDED. Phase 2 of the local-model cron tier: a daily Loki
+  # error-pattern skim summarized by the in-cluster Ollama (NOT Claude /
+  # Anthropic — no API key anywhere) and pushed to Pushover. Activation is
+  # a two-step unsuspend documented in ./app/README.md. Do not remove this
+  # `suspend` on a whim; it runs against a prod cluster. The CronJob inside
+  # is ALSO `suspend: true`, so even an unsuspended ks reconciles the
+  # objects without firing a run until the CronJob is explicitly enabled.
+  suspend: true
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: ./kubernetes/apps/ai/local-cron/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/observability/loki/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/loki/app/cnp-allow.yaml
@@ -12,10 +12,23 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
-  # No ingress rules needed: Loki is internal-only. Vector aggregator
-  # pushes to loki:3100 and Grafana queries loki:3100 — both intra-ns,
-  # covered by baseline allow-intra-namespace. No HTTPRoute exposes
-  # Loki publicly.
+  # Intra-ns callers (Vector aggregator push, Grafana query) are covered
+  # by baseline allow-intra-namespace and need no rule. No HTTPRoute
+  # exposes Loki publicly. The only cross-ns caller is below.
+  ingress:
+    # local-cron (ai ns) → loki:3100 — the daily error-pattern skim reads
+    # log state read-only via the Loki HTTP query API, then summarizes it
+    # on the local Ollama (never Claude). Egress side is punched through in
+    # ai/local-cron/app/cnp-allow.yaml. A wrong label here silent-drops
+    # (see reference_cnp_blackbox_exporter_label_trap).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: local-cron
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP
   egress:
     # Chunk + index storage on Rook Ceph RGW (S3 API). Loki's S3
     # endpoint resolves to the `rook-ceph-rgw-ceph-objectstore` Service


### PR DESCRIPTION
## What

Phase 2 of the two-tier cron routing (`ai/claude-runner` is the Claude tier). A **local-model cron tier** that runs summarize / log-triage work on the in-cluster Ollama (P40, `qwen2.5:7b`) instead of Claude, per HOMELAB-SPEC Layer 6 — **zero Anthropic tokens**, no `ANTHROPIC_API_KEY` / OAuth token anywhere.

### First workflow: `loki-error-skim`
A daily CronJob (pure `curl` on `alpine/k8s`, no custom image):

1. LogQL-ranks the top error/panic/fatal/traceback/exception log producers in Loki over 24h (`topk(15, sum by (namespace, app) (count_over_time(... [24h])))`).
2. Samples up to 8 lines each from the top 5 apps.
3. Distills them into a terse pattern digest via Ollama `/api/generate`.
4. Posts **one** Pushover message (private sink — reuses the alertmanager 1P `Pushover` item, so it may carry ns/app names a public artifact must not).

Silent (exit 0, no push) when Loki has no error lines in the window.

## Hardening
Mirrors `claude-runner` verbatim: non-root 1000, `readOnlyRootFilesystem`, drop `ALL`, `RuntimeDefault`, tmpfs `/tmp`, `automountServiceAccountToken: false`, zero-RBAC SA, `k8tz.io/inject: "false"`, `activeDeadlineSeconds`, `backoffLimit: 1`, `concurrencyPolicy: Forbid`. The SA has **no k8s-API access** — the job only speaks to the Loki, Ollama, and Pushover HTTP APIs.

## Network policy
`ai` is default-deny; `observability` is default-deny ingress. Two holes punched:
- **`ai/local-cron/app/cnp-allow.yaml`** (egress): `loki.observability:3100` + `world:443` (Pushover). Ollama is intra-ns → baseline `allow-intra-namespace` covers it, no rule needed.
- **`observability/loki/app/cnp-allow.yaml`** (ingress): added `ai/local-cron` as a cross-ns source on `loki:3100`. Loki previously admitted only intra-ns callers (Grafana/Vector via baseline), so this had to be listed explicitly or it would silent-drop.

## Shipped SUSPENDED
Both `ks.yaml` and the CronJob carry `suspend: true`. Activation is a two-step unsuspend documented in `kubernetes/apps/ai/local-cron/README.md` (unsuspend ks → out-of-band `create job --from=cronjob` test → unsuspend CronJob). **No auto-activation on the prod cluster.**

## Validation
- `kubectl kustomize kubernetes/apps/ai/local-cron/app` builds clean (4 resources).
- yamllint passes; all pre-commit hooks pass (incl. the custom envsubst-escape, CNP-has-rules, and no-literal-credentials hooks).
- Embedded shell script passes `sh -n` after simulating Flux `$$`→`$` envsubst.
- Root README badges bumped via `tools/lint-readme-drift.py` (apps → 162, secrets → 94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)