### PR TITLE
feat(ai): share the Obsidian vault into the cluster via livesync-cli sidecar (Phase 3)

### DIFF
--- a/kubernetes/apps/ai/claude-runner/README.md
+++ b/kubernetes/apps/ai/claude-runner/README.md
@@ -68,6 +68,76 @@ transcripts + scratch clones survive pod restarts. Needs the tmux-bearing image
 repo). Egress is the same CNP as the cron workflows (read-only Prometheus +
 world:443); attach is via `kubectl exec`, no route.
 
+## Vault bridge — the Obsidian vault as files in the pod (Phase 3)
+
+`deployment-shell.yaml` runs a **`vault-bridge` sidecar** next to the `shell`
+container so the in-cluster Claude sees the same `~/vaults/claude` files as the
+laptop. It mounts into the shell at **`/home/node/vaults/claude`**.
+
+**How it works.** The laptop's Obsidian syncs the vault into CouchDB
+(`obsidian.${SECRET_DOMAIN}`) via the Self-hosted LiveSync plugin. The sidecar
+runs the plugin author's **official** headless CLI — `ghcr.io/vrtmrz/livesync-cli`,
+same repo and core as the plugin — in its `daemon` mode: an initial mirror scan
+then continuous bidirectional replication between CouchDB and the local
+filesystem (CouchDB → files via the `_changes` feed; files → CouchDB via a file
+watcher). It talks to CouchDB over the **in-cluster** Service
+`obsidian-couchdb.collab.svc.cluster.local:5984` (not the public route).
+
+**Topology: sidecar, not standalone.** The bridge and the shell share one RWO
+`ceph-block` PVC (`claude-vault-data`) inside a single pod — `/db` (the CLI's
+PouchDB database) and `/vault` (the materialised `.md` files) are subPaths of
+it. A standalone bridge Deployment would need the vault PVC to be RWX, and this
+cluster's only RWX pattern is direct-NFS (not ceph/Longhorn), so the sidecar is
+the deliberate choice. The vault is regenerable from CouchDB, so `ceph-block`
+(rule 2) is correct; CouchDB stays the source of truth.
+
+**⚠ CouchDB is canonical; the pod is a SECONDARY writer.** LiveSync is
+eventually-consistent. If pod-Claude and the laptop edit the *same note* at the
+same time, LiveSync records **conflict revisions** rather than losing data —
+resolve them from Obsidian on the laptop (the conflict-resolution UI). Treat the
+in-cluster copy as a working mirror, not the primary.
+
+### Activation (ships inactive)
+
+The manifests are wired but the bridge cannot fully connect until two values
+are added to the 1Password **`obsidian`** item — they live in the laptop's
+LiveSync plugin config, not in this repo:
+
+1. **DB name.** From Obsidian → *Self-hosted LiveSync* → *Remote Database* →
+   **Database name**. Add it as a field on the `obsidian` 1P item:
+   `op item edit obsidian --vault Kubernetes couchdb_dbname=<name>`
+2. **E2EE passphrase** (only if the vault uses End-to-End Encryption). From
+   Obsidian → *Self-hosted LiveSync* → **End to End Encryption** passphrase:
+   `op item edit obsidian --vault Kubernetes couchdb_passphrase=<passphrase>`
+   - If the vault is **not** encrypted, set `encrypt: false` in
+     `externalsecret-vault-bridge.yaml`'s templated `settings.json` and skip
+     this field.
+
+Until these are set, the `claude-vault-bridge` ExternalSecret still renders (it
+resolves the already-present `couchdb_username`/`couchdb_password`), so the pod
+schedules and the **shell keeps working** — only the `vault-bridge` container
+crash-loops (empty DB name / passphrase) until the fields are populated. After
+adding them, `kubectl -n ai rollout restart deploy/claude-runner-shell` (or let
+the ES refresh) and confirm:
+
+```sh
+kubectl -n ai logs deploy/claude-runner-shell -c vault-bridge
+kubectl -n ai exec deploy/claude-runner-shell -c shell -- ls /home/node/vaults/claude
+```
+
+> **Merge disruption:** the shell Deployment is `strategy: Recreate`, so merging
+> this Phase-3 change replaces the pod once — the running tmux session is lost
+> (start it fresh after the roll). Land it in a routine window.
+
+### Network
+
+- `cnp-allow.yaml` (ai ns) adds an egress hole to `obsidian-couchdb:5984` in
+  `collab`. Both containers share the pod's Cilium identity
+  (`app.kubernetes.io/name: claude-runner`), so the hole covers the sidecar.
+- `obsidian-couchdb/app/cnp-allow.yaml` (collab ns) adds the matching ingress
+  rule from `ai`/`claude-runner`. Both namespaces are default-deny; DNS is
+  already granted by the baseline component.
+
 ## Add a Claude-tier workflow
 
 Copy `cronjob-flux-longhorn-drift-digest.yaml`, then:

--- a/kubernetes/apps/ai/claude-runner/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cnp-allow.yaml
@@ -43,3 +43,19 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # CouchDB (collab ns) — the vault-bridge sidecar in claude-runner-shell
+    # replicates the Obsidian vault from obsidian-couchdb:5984. Both the
+    # sidecar and the shell share this pod's Cilium identity
+    # (app.kubernetes.io/name: claude-runner), so this hole is scoped to the
+    # single CouchDB endpoint. Selector matches the couchdb pod's real label
+    # (the existing obsidian-couchdb-allow CNP uses the same one); a wrong
+    # label here silent-drops (reference_cnp_blackbox_exporter_label_trap).
+    # DNS for the Service name is already granted by the baseline allow-dns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: obsidian-couchdb
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP

--- a/kubernetes/apps/ai/claude-runner/app/deployment-shell.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/deployment-shell.yaml
@@ -81,6 +81,73 @@ spec:
               mountPath: /home/node
             - name: tmp
               mountPath: /tmp
+            # The materialised vault, shared with the vault-bridge sidecar
+            # (subPath `vault` of the same RWO PVC — single pod, no RWX).
+            # CouchDB (obsidian.${SECRET_DOMAIN}) stays the source of truth;
+            # this is a SECONDARY writer. If pod-Claude and the laptop edit
+            # the same note at once, LiveSync records conflict revisions —
+            # resolve them from Obsidian on the laptop. See ./README.md.
+            - name: vault
+              mountPath: /home/node/vaults/claude
+              subPath: vault
+        # ---------------------------------------------------------------
+        # vault-bridge — official Self-hosted LiveSync CLI (same author &
+        # core as the Obsidian plugin) running its `daemon`: continuously
+        # replicates the CouchDB remote <-> the local filesystem via the
+        # _changes feed. This is what materialises the vault as FILES the
+        # in-cluster Claude can read/write. Sidecar (not standalone) so the
+        # vault volume stays RWO inside one pod.
+        - name: vault-bridge
+          image: ghcr.io/vrtmrz/livesync-cli:1.0.16-cli
+          imagePullPolicy: IfNotPresent
+          # Entrypoint prepends the DB path (LIVESYNC_DB_PATH) as argv[1],
+          # so these args become:
+          #   /db --settings /config/settings.json --vault /vault daemon
+          # daemon = mirror-scan then continuous bidirectional sync.
+          args:
+            - --settings
+            - /config/settings.json
+            - --vault
+            - /vault
+            - daemon
+          env:
+            - name: LIVESYNC_DB_PATH
+              value: /db
+            - name: TZ
+              value: America/New_York
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            # PouchDB local database (leveldown writes here).
+            - name: vault
+              mountPath: /db
+              subPath: db
+            # The materialised vault .md files.
+            - name: vault
+              mountPath: /vault
+              subPath: vault
+            # settings.json (couchDB_URI/user/password/dbname/passphrase),
+            # rendered by the claude-vault-bridge ExternalSecret from 1P.
+            - name: bridge-config
+              mountPath: /config
+              readOnly: true
+            - name: bridge-tmp
+              mountPath: /tmp
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -89,3 +156,13 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 512Mi
+        - name: vault
+          persistentVolumeClaim:
+            claimName: claude-vault-data
+        - name: bridge-config
+          secret:
+            secretName: claude-vault-bridge-secret
+        - name: bridge-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 128Mi

--- a/kubernetes/apps/ai/claude-runner/app/externalsecret-vault-bridge.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/externalsecret-vault-bridge.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-vault-bridge
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: claude-vault-bridge-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Full livesync-cli settings.json, rendered from the 1P `obsidian`
+        # item. Mounted read-only into the bridge sidecar at
+        # /config/settings.json (daemon mode only reads it; --write-settings
+        # is never passed, so read-only is fine).
+        #
+        # Fields sourced from 1P `obsidian`:
+        #   couchdb_username / couchdb_password  — ALREADY present (used by
+        #                                          the CouchDB StatefulSet).
+        #   couchdb_dbname                       — ADD at activation. The DB
+        #                                          name the laptop's LiveSync
+        #                                          plugin replicates into
+        #                                          (Settings > Remote Database
+        #                                          > "Database name").
+        #   couchdb_passphrase                   — ADD at activation IF the
+        #                                          vault is E2E-encrypted
+        #                                          (Settings > "End to End
+        #                                          Encryption" passphrase). If
+        #                                          the vault is NOT encrypted,
+        #                                          set encrypt=false below and
+        #                                          leave this empty.
+        #
+        # In-cluster CouchDB Service DNS (NOT the public obsidian.<domain>
+        # route, which egresses the cluster). Service name is the
+        # app-template controller name obsidian-couchdb in ns collab.
+        settings.json: |-
+          {
+            "couchDB_URI": "http://obsidian-couchdb.collab.svc.cluster.local:5984",
+            "couchDB_USER": "{{ .couchdb_username }}",
+            "couchDB_PASSWORD": "{{ .couchdb_password }}",
+            "couchDB_DBNAME": "{{ .couchdb_dbname }}",
+            "encrypt": true,
+            "passphrase": "{{ .couchdb_passphrase }}",
+            "liveSync": true,
+            "syncOnSave": true,
+            "syncOnStart": true,
+            "usePluginSync": false,
+            "isConfigured": true
+          }
+  dataFrom:
+    - extract:
+        key: obsidian

--- a/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ./cronjob-flux-longhorn-drift-digest.yaml
   - ./deployment-shell.yaml
   - ./externalsecret.yaml
+  - ./externalsecret-vault-bridge.yaml
   - ./job-auth-spike.yaml
   - ./pvc-shell.yaml
+  - ./pvc-vault.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/ai/claude-runner/app/pvc-vault.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/pvc-vault.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: claude-vault-data
+spec:
+  # Holds two regenerable things, both reconstructable from the CouchDB
+  # source of truth (obsidian.${SECRET_DOMAIN}):
+  #   /db     — the livesync-cli PouchDB local database (leveldown)
+  #   /vault  — the materialised vault .md files (also mounted into the
+  #             shell container at /home/node/vaults/claude)
+  # Per storage-class.instructions.md rule 2 (regenerable → ceph-block):
+  # CouchDB stays canonical; this cache re-syncs on loss. RWO is fine —
+  # the bridge sidecar and the shell share it inside ONE pod, so no RWX
+  # is needed (this cluster's RWX pattern is direct-NFS, not ceph/Longhorn).
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
@@ -26,5 +26,18 @@ spec:
         - ports:
             - port: "5984"
               protocol: TCP
+    # The vault-bridge sidecar in claude-runner-shell (ai ns) replicates the
+    # vault out of CouchDB via the in-cluster Service (obsidian-couchdb.collab
+    # :5984), so the pod-Claude sees the same files as the laptop. Scoped to
+    # that one workload's Cilium identity. Egress side is claude-runner's
+    # cnp-allow.yaml. See kubernetes/apps/ai/claude-runner/app/README.md.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: claude-runner
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP
   # No egress holes needed — CouchDB is self-contained for this
   # single-node setup. No remote replication peers configured.


### PR DESCRIPTION
## What

Phase 3: share the Obsidian vault into the cluster so the in-cluster interactive Claude session (`claude-runner-shell`) sees the same `~/vaults/claude` files as the laptop. Adds a **`vault-bridge` sidecar** to the shell Deployment that materialises the vault as files at `/home/node/vaults/claude`.

## Mechanism

The laptop's Obsidian syncs the vault into the in-cluster CouchDB (`obsidian.${SECRET_DOMAIN}`) via the Self-hosted LiveSync plugin. The sidecar runs the plugin author's **official** headless CLI — [`ghcr.io/vrtmrz/livesync-cli`](https://github.com/vrtmrz/obsidian-livesync/tree/main/src/apps/cli) (`1.0.16-cli`), same repo and core as the plugin, actively released — in its `daemon` mode: an initial mirror scan then continuous bidirectional replication between CouchDB and the local filesystem (CouchDB → files via the `_changes` feed; files → CouchDB via a file watcher). It talks to CouchDB over the **in-cluster** Service `obsidian-couchdb.collab.svc.cluster.local:5984`.

### Why this image (not livesync-bridge)

The task pointed at `vrtmrz/livesync-bridge`, but that repo publishes **no official image** — only one-person community Docker Hub images. `livesync-cli` is published by the plugin author under `vrtmrz`, built from the main `obsidian-livesync` repo, and does exactly the headless CouchDB↔filesystem daemon we need. Per HOMELAB-SPEC "broad community / upstream-first," the official CLI is the correct choice.

## Topology: sidecar, not standalone

The bridge and the shell share one **RWO `ceph-block`** PVC (`claude-vault-data`) inside a single pod — `/db` (the CLI's PouchDB database) and `/vault` (the `.md` files) are subPaths. A standalone bridge would need the vault PVC to be RWX, and this cluster's only RWX pattern is direct-NFS (not ceph/Longhorn), so the sidecar is deliberate. The vault is regenerable from CouchDB → `ceph-block` (storage rule 2). **CouchDB stays canonical; the pod is a secondary writer** — concurrent edits produce LiveSync conflict revisions, resolved from the laptop.

## Changes

- **new** `claude-vault-data` ceph-block PVC (`/db` PouchDB + `/vault` files)
- **new** `claude-vault-bridge` ExternalSecret — templates `settings.json` from the 1P `obsidian` item
- `deployment-shell.yaml` — `vault-bridge` sidecar (full hardening block: non-root 1000, `readOnlyRootFilesystem`, drop ALL, RuntimeDefault, tmpfs) + vault mount on the shell container
- `claude-runner` CNP — egress hole to `obsidian-couchdb:5984` (collab)
- `obsidian-couchdb` CNP — matching ingress from `ai`/`claude-runner`
- READMEs — activation, topology, concurrent-writer caveat, Recreate note; root secrets badge 92→93

## Ships inactive

Two values live only in the laptop plugin config and must be added to the 1P `obsidian` item at activation:
1. `couchdb_dbname` — the LiveSync remote **Database name**
2. `couchdb_passphrase` — the E2EE passphrase (only if the vault is encrypted)

Until then the ExternalSecret still renders (couchdb creds already present), so the pod schedules and **the shell keeps working** — only the `vault-bridge` container crash-loops until the fields are populated. Full activation steps in `kubernetes/apps/ai/claude-runner/README.md`.

> **Merge disruption:** the shell Deployment is `strategy: Recreate`, so merging replaces the pod once (the running tmux session is lost). Land it in a routine window.

## Validation

- `kubectl kustomize` clean for both app dirs and both ns roots
- yamllint clean (one pre-existing spec-level comment warning, unchanged)
- all pre-commit hooks pass (secrets scan, readme-drift, CNP-has-rules, credential scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)