### PR TITLE
docs(upgrade): reusable rolling-upgrade automation + optimizations

### DIFF
--- a/docs/src/cluster_upgrade.md
+++ b/docs/src/cluster_upgrade.md
@@ -92,6 +92,57 @@ auto-on — audit `seLinuxChangePolicy` first), pod-level in-place resize
 (GA), CSI volume group snapshots (GA). Verify each against the *deployed*
 chart/arch before implementing.
 
+### Optimizations & lessons from the 1.36 run — reuse these next time
+
+The 1.36 run was hand-driven and iterated on live; the distilled, reusable
+automation now lives in **[`tools/cluster-upgrade/`](https://github.com/rwlove/home-ops/tree/main/tools/cluster-upgrade)**
+(`predownload.sh`, `rolling-upgrade.sh`, and a README). Start there next time.
+The per-node critical path dropped from ~40 min to ~7–10 min once these were in.
+
+**Speed optimizations (each safe; #2 needs an explicit "reduced-redundancy-OK"):**
+
+1. **Pre-download packages in parallel first.** `dnf/apt --downloadonly
+   --setopt=keepcache=1` across every node warms the cache so the real
+   `dnf upgrade` installs from disk. Removes ~10 min of download per node.
+2. **Clear Longhorn nodes by DELETE, not eviction.** `evictionRequested`
+   rebuilds every replica off the node *before* removing it (~12–25 min/node).
+   Instead, **delete** each replica that has a healthy copy on another node
+   (instant) and only evict a replica that is its volume's *last* healthy copy.
+   Longhorn re-replenishes the deleted replicas in the background afterward.
+   Trades temporary redundancy for speed — get operator sign-off. worker4
+   cleared in ~43 s this way vs. ~12–25 min by eviction.
+3. **Faulted-only health gate.** Don't gate drains on full Longhorn health
+   (that waits for rebuild-back churn). Block only if a volume is *faulted*
+   (0 replicas). Degraded / reduced-redundancy proceeds.
+4. **Idempotent orchestrator.** Skip nodes already at the target version →
+   the run is safe to stop and relaunch (which happened repeatedly). The skip
+   path also re-uncordons, so a node left cordoned by an abort self-heals.
+
+**Failure modes hit in 1.36 (added to the table below):**
+
+- **Longhorn dual instance-managers block the drain.** The 1.12.0→1.12.1 chart
+  bump upgraded Longhorn's control plane but **not the data plane** — the engine
+  image page showed the old engine holding *all* replica references, so every
+  node ran an old + new IM, each with a `disruptionsAllowed:0` PDB that blocks
+  `kubectl drain`. Workaround: after clearing replicas, **delete the node's now-
+  empty IM pods** (`kubectl delete` bypasses the PDB). Real fix: a Longhorn
+  **engine live-upgrade of all volumes**, done as separate maintenance *after*
+  the k8s upgrade — never stacked on it.
+- **Cordoned node + deleted OSD deadlock.** A drain's OSD-delete fallback plus an
+  aborted run leaves the node cordoned with its OSD `Pending` → ceph stuck at
+  N-1/N → the next `ceph_gate` hangs. **Uncordon** the node so the OSD
+  reschedules.
+- **Stalled replica rebuild.** A replica rebuilding from a source that was on an
+  evicted node freezes (progress static, 0 MB/s). **Delete the stuck replica**
+  so it re-rebuilds from a healthy source. (Clearing by delete avoids this.)
+- **CoreDNS preflight (see 1.36 deltas above):** `--ignore-preflight-errors=
+  CoreDNSUnsupportedPlugins,CoreDNSMigration --skip-phases=addon`.
+
+**Phase-5 restore list (settings toggled live for the run):**
+`node-drain-policy` → `block-if-contains-last-replica`;
+`replica-replenishment-wait-interval` → `600`; resume descheduler; etcd defrag;
+then the deferred Longhorn engine upgrade + old-IM GC.
+
 ## State at the start of the upgrade
 
 | Aspect | Reality |

--- a/tools/cluster-upgrade/README.md
+++ b/tools/cluster-upgrade/README.md
@@ -1,0 +1,77 @@
+# Cluster upgrade automation
+
+Reusable helpers for an in-place, one-node-at-a-time kubeadm **minor** upgrade,
+distilled from the 2026-08-22 `v1.35.4 → v1.36.4` run. The canonical runbook —
+phases, preflight, failure modes, and the **Optimizations & lessons** writeup —
+lives in [`docs/src/cluster_upgrade.md`](../../docs/src/cluster_upgrade.md). Read
+it before running anything here.
+
+| Script | What it does |
+| ------ | ------------ |
+| `predownload.sh` | Warms every node's package cache (`dnf/apt --downloadonly`) in parallel. Zero cluster impact. Run to completion **first**. |
+| `rolling-upgrade.sh` | Drives the fleet node-by-node with hard safety gates. Idempotent (skips nodes already at target) → safe to stop/relaunch. |
+
+## Usage (sketch — read the runbook + edit for your topology)
+
+```sh
+export SECRET_DOMAIN=your.cluster.domain
+export KVER=1.36.4
+
+# 0. Preflight (manual, see runbook): etcd snapshot, stage repos, suspend
+#    descheduler, kubeadm upgrade plan.
+# 1. Set Longhorn for fast/robust drains (restore in Phase 5):
+kubectl -n longhorn-system patch settings.longhorn.io node-drain-policy \
+  --type=merge -p '{"value":"allow-if-replica-is-stopped"}'
+kubectl -n longhorn-system patch settings.longhorn.io replica-replenishment-wait-interval \
+  --type=merge -p '{"value":"30"}'
+# 2. First control plane only — the manifest/etcd bump:
+ssh root@master1.$SECRET_DOMAIN "kubeadm upgrade apply v$KVER --yes \
+  --ignore-preflight-errors=CoreDNSUnsupportedPlugins,CoreDNSMigration --skip-phases=addon"
+# 3. Warm caches, then roll the rest:
+bash predownload.sh
+bash rolling-upgrade.sh          # runs in the foreground; long — background it if you like
+```
+
+## Safety model
+
+- **Gates between every node:** etcd quorum 3/3, ceph OSDs all-up + no PG/OSD
+  warns (pre-existing `AUTH_INSECURE_*` tolerated), Longhorn no-faulted-volume
+  floor. Any anomaly `die()`s the whole run rather than cascading.
+- **Never two control planes at once;** the heaviest CP goes last.
+- **`--skip-phases=addon`** on `upgrade apply` so kubeadm leaves the
+  Flux-managed CoreDNS / Cilium-replaced kube-proxy untouched.
+
+## The speed optimizations (why this run got ~4× faster after tuning)
+
+1. **Parallel pre-download** — removes ~10 min of package download per node.
+2. **Fast Longhorn clear by DELETE, not evict** — `longhorn_clear_node` deletes
+   a node's replicas that have a healthy copy elsewhere (instant) instead of
+   `evictionRequested` rebuild-first (~12–25 min/node). Longhorn re-replenishes
+   afterward. **Requires operator sign-off for temporary reduced redundancy.**
+3. **Faulted-only health gate** — replica *count* never blocks the upgrade; only
+   a genuinely unavailable (0-replica) volume does.
+
+## Known gotchas encoded here
+
+- **Longhorn dual instance-managers** (data plane still on the old engine — see
+  the engine-image page: old engine may hold all the replica references) leave a
+  `PodDisruptionBudget` at `disruptionsAllowed:0` that blocks `kubectl drain`.
+  `drain_node` deletes the node's *empty* IM pods first (`kubectl delete`
+  bypasses the PDB; safe once running-replicas are 0). The real fix is a separate
+  Longhorn **engine live-upgrade** of all volumes — do it after the k8s upgrade.
+- **Cordoned node + deleted OSD** (from a drain fallback in an aborted run) →
+  OSD can't reschedule → ceph stuck N-1/N. **Uncordon** to release it.
+- **Stalled replica rebuild** (progress frozen, 0 MB/s) when the rebuild source
+  was on an evicted node → **delete the stuck replica** to re-rebuild from a
+  healthy one.
+- **GPU/containerd appliance (DGX):** driver is firmware-coupled — do **not**
+  let a blanket `apt upgrade` move it. Hold the driver + kernel packages;
+  upgrade k8s only; handle driver currency via the vendor tool separately.
+
+## Phase 5 — restore after the upgrade
+
+- `node-drain-policy` → back to `block-if-contains-last-replica`
+- `replica-replenishment-wait-interval` → back to `600`
+- Resume descheduler; `tools/etcd-defrag.sh`; verify `flux get all -A`.
+- Longhorn **engine upgrade** (old→new) as its own maintenance; then GC the old
+  instance-managers.

--- a/tools/cluster-upgrade/predownload.sh
+++ b/tools/cluster-upgrade/predownload.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Parallel package pre-download for a rolling k8s upgrade.
+# ============================================================================
+# Warms every node's package cache BEFORE the upgrade so each node's real
+# `dnf upgrade` / `apt upgrade` installs from disk (~10 min/node of download
+# removed from the critical path). Pure cache-warming — installs nothing,
+# reboots nothing, zero cluster impact. Run it, let it finish, THEN run
+# rolling-upgrade.sh.
+#
+#   export SECRET_DOMAIN=your.cluster.domain
+#   export KVER=1.36.4
+#   bash predownload.sh
+#
+# Edit CENTOS / the containerd node list for your topology. Skip any node that
+# is currently mid-upgrade (a second dnf/apt would clash on the lock).
+# ============================================================================
+set -uo pipefail
+: "${SECRET_DOMAIN:?export SECRET_DOMAIN=your.cluster.domain}"
+D="$SECRET_DOMAIN"
+KVER="${KVER:-1.36.4}"
+CENTOS="${CENTOS:-worker2 worker3 worker4 worker5 worker6 worker7 worker8 master1 master2 master3}"
+CONTAINERD="${CONTAINERD:-spark}"   # apt/containerd nodes (GPU appliance etc.); empty to skip
+
+for n in $CENTOS; do
+  # worker8 example: hold the GPU driver out of the cached upgrade set
+  excl=""; [ "$n" = worker8 ] && excl="--exclude=nvidia*,cuda*,libnvidia*,kmod-nvidia*"
+  (
+    ssh -o ConnectTimeout=10 -o BatchMode=yes root@$n.$D "set -f
+      dnf install -y --downloadonly --setopt=keepcache=1 kubeadm-$KVER kubelet-$KVER kubectl-$KVER >/tmp/predl-k8s.log 2>&1
+      dnf upgrade -y --downloadonly --setopt=keepcache=1 $excl >/tmp/predl-full.log 2>&1
+      echo cached
+    " 2>&1 | tail -1 | sed "s/^/$n: /"
+  ) &
+done
+for n in $CONTAINERD; do
+  (
+    ssh -o ConnectTimeout=10 -o BatchMode=yes root@$n.$D "
+      f=\$(grep -rl pkgs.k8s.io /etc/apt/sources.list.d/ 2>/dev/null | head -1)
+      [ -n \"\$f\" ] && sed -i 's#v1\.[0-9][0-9]#v${KVER%.*}#g' \"\$f\"   # point deb repo at target minor
+      apt-get update -qq >/dev/null 2>&1
+      apt-get -y --download-only upgrade >/tmp/predl-full.log 2>&1
+      echo cached
+    " 2>&1 | tail -1 | sed "s/^/$n: /"
+  ) &
+done
+wait
+echo "===== ALL PRE-DOWNLOADS COMPLETE ====="

--- a/tools/cluster-upgrade/rolling-upgrade.sh
+++ b/tools/cluster-upgrade/rolling-upgrade.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Rolling kubeadm k8s minor-version upgrade — reusable orchestrator
+# ============================================================================
+# Distilled from the 2026-08-22 v1.35.4 -> v1.36.4 run. Drives the whole fleet
+# one node at a time with hard safety gates; idempotent (skips nodes already at
+# target) so it is safe to stop and relaunch. Any gate anomaly calls die().
+#
+# WHAT MAKES THIS FAST (see docs/src/cluster_upgrade.md "Optimizations"):
+#   1. Packages are pre-downloaded on every node first (predownload.sh) so the
+#      per-node `dnf upgrade` installs from cache (~10 min/node saved).
+#   2. longhorn_clear_node DELETES replicas that have a healthy copy elsewhere
+#      (instant) instead of evicting/rebuilding them (~12-25 min/node saved).
+#      Longhorn re-replenishes the deleted replicas in the background after.
+#   3. Health gate is a SAFETY FLOOR only: blocks iff a volume is FAULTED
+#      (0 replicas). Degraded/reduced-redundancy is allowed during the window.
+#
+# PREREQUISITES (operator, before running — see README.md):
+#   - export SECRET_DOMAIN=<your cluster domain>   (required)
+#   - export KVER=<target patch, e.g. 1.36.4>      (default 1.36.4)
+#   - Off-cluster etcd snapshot taken.
+#   - k8s + cri-o <minor> repos staged on all CentOS nodes; deb repo reachable
+#     on containerd nodes. Packages pre-downloaded (predownload.sh).
+#   - `kubeadm upgrade apply v$KVER --yes --ignore-preflight-errors=CoreDNSUnsupportedPlugins,CoreDNSMigration --skip-phases=addon`
+#     ALREADY RUN on the first control plane (this script does `upgrade node` only).
+#   - descheduler suspended (avoids rebalance churn fighting drains).
+#   - Longhorn (LIVE, restore after — Phase 5):
+#       node-drain-policy = allow-if-replica-is-stopped
+#       replica-replenishment-wait-interval = 30
+#   - Passwordless root SSH to every node; run from a host that can reach them.
+#   - EDIT the node list + order at the bottom for your topology.
+#
+# GOTCHAS THIS ENCODES (learned the hard way — see runbook "Failure modes"):
+#   - Longhorn dual instance-managers (data plane not engine-upgraded) leave a
+#     PDB@disruptionsAllowed=0 that blocks `kubectl drain`. drain_node deletes
+#     the node's empty IM pods first (kubectl delete bypasses the PDB).
+#   - A drain's OSD-delete fallback + an aborted run leaves the node cordoned
+#     with its OSD Pending -> ceph stuck N-1/N. Uncordon to let it reschedule.
+#   - A replica rebuilding from a source on an evicted node stalls (progress
+#     frozen, 0 MBps). Delete the stuck replica so it re-rebuilds from a healthy
+#     one. longhorn_clear_node avoids this by deleting, not rebuilding.
+# ============================================================================
+set -uo pipefail
+: "${SECRET_DOMAIN:?export SECRET_DOMAIN=your.cluster.domain}"
+D="$SECRET_DOMAIN"
+KVER="${KVER:-1.36.4}"
+VER="v$KVER"
+KHOST="${KHOST:-master1}"   # healthy master used as kubectl proxy (never the target)
+ETCDHOST="${ETCDHOST:-master1}"
+
+kc(){ local a q=""; for a in "$@"; do q+=" $(printf '%q' "$a")"; done; ssh -o ConnectTimeout=8 -o BatchMode=yes root@$KHOST.$D "kubectl$q"; }
+nssh(){ local h=$1; shift; ssh -o ConnectTimeout=8 -o BatchMode=yes root@$h.$D "$@"; }
+die(){ echo "!!!!! ABORT: $* !!!!!"; exit 1; }
+ts(){ date '+%H:%M:%S'; }
+
+verify_quorum(){ # require 3/3 etcd members healthy (adjust count for your CP size)
+  local out h
+  out=$(nssh $ETCDHOST "kubectl -n kube-system exec etcd-$ETCDHOST.$D -- etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/server.crt --key=/etc/kubernetes/pki/etcd/server.key endpoint health --cluster" 2>&1)
+  h=$(echo "$out" | grep -c "is healthy")
+  echo "  [$(ts)] etcd quorum: $h/3 healthy"
+  [ "$h" -eq 3 ] || die "etcd quorum $h/3 (need 3): $out"
+}
+
+ceph_gate(){ # wait: all OSD pods Running, no PG/OSD health warns (pre-existing AUTH_INSECURE tolerated)
+  local i h det bad tot run
+  for i in $(seq 1 180); do
+    h=$(kc -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.ceph.health}' 2>/dev/null)
+    [ "$h" = "HEALTH_ERR" ] && die "ceph HEALTH_ERR"
+    det=$(kc -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.ceph.details}' 2>/dev/null)
+    bad=$(echo "$det" | grep -oE '[A-Z_0-9]+:map\[' | sed 's/:map\[//' | grep -v '^AUTH_INSECURE' | tr '\n' ',')
+    tot=$(kc -n rook-ceph get pod -l app=rook-ceph-osd --no-headers 2>/dev/null | grep -c .)
+    run=$(kc -n rook-ceph get pod -l app=rook-ceph-osd --no-headers 2>/dev/null | awk '$3=="Running"{c++} END{print c+0}')
+    if [ -n "$tot" ] && [ "$tot" != "0" ] && [ "$run" = "$tot" ] && [ -z "$bad" ]; then
+      echo "  [$(ts)] ceph gate OK (osd $run/$tot, health=$h)"; return 0
+    fi
+    [ $((i%6)) -eq 0 ] && echo "  [$(ts)] ceph not clean: osd=$run/$tot health=$h bad=[$bad]"
+    sleep 10
+  done
+  die "ceph gate timeout"
+}
+
+longhorn_restore(){ kc -n longhorn-system patch nodes.longhorn.io $1.$D --type=merge \
+  -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}' >/dev/null 2>&1; echo "  [$(ts)] longhorn restored on $1"; }
+
+longhorn_clear_node(){ # FAST clear: DELETE each running replica that has a healthy copy on another node
+  # (instant, no rebuild wait). Only a replica that is its volume's LAST healthy copy is evicted
+  # (rebuild-first). REQUIRES operator OK for temporary reduced redundancy (Longhorn re-replenishes after).
+  local n=$1.$D r rname vol he i c
+  for r in $(kc get replicas.longhorn.io -n longhorn-system -o jsonpath="{range .items[?(@.spec.nodeID=='$n')]}{.metadata.name}|{.spec.volumeName}|{.status.currentState}{'\n'}{end}" 2>/dev/null | awk -F'|' '$3=="running"{print $1"|"$2}'); do
+    rname="${r%%|*}"; vol="${r##*|}"
+    he=$(kc get replicas.longhorn.io -n longhorn-system -o jsonpath="{range .items[?(@.spec.volumeName=='$vol')]}{.spec.nodeID}|{.status.currentState}|{.spec.healthyAt}{'\n'}{end}" 2>/dev/null | awk -F'|' -v n="$n" '$1!=n && $2=="running" && $3!=""{c++} END{print c+0}')
+    if [ "$he" -ge 1 ]; then
+      kc delete replicas.longhorn.io -n longhorn-system "$rname" >/dev/null 2>&1
+    else
+      echo "  [$(ts)] $vol: last healthy copy is on $1 -> evict/rebuild (not delete)"
+    fi
+  done
+  c=$(kc get replicas.longhorn.io -n longhorn-system -o jsonpath="{range .items[?(@.spec.nodeID=='$n')]}{.status.currentState}{'\n'}{end}" 2>/dev/null | grep -c '^running$')
+  kc -n longhorn-system patch nodes.longhorn.io "$n" --type=merge -p "{\"spec\":{\"allowScheduling\":false$([ "$c" -gt 0 ] && echo ',"evictionRequested":true')}}" >/dev/null 2>&1
+  if [ "$c" -gt 0 ]; then
+    echo "  [$(ts)] $1: $c last-copy replica(s) evicting (rebuild-first)"
+    for i in $(seq 1 180); do
+      c=$(kc get replicas.longhorn.io -n longhorn-system -o jsonpath="{range .items[?(@.spec.nodeID=='$n')]}{.status.currentState}{'\n'}{end}" 2>/dev/null | grep -c '^running$')
+      [ "$c" = "0" ] && break; [ $((i%6)) -eq 0 ] && echo "  [$(ts)] $1: $c last-copy replica(s) left"; sleep 10
+    done
+  fi
+  c=$(kc get replicas.longhorn.io -n longhorn-system -o jsonpath="{range .items[?(@.spec.nodeID=='$n')]}{.status.currentState}{'\n'}{end}" 2>/dev/null | grep -c '^running$')
+  [ "$c" = "0" ] || die "$1 still has $c running replicas after clear"
+  echo "  [$(ts)] longhorn cleared on $1 (0 running replicas)"
+}
+
+longhorn_wait_healthy(){ # SAFETY FLOOR: block iff an ATTACHED volume is FAULTED (0 replicas). Degraded OK.
+  local i flt
+  for i in $(seq 1 120); do
+    flt=$(kc get volumes.longhorn.io -n longhorn-system -o jsonpath="{range .items[*]}{.status.state}{'='}{.status.robustness}{'\n'}{end}" 2>/dev/null | awk -F= '$1=="attached" && $2=="faulted"{c++} END{print c+0}')
+    [ "$flt" = "0" ] && { echo "  [$(ts)] longhorn: no faulted attached volumes"; return 0; }
+    [ $((i%3)) -eq 0 ] && echo "  [$(ts)] longhorn: $flt FAULTED attached volume(s) - waiting for >=1 replica"
+    sleep 10
+  done
+  die "longhorn: attached volume(s) FAULTED (0 replicas)"
+}
+
+already_done(){ [ "$(kc get node $1.$D -o jsonpath='{.status.nodeInfo.kubeletVersion}' 2>/dev/null)" = "$VER" ]; }
+
+cnpg_failover(){ # $1 node (cordon first). Delete primaries -> CNPG promotes a replica elsewhere.
+  local w=$1 cl reps primpod i n
+  for cl in $(kc get pod -n databases -l cnpg.io/instanceRole=primary --field-selector spec.nodeName=$w.$D \
+              -o jsonpath="{range .items[*]}{.metadata.labels.cnpg\.io/cluster}{'\n'}{end}" 2>/dev/null); do
+    reps=$(kc get pod -n databases -l "cnpg.io/cluster=$cl,cnpg.io/instanceRole=replica" --field-selector status.phase=Running -o name 2>/dev/null | grep -c .)
+    [ "$reps" -ge 1 ] || die "CNPG $cl has 0 running replicas; refuse failover"
+    primpod=$(kc get pod -n databases -l "cnpg.io/cluster=$cl,cnpg.io/instanceRole=primary" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    echo "  [$(ts)] cnpg failover $cl: delete primary $primpod ($reps replica ok)"
+    kc delete pod -n databases "$primpod" --wait=false >/dev/null 2>&1
+  done
+  for i in $(seq 1 50); do
+    n=$(kc get pod -n databases -l cnpg.io/instanceRole=primary --field-selector spec.nodeName=$w.$D --no-headers 2>/dev/null | grep -c .)
+    [ "$n" -eq 0 ] && { echo "  [$(ts)] cnpg: 0 primaries on $w"; return 0; }
+    sleep 6
+  done
+  die "cnpg primaries still on $w after failover"
+}
+
+drain_node(){ # pre-delete empty IM pods (their PDB blocks drain) + OSD-host-PDB fallback
+  local w=$1 osd rr im
+  rr=$(kc get replicas.longhorn.io -n longhorn-system -o jsonpath="{range .items[?(@.spec.nodeID=='$w.$D')]}{.status.currentState}{'\n'}{end}" 2>/dev/null | grep -c '^running$')
+  if [ "$rr" = "0" ]; then
+    for im in $(kc -n longhorn-system get pods --field-selector spec.nodeName=$w.$D -o name 2>/dev/null | grep instance-manager); do
+      echo "  [$(ts)] pre-drain: deleting empty IM $im"; kc delete -n longhorn-system "$im" --grace-period=30 >/dev/null 2>&1
+    done
+  else
+    echo "  [$(ts)] WARN: $w has $rr running replicas at drain time (expected 0)"
+  fi
+  kc drain $w.$D --ignore-daemonsets --delete-emptydir-data --timeout=300s >/tmp/drain-$w.log 2>&1 &
+  local dp=$!
+  sleep 75
+  if kill -0 $dp 2>/dev/null; then
+    osd=$(kc -n rook-ceph get pod -l app=rook-ceph-osd --field-selector spec.nodeName=$w.$D -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    [ -n "$osd" ] && { echo "  [$(ts)] drain stalled; deleting OSD $osd"; kc delete pod -n rook-ceph "$osd" --grace-period=30 >/dev/null 2>&1; }
+  fi
+  wait $dp 2>/dev/null || die "$w drain failed (see /tmp/drain-$w.log)"
+  echo "  [$(ts)] $w drained"
+}
+
+pkg_upgrade_reboot(){ # CentOS/cri-o RPM node. $2 optional dnf exclude (e.g. GPU driver hold)
+  local w=$1 excl="${2:-}"
+  nssh $w "set -e
+    dnf install -y kubeadm-$KVER kubelet-$KVER kubectl-$KVER
+    kubeadm upgrade node --ignore-preflight-errors=CoreDNSUnsupportedPlugins,CoreDNSMigration
+    if [ -n \"$excl\" ]; then ( set -f; dnf upgrade -y $excl ); else dnf upgrade -y; fi
+    LK=\$(ls -1 /boot/vmlinuz-* | grep -v rescue | sort -V | tail -1 | sed 's|/boot/vmlinuz-||')
+    [ -f /boot/initramfs-\${LK}.img ] || dracut -f /boot/initramfs-\${LK}.img \$LK
+    systemctl enable crio kubelet
+    systemd-run --on-active=5s --unit=upgrade-reboot systemctl reboot
+  " >/tmp/up-$w.log 2>&1 || die "$w package upgrade failed (see /tmp/up-$w.log)"
+  echo "  [$(ts)] $w upgraded + reboot triggered"
+}
+
+wait_ready(){ local w=$1 i r v; sleep 45
+  for i in $(seq 1 80); do
+    r=$(kc get node $w.$D --no-headers 2>/dev/null | awk '{print $2}')
+    v=$(kc get node $w.$D -o jsonpath='{.status.nodeInfo.kubeletVersion}' 2>/dev/null)
+    { [ "${r%%,*}" = "Ready" ] && [ "$v" = "$VER" ]; } && { echo "  [$(ts)] $w Ready@$v"; return 0; }
+    [ $((i%4)) -eq 0 ] && echo "  [$(ts)] $w waiting: ready=$r ver=$v"; sleep 15
+  done
+  die "$w not Ready@$VER after reboot"
+}
+
+upgrade_master_light(){ # control-plane node with no OSD/mon/CNPG/Longhorn workload
+  local m=$1; echo ">>> [$(ts)] MASTER $m"
+  already_done $m && { echo "  [$(ts)] $m already $VER, ensuring uncordoned"; kc uncordon $m.$D >/dev/null 2>&1; return 0; }
+  verify_quorum; kc cordon $m.$D >/dev/null 2>&1; drain_node $m
+  pkg_upgrade_reboot $m; wait_ready $m; kc uncordon $m.$D >/dev/null 2>&1; verify_quorum
+  echo ">>> [$(ts)] MASTER $m DONE"
+}
+
+upgrade_worker(){ # $1 short, $2 optional dnf exclude
+  local w=$1 excl="${2:-}"; echo ">>> [$(ts)] WORKER $w"
+  already_done $w && { echo "  [$(ts)] $w already $VER, ensuring uncordoned"; kc uncordon $w.$D >/dev/null 2>&1; longhorn_restore $w; return 0; }
+  verify_quorum; ceph_gate "$w"; longhorn_wait_healthy
+  kc cordon $w.$D >/dev/null 2>&1; cnpg_failover $w; longhorn_clear_node $w; drain_node $w
+  pkg_upgrade_reboot $w "$excl"; wait_ready $w
+  kc uncordon $w.$D >/dev/null 2>&1; longhorn_restore $w; ceph_gate "$w"
+  echo ">>> [$(ts)] WORKER $w DONE"
+}
+
+# NOTE: containerd/apt GPU node (e.g. DGX) is upgraded k8s-only with the driver+
+# kernel HELD (bricking risk on some appliances — update the driver via the
+# vendor's own tool separately). Adapt the held-package list to your node.
+
+##### RUN — edit node list/order for your topology #####
+echo "########## ROLLING UPGRADE START $(ts) — target $VER ##########"
+verify_quorum
+# Control planes first (the FIRST one must already have had `kubeadm upgrade apply`):
+upgrade_master_light master3
+# Workers (hardware-pinned / GPU last; pass a dnf --exclude to hold a pinned GPU driver):
+upgrade_worker worker7
+upgrade_worker worker3
+upgrade_worker worker2
+upgrade_worker worker6
+upgrade_worker worker5
+upgrade_worker worker4
+upgrade_worker worker8 "--exclude=nvidia*,cuda*,libnvidia*,kmod-nvidia*"
+# GPU/containerd node (spark) handled separately — see README.
+# Heaviest control plane LAST (its `apply` was done up front; here only the node bits):
+KHOST=master2; ETCDHOST=master2
+upgrade_master_light master1   # or a heavy variant with cnpg_failover/longhorn_clear_node if it hosts workload
+
+echo "########## FINAL VERIFY $(ts) ##########"
+KHOST=master1; ETCDHOST=master1
+kc get nodes -o custom-columns=NAME:.metadata.name,STATUS:.status.conditions[-1].type,VERSION:.status.nodeInfo.kubeletVersion --no-headers 2>/dev/null
+ceph_gate none; longhorn_wait_healthy; verify_quorum
+echo "########## ROLLING UPGRADE COMPLETE $(ts) — restore Longhorn settings + resume descheduler (Phase 5) ##########"


### PR DESCRIPTION
Saves the optimizations and lessons from the 2026-08-22 1.35.4→1.36.4 run for the next upgrade.

**tools/cluster-upgrade/**
- `predownload.sh` — parallel `dnf/apt --downloadonly` cache warming (~10 min/node saved)
- `rolling-upgrade.sh` — idempotent, gated, one-node-at-a-time orchestrator; fast Longhorn clear-by-DELETE (replicas with a healthy copy elsewhere deleted instantly instead of evict/rebuild → ~12–25 min/node saved), empty-IM pre-delete before drain, faulted-only health floor, CoreDNS skip-phases
- `README.md` — usage, safety model, gotchas, Phase-5 restore list

**docs/src/cluster_upgrade.md** — new 'Optimizations & lessons' section (speed wins + failure modes: dual-IM PDB block, cordoned-node/deleted-OSD deadlock, stalled rebuild).

Domain parameterized via `SECRET_DOMAIN`; no secrets or restricted-tier content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)