### PR TITLE
feat(ai): finish claude-runner vault-bridge (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-93-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-94-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/claude-runner/README.md
+++ b/kubernetes/apps/ai/claude-runner/README.md
@@ -68,6 +68,62 @@ transcripts + scratch clones survive pod restarts. Needs the tmux-bearing image
 repo). Egress is the same CNP as the cron workflows (read-only Prometheus +
 world:443); attach is via `kubectl exec`, no route.
 
+## Vault bridge — the Obsidian vault as files in the pod (Phase 3)
+
+`deployment-shell.yaml` runs a **`vault-bridge` sidecar** next to the `shell`
+container so the in-cluster Claude sees the same `~/vaults/claude` files as the
+laptop. It mounts into the shell at **`/home/node/vaults/claude`**.
+
+**How it works.** The laptop's Obsidian syncs the vault into CouchDB
+(`obsidian.${SECRET_DOMAIN}`) via the Self-hosted LiveSync plugin. The sidecar
+runs the plugin author's **official** headless CLI — `ghcr.io/vrtmrz/livesync-cli`,
+same repo and core as the plugin — in its `daemon` mode: an initial mirror scan
+then continuous bidirectional replication between CouchDB and the local
+filesystem (CouchDB → files via the `_changes` feed; files → CouchDB via a file
+watcher). It talks to CouchDB over the **in-cluster** Service
+`obsidian-couchdb.collab.svc.cluster.local:5984` (not the public route).
+
+**Topology: sidecar, not standalone.** The bridge and the shell share one RWO
+`ceph-block` PVC (`claude-vault-data`) inside a single pod — `/db` (the CLI's
+PouchDB database) and `/vault` (the materialised `.md` files) are subPaths of
+it. A standalone bridge Deployment would need the vault PVC to be RWX, and this
+cluster's only RWX pattern is direct-NFS (not ceph/Longhorn), so the sidecar is
+the deliberate choice. The vault is regenerable from CouchDB, so `ceph-block`
+(rule 2) is correct; CouchDB stays the source of truth.
+
+**⚠ CouchDB is canonical; the pod is a SECONDARY writer.** LiveSync is
+eventually-consistent. If pod-Claude and the laptop edit the *same note* at the
+same time, LiveSync records **conflict revisions** rather than losing data —
+resolve them from Obsidian on the laptop (the conflict-resolution UI). Treat the
+in-cluster copy as a working mirror, not the primary.
+
+### Verify (comes up on merge)
+
+No extra activation step: the db name (`claude`) and `encrypt: false` are inline
+in `externalsecret-vault-bridge.yaml` — the `claude` vault is **not** E2E-encrypted
+(verified against the live db, plaintext docs) — and the CouchDB creds
+(`couchdb_username`/`couchdb_password`) are already in the 1P `obsidian` item. On
+merge the shell pod rolls once (Recreate) and the `vault-bridge` sidecar connects
+and materialises the vault. Confirm:
+
+```sh
+kubectl -n ai logs deploy/claude-runner-shell -c vault-bridge
+kubectl -n ai exec deploy/claude-runner-shell -c shell -- ls /home/node/vaults/claude
+```
+
+> **Merge disruption:** the shell Deployment is `strategy: Recreate`, so merging
+> this Phase-3 change replaces the pod once — the running tmux session is lost
+> (start it fresh after the roll). Land it in a routine window.
+
+### Network
+
+- `cnp-allow.yaml` (ai ns) adds an egress hole to `obsidian-couchdb:5984` in
+  `collab`. Both containers share the pod's Cilium identity
+  (`app.kubernetes.io/name: claude-runner`), so the hole covers the sidecar.
+- `obsidian-couchdb/app/cnp-allow.yaml` (collab ns) adds the matching ingress
+  rule from `ai`/`claude-runner`. Both namespaces are default-deny; DNS is
+  already granted by the baseline component.
+
 ## Add a Claude-tier workflow
 
 Copy `cronjob-flux-longhorn-drift-digest.yaml`, then:

--- a/kubernetes/apps/ai/claude-runner/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cnp-allow.yaml
@@ -43,3 +43,19 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # CouchDB (collab ns) — the vault-bridge sidecar in claude-runner-shell
+    # replicates the Obsidian vault from obsidian-couchdb:5984. Both the
+    # sidecar and the shell share this pod's Cilium identity
+    # (app.kubernetes.io/name: claude-runner), so this hole is scoped to the
+    # single CouchDB endpoint. Selector matches the couchdb pod's real label
+    # (the existing obsidian-couchdb-allow CNP uses the same one); a wrong
+    # label here silent-drops (reference_cnp_blackbox_exporter_label_trap).
+    # DNS for the Service name is already granted by the baseline allow-dns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: obsidian-couchdb
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP

--- a/kubernetes/apps/ai/claude-runner/app/deployment-shell.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/deployment-shell.yaml
@@ -81,6 +81,73 @@ spec:
               mountPath: /home/node
             - name: tmp
               mountPath: /tmp
+            # The materialised vault, shared with the vault-bridge sidecar
+            # (subPath `vault` of the same RWO PVC — single pod, no RWX).
+            # CouchDB (obsidian.${SECRET_DOMAIN}) stays the source of truth;
+            # this is a SECONDARY writer. If pod-Claude and the laptop edit
+            # the same note at once, LiveSync records conflict revisions —
+            # resolve them from Obsidian on the laptop. See ./README.md.
+            - name: vault
+              mountPath: /home/node/vaults/claude
+              subPath: vault
+        # ---------------------------------------------------------------
+        # vault-bridge — official Self-hosted LiveSync CLI (same author &
+        # core as the Obsidian plugin) running its `daemon`: continuously
+        # replicates the CouchDB remote <-> the local filesystem via the
+        # _changes feed. This is what materialises the vault as FILES the
+        # in-cluster Claude can read/write. Sidecar (not standalone) so the
+        # vault volume stays RWO inside one pod.
+        - name: vault-bridge
+          image: ghcr.io/vrtmrz/livesync-cli:1.0.16-cli
+          imagePullPolicy: IfNotPresent
+          # Entrypoint prepends the DB path (LIVESYNC_DB_PATH) as argv[1],
+          # so these args become:
+          #   /db --settings /config/settings.json --vault /vault daemon
+          # daemon = mirror-scan then continuous bidirectional sync.
+          args:
+            - --settings
+            - /config/settings.json
+            - --vault
+            - /vault
+            - daemon
+          env:
+            - name: LIVESYNC_DB_PATH
+              value: /db
+            - name: TZ
+              value: America/New_York
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            # PouchDB local database (leveldown writes here).
+            - name: vault
+              mountPath: /db
+              subPath: db
+            # The materialised vault .md files.
+            - name: vault
+              mountPath: /vault
+              subPath: vault
+            # settings.json (couchDB_URI/user/password/dbname/passphrase),
+            # rendered by the claude-vault-bridge ExternalSecret from 1P.
+            - name: bridge-config
+              mountPath: /config
+              readOnly: true
+            - name: bridge-tmp
+              mountPath: /tmp
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -89,3 +156,13 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 512Mi
+        - name: vault
+          persistentVolumeClaim:
+            claimName: claude-vault-data
+        - name: bridge-config
+          secret:
+            secretName: claude-vault-bridge-secret
+        - name: bridge-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 128Mi

--- a/kubernetes/apps/ai/claude-runner/app/externalsecret-vault-bridge.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/externalsecret-vault-bridge.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-vault-bridge
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: claude-vault-bridge-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Full livesync-cli settings.json, rendered from the 1P `obsidian`
+        # item. Mounted read-only into the bridge sidecar at
+        # /config/settings.json (daemon mode only reads it; --write-settings
+        # is never passed, so read-only is fine).
+        #
+        # Fields sourced from 1P `obsidian`:
+        #   couchdb_username / couchdb_password  — ALREADY present (used by
+        #                                          the CouchDB StatefulSet).
+        #   couchdb_dbname                       — ADD at activation. The DB
+        #                                          name the laptop's LiveSync
+        #                                          plugin replicates into
+        #                                          (Settings > Remote Database
+        #                                          > "Database name").
+        #   couchdb_passphrase                   — ADD at activation IF the
+        #                                          vault is E2E-encrypted
+        #                                          (Settings > "End to End
+        #                                          Encryption" passphrase). If
+        #                                          the vault is NOT encrypted,
+        #                                          set encrypt=false below and
+        #                                          leave this empty.
+        #
+        # In-cluster CouchDB Service DNS (NOT the public obsidian.<domain>
+        # route, which egresses the cluster). Service name is the
+        # app-template controller name obsidian-couchdb in ns collab.
+        settings.json: |-
+          {
+            "couchDB_URI": "http://obsidian-couchdb.collab.svc.cluster.local:5984",
+            "couchDB_USER": "{{ .couchdb_username }}",
+            "couchDB_PASSWORD": "{{ .couchdb_password }}",
+            "couchDB_DBNAME": "claude",
+            "encrypt": false,
+            "passphrase": "",
+            "liveSync": true,
+            "syncOnSave": true,
+            "syncOnStart": true,
+            "usePluginSync": false,
+            "isConfigured": true
+          }
+  dataFrom:
+    - extract:
+        key: obsidian

--- a/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ./cronjob-flux-longhorn-drift-digest.yaml
   - ./deployment-shell.yaml
   - ./externalsecret.yaml
+  - ./externalsecret-vault-bridge.yaml
   - ./job-auth-spike.yaml
   - ./pvc-shell.yaml
+  - ./pvc-vault.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/ai/claude-runner/app/pvc-vault.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/pvc-vault.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: claude-vault-data
+spec:
+  # Holds two regenerable things, both reconstructable from the CouchDB
+  # source of truth (obsidian.${SECRET_DOMAIN}):
+  #   /db     — the livesync-cli PouchDB local database (leveldown)
+  #   /vault  — the materialised vault .md files (also mounted into the
+  #             shell container at /home/node/vaults/claude)
+  # Per storage-class.instructions.md rule 2 (regenerable → ceph-block):
+  # CouchDB stays canonical; this cache re-syncs on loss. RWO is fine —
+  # the bridge sidecar and the shell share it inside ONE pod, so no RWX
+  # is needed (this cluster's RWX pattern is direct-NFS, not ceph/Longhorn).
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
@@ -26,5 +26,18 @@ spec:
         - ports:
             - port: "5984"
               protocol: TCP
+    # The vault-bridge sidecar in claude-runner-shell (ai ns) replicates the
+    # vault out of CouchDB via the in-cluster Service (obsidian-couchdb.collab
+    # :5984), so the pod-Claude sees the same files as the laptop. Scoped to
+    # that one workload's Cilium identity. Egress side is claude-runner's
+    # cnp-allow.yaml. See kubernetes/apps/ai/claude-runner/app/README.md.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: claude-runner
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP
   # No egress holes needed — CouchDB is self-contained for this
   # single-node setup. No remote replication peers configured.


### PR DESCRIPTION
Finalizes the vault-bridge sidecar (official `vrtmrz/livesync-cli`) mirroring the Obsidian `claude` vault into the `claude-runner-shell` pod at `/home/node/vaults/claude` over the in-cluster CouchDB Service.

- **`encrypt: false` + db `claude` inline** — the claude vault is not E2E-encrypted (verified against the live db). Only `couchdb_username`/`password` come from 1P (already present), so the bridge comes up healthy on first roll, **no crash-loop, no extra activation step**.
- The `claude` CouchDB db is already populated (1,267 files uploaded today).
- CNPs: ai→obsidian-couchdb:5984 egress + collab ingress from ai. Sidecar shares one RWO ceph-block PVC with the shell (no RWX). CouchDB canonical; pod is a secondary writer.

Merge rolls the shell pod once (Recreate); current tmux session is idle. **Supersedes #13714.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)