### PR TITLE
feat(longhorn): auto-migrate volume engines on new default image

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -27,6 +27,13 @@ spec:
       # detached, so no running workload is interrupted.
       allowRecurringJobWhileVolumeDetached: true
       backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
+      # Auto-migrate every volume's engine to the new default image whenever a
+      # Longhorn bump changes it, so the old engine's instance-managers empty
+      # instead of lingering. A stale IM keeps a PDB at disruptionsAllowed=0
+      # that blocks `kubectl drain` — this bit the k8s 1.35->1.36 upgrade hard
+      # (1.12.0 data plane never migrated after the 1.12.0->1.12.1 chart bump).
+      # Rule: never run two instance-managers unless absolutely necessary.
+      concurrentAutomaticEngineUpgradePerNodeLimit: 3
       createDefaultDiskLabeledNodes: true
       defaultDataLocality: best-effort
       defaultReplicaCount: 2


### PR DESCRIPTION
Sets `concurrentAutomaticEngineUpgradePerNodeLimit=3` in the Longhorn HelmRelease so a chart bump that changes the default engine image auto-live-upgrades every volume to it — the old instance-managers empty instead of lingering as a dual-IM data plane.

**Why:** a stale IM's PDB (`disruptionsAllowed:0`) blocks `kubectl drain`, which repeatedly broke the k8s 1.35→1.36 upgrade (the data plane was still on `longhorn-engine:v1.12.0` months after the 1.12.0→1.12.1 chart bump). Enforces the rule: never run two instance-managers unless absolutely necessary — migrate as part of the Longhorn upgrade, not deferred into a k8s upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)