### PR TITLE
fix(multus): raise memory limit to stop OOMKill on heavy nodes

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -31,8 +31,14 @@ spec:
       netPath: /etc/cni/net.d
     multus:
       resources:
+        # The 62Mi ceiling (req==limit, Guaranteed) OOMKilled the DaemonSet
+        # on master1 — the heaviest node (control-plane + OSD + workloads),
+        # where multus sets up far more pod networks than a plain worker.
+        # Keep a lean request for scheduling; raise the limit to a burst
+        # ceiling so heavy-churn nodes stop OOM-looping. Real steady-state
+        # use is ~30Mi, so the higher ceiling reserves nothing extra.
         limits:
-          memory: 62Mi
+          memory: 256Mi
         requests:
           cpu: 10m
-          memory: 62Mi
+          memory: 64Mi


### PR DESCRIPTION
## Problem

Post k8s 1.36 upgrade, the multus CNI DaemonSet pod on the busiest node (control-plane + OSD + workloads) was OOMKilling repeatedly (10 restarts, `ready=false`, exit 137). The container's own Guaranteed 62Mi ceiling was too tight for a node that sets up far more pod networks than a plain worker. Fired a critical OOM alert that would not self-clear.

## Fix

- Keep a lean **64Mi request** (scheduling reservation; steady-state use is ~30Mi).
- Raise the **limit to 256Mi** as a burst ceiling so heavy-churn nodes stop OOM-looping.

Limit is a ceiling, not a reservation — nothing extra is reserved cluster-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)