### PR TITLE
fix(gpu): durable driver-ready on CRI-O P40 + right-size ollama CPU

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -118,7 +118,12 @@ spec:
             resources:
               requests:
                 memory: 6G
-                cpu: 2000m
+                # Right-sized from 2000m: ollama is GPU-bound, and the 2-core
+                # reservation monopolized worker8 (the only P40 node), starving
+                # co-scheduled GPU workloads that MUST land here (Renee-facing
+                # wyoming-whisper, immich CLIP/pet-tagger). No CPU limit, so it
+                # still bursts under load.
+                cpu: 500m
                 nvidia.com/gpu: 1
               limits:
                 memory: 6G

--- a/kubernetes/apps/kube-system/gpu-operator/app/crio-cdi-setup.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/crio-cdi-setup.yaml
@@ -19,7 +19,16 @@
 #   2. Generates /var/run/cdi/management.nvidia.com-gpu.yaml
 #   3. Creates /run/nvidia/validations/toolkit-ready to unblock the
 #      device-plugin's toolkit-validation init container.
-#   4. Re-runs every hour so the spec stays fresh after driver updates.
+#   4. Creates /run/nvidia/validations/driver-ready (host-managed
+#      driver-root values), which the device-plugin entrypoint blocks on
+#      and SOURCES for NVIDIA_DRIVER_ROOT. On Pascal the operator-validator
+#      (which normally writes this) is disabled by the
+#      gpu-operator-pascal-validator-skip NFR because its cuda-validation
+#      false-negatives; /run is tmpfs, so after a reboot nothing rewrote
+#      driver-ready and the device-plugin crashlooped hunting driver libs
+#      in the empty operator-managed /run/nvidia/driver path. We emulate
+#      driver-validation here, gated on the host driver actually responding.
+#   5. Re-runs every hour so the specs stay fresh after driver updates.
 #
 # Scoped exclusively to CRI-O GPU nodes via:
 #   nvidia.com/gpu.present=true (has a GPU)
@@ -78,8 +87,19 @@ spec:
                     --vendor=management.nvidia.com \
                     --output=/var/run/cdi/management.nvidia.com-gpu.yaml
                   touch /run/nvidia/validations/toolkit-ready
+                  # Emulate the operator-validator driver-validation that is
+                  # disabled on Pascal: only signal driver-ready if the host
+                  # driver actually responds (fail loud if it ever breaks),
+                  # then write the host-managed driver-root values the
+                  # device-plugin entrypoint sources for NVIDIA_DRIVER_ROOT.
+                  if nvidia-smi >/dev/null 2>&1; then
+                    printf "IS_HOST_DRIVER=true\nNVIDIA_DRIVER_ROOT=/\nDRIVER_ROOT_CTR_PATH=/host\nNVIDIA_DEV_ROOT=/\nDEV_ROOT_CTR_PATH=/host\n" \
+                      > /run/nvidia/validations/driver-ready
+                  else
+                    rm -f /run/nvidia/validations/driver-ready
+                  fi
                 '
-                echo "$(date -u): management CDI spec generated / toolkit-ready signaled"
+                echo "$(date -u): management CDI spec + driver-ready generated / toolkit-ready signaled"
               }
 
               generate


### PR DESCRIPTION
## Post-1.36-upgrade P40 (worker8) remediation

After worker8's upgrade reboot the P40 advertised `nvidia.com/gpu: 0` and 4 GPU workloads (ollama, **Renee-facing wyoming-whisper**, immich-machine-learning, immich-pet-tagger) went Pending.

### Root cause
The `nvidia-device-plugin` entrypoint blocks on `/run/nvidia/validations/driver-ready` and **sources** it for `NVIDIA_DRIVER_ROOT=/`. That file is normally written by the operator-validator's `driver-validation`, but the validator is disabled on Pascal (its `cuda-validation` false-negatives on sm_61 under CUDA 13). `/run` is tmpfs → the reboot cleared the flag → plugin fell back to the empty `/run/nvidia/driver` and crashlooped (`libcuda.so.580.159.03: not found`).

### Fix 1 — durable `driver-ready` via the existing CRI-O shim
`crio-cdi-setup` already writes `toolkit-ready`; extend it to also write `driver-ready` (host-managed driver-root values), **gated on `nvidia-smi`** so it fails loud if the driver breaks. Survives reboots, GitOps-native, no validator re-enable (avoids permanent cosmetic DaemonSet-rollout alerts).

### Fix 2 — right-size ollama CPU (2000m → 500m)
The master1-drain CNPG failover packed ~13 postgres pods onto worker8; ollama's 2-core request pushed it to 99% CPU requests, starving whisper/pet-tagger which must run on the P40 node. ollama is GPU-bound; 500m request, no CPU limit.

A live interim (manually populated `driver-ready`) already restored GPU service; this makes it durable with an idempotent handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)