### PR TITLE
feat(local-cron): add Renovate open-PR digest (local Ollama tier, zero-token)

### DIFF
--- a/kubernetes/apps/ai/local-cron/README.md
+++ b/kubernetes/apps/ai/local-cron/README.md
@@ -29,18 +29,25 @@ The load-bearing design points:
 | Workflow | Schedule (UTC) | Tier | What |
 |---|---|---|---|
 | `loki-error-skim` | `0 12 * * *` (08:00 EDT / 07:00 EST, daily) | Local (Ollama) | LogQL-rank the top error/panic/fatal log producers in Loki over 24h, pull a small sample of lines from the top 5, have the local model distill them into a terse pattern digest, send ONE Pushover message. Silent (exit 0, no push) when there are no error lines. |
+| `renovate-pr-digest` | `30 12 * * *` (08:30 EDT / 07:30 EST, daily) | Local (Ollama) | List the open Renovate PRs (unauthenticated GitHub REST — the repo is public), have the local model produce a terse digest that flags likely major bumps + PRs stuck > 7 days and groups the rest by kind, send ONE Pushover message. Silent (exit 0, no push) when the queue is empty. |
 
 Query path: `topk(15, sum by (namespace, app) (count_over_time({namespace=~".+"} |~ "(?i)(error|panic|fatal|traceback|exception)" [24h])))`
 against `loki:3100` (Loki stream labels here are `app` / `namespace` /
 `node`, set by the Vector aggregator sink).
 
-## Why Loki (not the PR-summary fallback)
+## Why Loki first, PR digest second
 
-Loki was the clean wire: `auth_enabled: false`, monolithic SingleBinary,
-one Service (`loki.observability:3100`), and a real LogQL metric API that
-does the ranking server-side. The PR-summary fallback would have needed a
-`gh` token + world egress to `api.github.com` for a weaker signal. Loki
-gives a genuine ops-triage digest with no extra credential.
+Loki was the clean first wire: `auth_enabled: false`, monolithic
+SingleBinary, one Service (`loki.observability:3100`), and a real LogQL
+metric API that does the ranking server-side — a genuine ops-triage
+digest with no extra credential.
+
+The PR digest was originally deferred because a PR summary was assumed to
+need a `gh` token. It doesn't: **home-ops is a public repo**, so the
+Renovate-queue read is unauthenticated GitHub REST (60 req/hr unauth ≫ one
+daily call) and rides the same `world:443` egress Pushover already uses —
+no token, no secret, no CNP change. That removed the only reason it was
+held back, so it now ships alongside the log skim.
 
 ## Network policy
 
@@ -48,8 +55,10 @@ The `ai` namespace is default-deny; `observability` is default-deny
 ingress. Two holes were punched:
 
 - **`ai/local-cron/app/cnp-allow.yaml`** (egress): `loki.observability:3100`
-  plus `world:443` (Pushover). Ollama is **intra-ns** (both in `ai`), so it
-  rides the baseline `allow-intra-namespace` — no rule needed.
+  plus `world:443` (Pushover **and** `api.github.com` for the PR digest —
+  both external HTTPS, one rule). Ollama is **intra-ns** (both in `ai`), so
+  it rides the baseline `allow-intra-namespace` — no rule needed. The PR
+  digest added **no** new egress.
 - **`observability/loki/app/cnp-allow.yaml`** (ingress): added
   `ai/local-cron` as a cross-ns source on `loki:3100`. Loki previously had
   no ingress rules (only intra-ns Grafana/Vector via baseline), so this
@@ -70,14 +79,19 @@ order:
    (`local-cron-secret`), the CNP, the RBAC, and the CronJob object. The
    CronJob is still `suspend: true`, so nothing fires yet. Verify:
    `kubectl -n ai get externalsecret local-cron` shows `SecretSynced`.
-3. **Test once, out of band.** With the CronJob still suspended:
-   `kubectl -n ai create job --from=cronjob/local-cron-loki-error-skim skim-test`
-   then `kubectl -n ai logs job/skim-test -f`. Expect the ranked list, the
-   `----- local-model digest -----` block, and `Pushover digest sent`. If
-   Loki returns no error lines it exits 0 with "Nothing to report" and
-   sends nothing — that is success, not failure.
-4. **Unsuspend the CronJob** — remove `spec.suspend: true` from
-   `cronjob-loki-error-skim.yaml`. It now runs daily at 12:00 UTC.
+3. **Test once, out of band.** With the CronJobs still suspended, test each:
+   - `kubectl -n ai create job --from=cronjob/local-cron-loki-error-skim skim-test`
+   - `kubectl -n ai create job --from=cronjob/local-cron-renovate-pr-digest renovate-test`
+
+   then `kubectl -n ai logs job/<name> -f`. Expect (for the skim) the
+   ranked list, or (for the digest) `Open Renovate PRs (N):` + the list,
+   then the `----- local-model digest -----` block and `Pushover digest
+   sent`. Empty-input is success, not failure: the skim prints "Nothing to
+   report" and the digest prints "No open Renovate PRs" — both exit 0 and
+   send nothing.
+4. **Unsuspend the CronJob(s)** — remove `spec.suspend: true` from
+   `cronjob-loki-error-skim.yaml` and/or `cronjob-renovate-pr-digest.yaml`.
+   They then run daily at 12:00 / 12:30 UTC respectively.
 
 To pause again: re-add `spec.suspend: true` to the CronJob (fast, keeps
 objects) or to the ks (full teardown of the app's objects on next prune).

--- a/kubernetes/apps/ai/local-cron/app/cronjob-renovate-pr-digest.yaml
+++ b/kubernetes/apps/ai/local-cron/app/cronjob-renovate-pr-digest.yaml
@@ -1,0 +1,185 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: local-cron-renovate-pr-digest
+  labels:
+    app.kubernetes.io/name: local-cron
+spec:
+  # SHIPPED SUSPENDED (see ./README.md → Activation). Even with the ks
+  # unsuspended, this CronJob does not fire until `spec.suspend` is removed.
+  suspend: true
+  # 30 12 * * * UTC = 08:30 EDT / 07:30 EST, daily — 30 min after the
+  # loki-error-skim (0 12) so the two don't share a P40 model-load spike,
+  # and off the mcp-gateway 04:30 rotation. Daily is justified here: this
+  # cluster runs Renovate automerge, so the open queue turns over fast (see
+  # the 27-PR-storm incident in memory) — a daily read of what is currently
+  # pending/stuck is fresh, not repetitive. Silent on an empty queue, so a
+  # quiet day costs no notification.
+  schedule: "30 12 * * *"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # 15 min hard cap: one GitHub REST call + a qwen2.5:7b generation.
+      activeDeadlineSeconds: 900
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: local-cron
+          annotations:
+            k8tz.io/inject: "false"
+        spec:
+          # amd64 image; ai ns also has arm64 Spark nodes — pin so the pod
+          # can't land on Spark and hit an exec-format error.
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          serviceAccountName: local-cron
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          containers:
+            - name: digest
+              # Carries curl + jq (same image as loki-error-skim). NOTE:
+              # `date` is busybox — the PR-age math is done in jq (which has
+              # `now` + `fromdateiso8601`), not with `date -d`.
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ceu
+                # Flux postBuild runs envsubst in STRICT mode over this
+                # manifest: a bare ${VAR} is read as a Flux substitution and
+                # fails the whole Kustomization with "variable not set".
+                # Every shell `$` is doubled (`$$`) so the rendered manifest
+                # carries a literal `$` for /bin/sh. Same convention as
+                # cronjob-loki-error-skim.yaml.
+                - |
+                  GITHUB_API="https://api.github.com/repos/rwlove/home-ops/pulls"
+                  OLLAMA="http://ollama.ai.svc.cluster.local:11434"
+                  MODEL="qwen2.5:7b"
+                  DAY="$$(date -u +%Y-%m-%d)"
+
+                  # (1) Fetch open PRs. home-ops is a PUBLIC repo, so this is
+                  # UNAUTHENTICATED — no token, no secret. Unauth GitHub REST
+                  # is 60 req/hr, far above one daily call. api.github.com is
+                  # reached over the existing world:443 egress (shared with
+                  # Pushover); no CNP change was needed.
+                  PRS="$$(curl -sSG --max-time 60 \
+                            -H 'Accept: application/vnd.github+json' \
+                            -H 'X-GitHub-Api-Version: 2022-11-28' \
+                            "$$GITHUB_API" \
+                            --data-urlencode "state=open" \
+                            --data-urlencode "per_page=100")" || {
+                    echo "FATAL: GitHub API request failed"
+                    exit 1
+                  }
+
+                  # Hard-fail on a non-array payload (rate-limit / error
+                  # object) so a broken job is VISIBLE instead of looking
+                  # like an empty queue.
+                  if ! printf '%s' "$$PRS" | jq -e 'type=="array"' >/dev/null 2>&1; then
+                    echo "FATAL: GitHub API did not return a PR array"
+                    printf '%s' "$$PRS" | head -c 300
+                    exit 1
+                  fi
+
+                  # (2) Keep only Renovate-authored PRs; format
+                  # "#<num> [<age>d] <title>", oldest first. jq computes age
+                  # from created_at.
+                  LIST="$$(printf '%s' "$$PRS" | jq -r '
+                    [ .[] | select(.user.login | test("renovate"; "i")) ]
+                    | sort_by(.created_at)
+                    | .[]
+                    | "#\(.number) [\(((now - (.created_at | fromdateiso8601)) / 86400) | floor)d] \(.title)"
+                  ')"
+
+                  if [ -z "$$LIST" ]; then
+                    echo "No open Renovate PRs. Nothing to report."
+                    exit 0
+                  fi
+
+                  COUNT="$$(printf '%s\n' "$$LIST" | grep -c '^#' || true)"
+                  echo "Open Renovate PRs ($$COUNT):"
+                  printf '%s\n' "$$LIST"
+
+                  # (3) Summarize with the LOCAL model (Ollama, P40) — never
+                  # Claude. Build the /api/generate body with jq so the PR
+                  # titles are safely JSON-escaped.
+                  PROMPT="You are a release-hygiene assistant for a home Kubernetes GitOps repo. Below are the currently-open Renovate dependency-update PRs (number, age in days, title). Produce a terse digest (max 10 short lines, plain text, no markdown): the total count; flag any likely MAJOR version bumps (a jump in the leading version number in the title) as needing manual review; call out any PR older than 7 days as stuck; group the rest briefly by kind (container images, Helm charts, GitHub Actions). Do not invent PRs that are not listed. Data:\n\n$${LIST}"
+
+                  REQ="$$(jq -n --arg m "$$MODEL" --arg p "$$PROMPT" \
+                          '{model:$$m, prompt:$$p, stream:false, options:{num_predict:400, temperature:0.2}}')"
+
+                  SUMMARY="$$(curl -sSf --max-time 300 \
+                              -H 'Content-Type: application/json' \
+                              -d "$$REQ" \
+                              "$${OLLAMA}/api/generate" \
+                            | jq -r '.response // empty')" || {
+                    echo "FATAL: Ollama summarization failed"
+                    exit 1
+                  }
+
+                  if [ -z "$$SUMMARY" ]; then
+                    echo "FATAL: Ollama returned an empty summary"
+                    exit 1
+                  fi
+
+                  echo "----- local-model digest -----"
+                  printf '%s\n' "$$SUMMARY"
+
+                  # (4) Send ONE Pushover notification (private channel).
+                  # Pushover message limit is 1024 chars; truncate to be safe.
+                  MSG="$$(printf '%s' "$$SUMMARY" | cut -c1-1000)"
+                  HTTP="$$(curl -sS --max-time 30 -o /tmp/pushover.out -w '%{http_code}' \
+                            --form-string "token=$${PUSHOVER_TOKEN}" \
+                            --form-string "user=$${PUSHOVER_USER}" \
+                            --form-string "title=renovate-pr-digest $${DAY}" \
+                            --form-string "message=$${MSG}" \
+                            https://api.pushover.net/1/messages.json)" || {
+                    echo "FATAL: Pushover request errored"
+                    exit 1
+                  }
+                  case "$$HTTP" in
+                    2??) echo "Pushover digest sent (HTTP $$HTTP)";;
+                    *) echo "FATAL: Pushover returned HTTP $$HTTP"; cat /tmp/pushover.out; exit 1;;
+                  esac
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: TZ
+                  value: America/New_York
+              envFrom:
+                - secretRef:
+                    name: local-cron-secret
+                    optional: false
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 64Mi

--- a/kubernetes/apps/ai/local-cron/app/kustomization.yaml
+++ b/kubernetes/apps/ai/local-cron/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - ./cnp-allow.yaml
   - ./cronjob-loki-error-skim.yaml
+  - ./cronjob-renovate-pr-digest.yaml
   - ./externalsecret.yaml
   - ./rbac.yaml


### PR DESCRIPTION
## What

Adds a second `local-cron` CronJob — `local-cron-renovate-pr-digest` — completing the recommended local-tier automation batch from the trial plan. Shipped **SUSPENDED** (daily 12:30 UTC when activated). It lists the open Renovate PRs and has the in-cluster Ollama (`qwen2.5:7b`, P40) distill them into a terse digest (flagging likely major bumps + PRs stuck > 7 days, grouped by kind), then sends one private Pushover message.

**Zero Anthropic tokens** — this is the HOMELAB-SPEC Layer 6 local-model tier, not the Claude tier.

## Why it's cheap now

home-ops is a **public** repo, so the GitHub REST read is **unauthenticated** (60 req/hr ≫ one daily call) and rides the existing `world:443` egress alongside Pushover. **No token, no secret, no CNP change.** That removes the only reason the PR digest was originally deferred in favor of the Loki skim (the old README claimed it would need a `gh` token — it doesn't).

## Design

Mirrors `cronjob-loki-error-skim.yaml` verbatim for the hardening block, `$$` envsubst escaping, image (`alpine/k8s`, curl+jq), `local-cron-secret`, and volumes. Notable points:

- **PR age is computed in jq** (`now`/`fromdateiso8601`) — busybox `date` can't parse ISO8601.
- **A non-array GitHub payload hard-fails** (rate-limit / error object) so a broken job stays visible instead of masquerading as an empty queue.
- **Empty queue exits 0 and sends nothing** — a quiet day costs no notification.
- Filters to Renovate-authored PRs only.

## Verification

- `kubectl kustomize` renders clean (2 CronJobs, envsubst placeholders intact).
- Fetch + array-check + LIST pipeline + renovate-filter + age math exercised against live GitHub (empty queue → silent path) and a synthetic non-empty array (correct format + ages + filter).
- All pre-commit hooks pass (incl. envsubst-escaping and no-literal-credentials checks); yamllint clean.

## Activation

Suspended at both ks and CronJob level. See `kubernetes/apps/ai/local-cron/README.md` → Activation. Governed by the claude-runner trial policy (`.agents/instructions/claude-runner-routing.md`); revert is a one-PR prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)