### PR TITLE
fix(kube-vip): tune leaderElection for faster API-VIP failover (15s→5s)

### DIFF
--- a/kubernetes/apps/kube-system/kube-vip/daemon-set.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/daemon-set.yaml
@@ -37,6 +37,22 @@ spec:
               value: "true"
             - name: cp_namespace
               value: kube-system
+            # LeaderElection tuning. The API VIP failover window was ~15s
+            # (kube-vip default leaseDuration), which strands the VIP when the
+            # owning master hangs ungracefully (bit us during the 1.36 upgrade
+            # when master1's cri-o froze). 5/3/1 shortens the lease-driven
+            # failover to ~5s. The VIP intentionally stays on L2/ARP so brain
+            # remains OUT of the control-plane datapath — BGP-advertising the
+            # /32 would route it through brain and make brain a control-plane
+            # SPOF, which ARP (flat 192.168.0.0/16 L2) avoids today.
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leaseduration
+              value: "5"
+            - name: vip_renewdeadline
+              value: "3"
+            - name: vip_retryperiod
+              value: "1"
             - name: svc_enable
               value: "false"
             - name: address
@@ -105,6 +121,22 @@ spec:
               value: "true"
             - name: cp_namespace
               value: kube-system
+            # LeaderElection tuning. The API VIP failover window was ~15s
+            # (kube-vip default leaseDuration), which strands the VIP when the
+            # owning master hangs ungracefully (bit us during the 1.36 upgrade
+            # when master1's cri-o froze). 5/3/1 shortens the lease-driven
+            # failover to ~5s. The VIP intentionally stays on L2/ARP so brain
+            # remains OUT of the control-plane datapath — BGP-advertising the
+            # /32 would route it through brain and make brain a control-plane
+            # SPOF, which ARP (flat 192.168.0.0/16 L2) avoids today.
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leaseduration
+              value: "5"
+            - name: vip_renewdeadline
+              value: "3"
+            - name: vip_retryperiod
+              value: "1"
             - name: svc_enable
               value: "false"
             - name: address


### PR DESCRIPTION
## Problem
The control-plane API VIP (`192.168.6.1`) failover window is **~15s** — kube-vip's default `leaseDuration`, because no leaderElection timers were ever set (verified live: `plndr-cp-lock` lease `leaseDurationSeconds=15`, held by master3). When the owning master hangs ungracefully — as master1's cri-o did during the 1.36 upgrade — the VIP strands for that window.

## Fix
Set on both DaemonSets: `vip_leaderelection=true`, `vip_leaseduration=5`, `vip_renewdeadline=3`, `vip_retryperiod=1` (kube-vip's recommended values). Shortens lease-driven failover to ~5s.

## Why ARP, not BGP (deliberate)
Verified the VIP is reached **on-link** on the flat `192.168.0.0/16` L2 (brain's DHCP hands a /16 mask): both a `.1.x` node (master1) and a `.4.x` node (worker8) resolve `192.168.6.1` **directly to the owning master's NIC MAC** (`52:54:00:75:a0:cf`), *not* via brain. So today the control plane survives brain being down — etcd peers, apiserver-to-apiserver, the VIP, and pod-to-pod are all L2-direct. Advertising the `/32` via BGP would route it through brain and make **brain a control-plane SPOF**. This change keeps the VIP on L2 and only fixes the failover *timing*.

## Rollout / blast radius
DaemonSet rolls one pod at a time (masters only). When the owner's (master3) pod restarts, the VIP briefly fails over (~seconds) — which also live-validates the new timers. No worker, brain, firewall, or BGP changes.

## Known limitation
This fixes lease-driven failover. A truly wedged-but-not-dead node can still keep its kernel ARP-responding for the VIP until it fully dies/reboots; the new leader's gratuitous ARP overrides client caches within the shortened window. Full belt-and-suspenders for a wedged node is node-level auto-recovery (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)