### PR TITLE
fix(qbittorrent): decouple memory soft cap from hard limit to stop OOMKills

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -39,12 +39,14 @@ spec:
               tag: 5.2.3@sha256:4fcf15b7f265c2c8d7bc2a7e13240a07e0593c326f3cf3b5b9bb69eec5b79299
 
             env:
-              QBT_Application__MemoryWorkingSetLimit:
-                valueFrom:
-                  resourceFieldRef:
-                    containerName: app
-                    resource: limits.memory
-                    divisor: 1Mi
+              # Soft cap MUST sit below limits.memory so qBittorrent sheds
+              # cache before the kernel OOMKills. Deriving it from limits.memory
+              # set cap == hard limit (both 10.24 GiB), so libtorrent buffer
+              # overhead pushed total usage past the ceiling before the soft cap
+              # ever forced a shed → repeated OOMKills. 10240 MiB (10 GiB) caps
+              # just under the observed ~10.2 GiB working-set peak and leaves
+              # ~1.18 GiB headroom under the 12G limit.
+              QBT_Application__MemoryWorkingSetLimit: "10240"
               QBT_BitTorrent__Session__Interface: vxlan0
               QBT_BitTorrent__Session__InterfaceAddress:
                 valueFrom:
@@ -80,7 +82,7 @@ spec:
                 cpu: 35m
                 memory: 8G
               limits:
-                memory: 11G
+                memory: 12G
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem

qBittorrent was being OOMKilled repeatedly (5 restarts against its 11G limit). Each unclean shutdown truncated config files on the Longhorn config PVC — `watched_folders.json`, `web_clientdata.json`, and one torrent's `.fastresume` all came back corrupt after this morning's kill (~05:46 EDT). The backend reloads its torrents fine on restart, but the stale WebUI session showed an empty list, which is what surfaced the issue.

## Root cause

`QBT_Application__MemoryWorkingSetLimit` was derived from `limits.memory` via `resourceFieldRef` (divisor `1Mi`), which set qBittorrent's internal cache-shed target to **10491 MiB** — identical to the cgroup OOM ceiling (`11G` = 10.24 GiB).

Working set ≠ total RSS: libtorrent's disk buffers and malloc overhead sit on top of working set, so total container usage crossed the hard limit *before* the soft cap ever forced a shed. The soft cap could never rescue the pod because it was aiming at the exact number the kernel kills at — zero headroom by construction.

## Fix

- Hardcode `MemoryWorkingSetLimit` to `10240` MiB (10 GiB) — just under the observed ~10.2 GiB working-set peak, decoupled from `limits.memory`.
- Raise `limits.memory` `11G → 12G` (11.18 GiB), leaving ~1.18 GiB of headroom below the OOM ceiling for non-working-set overhead.

## Evidence

- 48h working-set trend: classic sawtooth ramping to ~10.1–10.3 GiB then OOMKill/restart, on repeat.
- worker3 has ~39 GiB memory available (62.3 GiB total), so the limit bump introduces no node pressure.

## Impact

Rolls the qBittorrent StatefulSet pod once on apply (env change). Backend restores all torrents from its state files on restart. Routine-tier download client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)