### PR TITLE
fix(immichkiosk): enable video playback via correct KIOSK_SHOW_VIDEOS key

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -77,7 +77,8 @@ spec:
               KIOSK_IMAGE_EFFECT_AMOUNT: 100
               KIOSK_USE_ORIGINAL_IMAGE: true
               # Video display settings
-              KIOSK_ALBUM_VIDEO: true
+              KIOSK_SHOW_VIDEOS: true
+              # KIOSK_EXCLUDE_VIDEOS_OVER: 0  # seconds; 0 = no cap
               # Image metadata
               KIOSK_SHOW_ALBUM_NAME: false
               KIOSK_SHOW_PERSON_NAME: true

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -82,8 +82,9 @@ spec:
               KIOSK_IMAGE_EFFECT: smart-zoom
               KIOSK_IMAGE_EFFECT_AMOUNT: 100
               KIOSK_USE_ORIGINAL_IMAGE: false
-              # Vdieo display settings
-              KIOSK_ALBUM_VIDEO: true
+              # Video display settings
+              KIOSK_SHOW_VIDEOS: true
+              # KIOSK_EXCLUDE_VIDEOS_OVER: 0  # seconds; 0 = no cap
               # Image metadata
               KIOSK_SHOW_ALBUM_NAME: false
               KIOSK_SHOW_PERSON_NAME: true


### PR DESCRIPTION
## What

Both `immichkiosk` and `immichkiosk-party` set `KIOSK_ALBUM_VIDEO: true` to try to enable video. That key is **not recognized by immich-kiosk in any version** — verified against the config struct at `v0.40.0`, `v0.41.0`, `v0.42.0` (our pinned tag) and `main`. Unknown `KIOSK_*` env vars are silently ignored, so video playback was never actually on. The real flag is `KIOSK_SHOW_VIDEOS` (default `false`).

The ImmichFrame apps on the Frameo frames render these kiosk endpoints in their webview, so this HelmRelease is the correct layer for the toggle.

## Changes

- `KIOSK_ALBUM_VIDEO: true` → `KIOSK_SHOW_VIDEOS: true` in both HelmReleases
- Fix the `# Vdieo` comment typo
- Add a commented `KIOSK_EXCLUDE_VIDEOS_OVER` placeholder for future length capping

## Prerequisites (already satisfied)

- `KIOSK_PREFETCH: true` — required for video
- writable `/tmp` emptyDir — the video manager's scratch dir

## Notes for verification after merge

Video will only actually play if, downstream of kiosk: (1) the Frameo Android System WebView is ≥ v101, and (2) Immich is serving H.264 for the clips (its transcode policy is global/rule-based, not per-album).

🤖 Generated with [Claude Code](https://claude.com/claude-code)