### PR TITLE
refactor(dragonfly): split evicting cache tier off the durable instance

### DIFF
--- a/kubernetes/apps/collab/nametag/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/nametag/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
               LOG_LEVEL: debug
               NEXTAUTH_URL: http://localhost:3000
               NEXT_PUBLIC_APP_URL: http://localhost:3000
-              REDIS_URL: redis://dragonfly.databases.svc.cluster.local:6379/0 # redis://:${REDIS_PASSWORD}@redis:6379
+              REDIS_URL: redis://dragonfly.databases.svc.cluster.local:6379/6 # own db index (db6); no longer shares db0
 
             envFrom: *envFrom
 

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -84,8 +84,9 @@ spec:
               PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: "true"
               # Configure OCR
               PAPERLESS_OCR_LANGUAGE: eng
-              # Configure redis integration
-              PAPERLESS_REDIS: redis://dragonfly.databases.svc.cluster.local:6379/0
+              # Configure redis integration (celery broker). Own db index
+              # (db7) so it no longer shares db0 with other tenants.
+              PAPERLESS_REDIS: redis://dragonfly.databases.svc.cluster.local:6379/7
 
             envFrom: *envFrom
 

--- a/kubernetes/apps/collab/searxng/app/resources/settings.yml
+++ b/kubernetes/apps/collab/searxng/app/resources/settings.yml
@@ -5,8 +5,10 @@ server:
   limiter: false
   image_proxy: true
 
-redis:
-  url: redis://dragonfly.databases.svc.cluster.local:6379?db=10
+# No redis: the limiter is off, so searxng needs no shared cache. The
+# prior `redis:` stanza pointed at dragonfly db10 but searxng-allow never
+# permitted egress to databases:6379, so it was unreachable dead config
+# (0 live keys). Removed rather than wired up — fewer moving parts.
 
 search:
   safe_search: 0

--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-cache.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-cache.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-cache
+spec:
+  labels:
+    dragonflydb.io/cluster: dragonfly-cache
+  image: ghcr.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
+  # Regenerable-cache tier. Single replica: the data is reconstructable
+  # (renovate repository cache), so node-loss HA is not worth 3x the RAM.
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1280Mi
+    limits:
+      memory: 1280Mi
+  networkPolicyEnabled: false
+  # --cache_mode makes this instance EVICT (LRU-style) when it reaches
+  # --maxmemory instead of returning `ERR Out of memory`. Correct for a
+  # pure cache: a full cache should shed cold keys, never refuse writes.
+  # This is the property the shared instance lacked (noeviction) that let
+  # renovate's cache jam authelia/immich/paperless. Isolating renovate
+  # here means its churn can never again reach the durable instance.
+  # --maxmemory stays strictly below limits.memory (RSS overhead sits on
+  # top) so background activity can't OOM-kill the pod.
+  args:
+    - "--maxmemory=1024Mi"
+    - "--cache_mode=true"
+    - "--proactor_threads=2"
+    - "--cluster_mode=emulated"

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-cache.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-cache.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly-cache-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly-cache
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Consumers of `dragonfly-cache.databases.svc.cluster.local:6379`:
+    #   renovate/renovate — repository cache (the only tenant today)
+    # Same rationale as the durable instance's policy: fromEntities:
+    # cluster on 6379 rather than a fragile per-pod enumeration.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow.yaml
@@ -14,17 +14,16 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Known consumers (`dragonfly.databases.svc.cluster.local:6379`):
-    #   auth/authelia         — session store
-    #   collab/nametag        — caching backend
-    #   collab/paperless      — broker / cache
-    #   collab/searxng        — redis cache (db=10)
-    #   collab/zulip          — broker / cache
-    #   collab/pump           — broker
-    #   home/netbox           — caching + django-q broker
-    #   media/immich          — task queue
-    #   media/romm            — task queue
-    #   renovate/renovate     — caching
+    # Durable tier (sessions + queues, noeviction). Consumers of
+    # `dragonfly.databases.svc.cluster.local:6379`, by db index:
+    #   auth/authelia    db5 — session store
+    #   media/immich     db1 — BullMQ task queue
+    #   home/netbox      db3 — task queue   / db4 — django cache
+    #   collab/paperless db7 — celery broker
+    #   media/romm       db2 — RQ task queue
+    #   collab/nametag   db6 — session / cache
+    # The pure-cache hog (renovate) lives on the separate evicting
+    # `dragonfly-cache` instance so its churn can't jam this tier.
     # Enumerating each per-pod selector across 6 namespaces is fragile.
     # Use fromEntities: cluster on port 6379 — the cross-cluster /
     # default-deny boundary is what matters; missing a consumer here

--- a/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
@@ -3,6 +3,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cluster-cache.yaml
   - ./cluster.yaml
+  - ./cnp-allow-cache.yaml
   - ./cnp-allow.yaml
+  - ./podmonitor-cache.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/databases/dragonfly/cluster/podmonitor-cache.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/podmonitor-cache.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dragonfly-cache
+spec:
+  selector:
+    matchLabels:
+      app: dragonfly-cache
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin

--- a/kubernetes/apps/media/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/media/romm/app/helmrelease.yaml
@@ -73,6 +73,9 @@ spec:
               # Runtime
               ROMM_PORT: &port 8080
               ROMM_DB_DRIVER: postgresql
+              # Redis (host/port from ExternalSecret). Own db index (db2)
+              # so RQ queue keys no longer share db0 with other tenants.
+              REDIS_DB: "2"
 
               # Scrapers / scheduled jobs
               ENABLE_SCHEDULED_RESCAN: "true"

--- a/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
@@ -27,12 +27,14 @@ spec:
     ingress: false
   egress:
     # Dragonfly (Redis) in databases ns — RENOVATE_REDIS_URL is set to
-    # `redis://dragonfly.databases.svc.cluster.local:6379` for the
-    # repository cache shared across runs.
+    # `redis://dragonfly-cache.databases.svc.cluster.local:6379` for the
+    # repository cache shared across runs. This is the dedicated evicting
+    # cache instance, NOT the durable `dragonfly` instance — renovate was
+    # split off so its cache churn can't jam sessions/queues there.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: databases
-            app.kubernetes.io/name: dragonfly
+            app.kubernetes.io/name: dragonfly-cache
       toPorts:
         - ports:
             - port: "6379"

--- a/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
@@ -33,7 +33,7 @@ spec:
       value: >-
         [{"hostType":"docker","matchHost":"docker.io","username":"$(DOCKERHUB_USERNAME)","password":"$(DOCKERHUB_TOKEN)"}]
     - name: RENOVATE_REDIS_URL
-      value: redis://dragonfly.databases.svc.cluster.local:6379
+      value: redis://dragonfly-cache.databases.svc.cluster.local:6379
     - name: RENOVATE_REPOSITORY_CACHE
       value: enabled
     - name: RENOVATE_CACHE_PRIVATE_PACKAGES

--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump-repo.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump-repo.yaml
@@ -37,7 +37,7 @@ spec:
     - name: RENOVATE_PLATFORM_COMMIT
       value: disabled  # Matches rwlove-home-ops; enabled trips a repo-changed abort.
     - name: RENOVATE_REDIS_URL
-      value: redis://dragonfly.databases.svc.cluster.local:6379
+      value: redis://dragonfly-cache.databases.svc.cluster.local:6379
     - name: RENOVATE_REPOSITORY_CACHE
       value: enabled
     - name: RENOVATE_CACHE_PRIVATE_PACKAGES

--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
@@ -18,7 +18,7 @@ spec:
     - name: RENOVATE_PLATFORM_COMMIT
       value: enabled
     - name: RENOVATE_REDIS_URL
-      value: redis://dragonfly.databases.svc.cluster.local:6379
+      value: redis://dragonfly-cache.databases.svc.cluster.local:6379
     - name: RENOVATE_REPOSITORY_CACHE
       value: enabled
     - name: RENOVATE_CACHE_PRIVATE_PACKAGES

--- a/kubernetes/apps/renovate/renovate-operator/ks.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/ks.yaml
@@ -54,3 +54,5 @@ spec:
   dependsOn:
     - name: renovate-operator
     - name: renovate-github-auth
+    - name: dragonfly-cluster
+      namespace: databases


### PR DESCRIPTION
## Problem

The shared Dragonfly (redis-compatible) instance ran **noeviction** at `--maxmemory=768Mi` with 8 tenants mixing **cache, sessions, and queues** in one keyspace. Renovate's repository cache filled it, and with no eviction policy Dragonfly returned `ERR Out of memory` on every new write — **82k+ `oom_errors` on the master**, jamming authelia sessions and immich/paperless/romm queues alike. Not a k8s OOMKill (RSS < 1Gi limit) — a self-inflicted soft cap.

Audit of all 8 consumers (db index / auth / usage) confirmed the collision: renovate (cache), paperless (celery), romm (RQ), nametag (session) all piled into `db0`.

## Fix — isolate the cache hog, de-collide the rest

- **New `dragonfly-cache` instance** — `--cache_mode=true` (evicts LRU instead of erroring), `replicas: 1` (data is regenerable), `maxmemory 1024Mi`. Renovate (3 jobs + CNP egress + ks `dependsOn`) repointed to it. Its churn can never again reach the durable tier.
- **Durable `dragonfly` instance left unchanged** — no CR roll, so **authelia sessions are preserved** (no re-login). De-collided `db0`: paperless→`db7`, nametag→`db6`, romm→`db2` (authelia `db5`, immich `db1`, netbox `db3`/`db4` were already isolated). `db0` is now tenant-less and reclaimable without touching sessions.
- **Removed searxng's dead redis stanza** — limiter is off and its CNP never permitted egress to `databases:6379`, so it was unreachable dead config (0 live keys). Fewer moving parts.

## Rollout note

Merging moves renovate's *new* writes to the cache instance, but renovate's **existing ~700 MB of orphaned keys stay in durable `db0`** until they TTL-expire (1–7 d). A surgical `FLUSHDB` on durable `db0` after reconcile reclaims that memory and unjams the durable tier **without touching authelia's `db5`** — done as a follow-up op, not in this PR.

## Deferred (focused follow-ups, kept out to avoid multiplying outage risk on the auth-adjacent path)

`--requirepass` auth · durable-tier snapshotting · tightening the permissive `fromEntities: cluster` ingress CNP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)