### PR TITLE
chore(collab): bump pump v0.2.6 + pump-voltra v0.1.9

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.8@sha256:cebcafe82ff68dd554d8161e0f689d7ad979188bc8082c6dd63a4cd4c9c4de91
+              tag: v0.1.9@sha256:4dcf60da11f75d6ae5ef3c7c8bda3ab9fd574c49091581c5f0ff1ed39b2e07e9
 
             env:
               VOLTRA_ENABLED: "true"

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.5@sha256:b780d27c729f9b2ebcb5dcd9677643cb6f7e4940c2e50801c835c2b720d760c3
+              tag: v0.2.6@sha256:6cc030ff924cfb05df6e5817e989b21a42d216fb1a5e7b9050c81da7b51350fc
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Manual digest bump — deploys the Voltra failing-load cancel path + reconcile retry-storm backoff (rwlove/PUMP#131).

**Why manual:** the Renovate auto-path was jammed on the Dragonfly cache OOM (fixed in #13733); the last hourly run (13:00Z) finished ~5 min before that fix merged, so it still OOM'd and never opened the auto-merge PRs. This unblocks the deploy without waiting for the 14:00Z run. Idempotent with Renovate — a recovered run sees these tags already current.

- `pump` → `v0.2.6@sha256:6cc030ff…50fc` (server image; JS cancel path)
- `pump-voltra` → `v0.1.9@sha256:4dcf60da…07e9` (sidecar; reconcile backoff — rolls first)

Non-destructive rolling update. No schema change.