### PR TITLE
chore(immich): temporarily enable transcode for frame-album video (revert follows)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -22,7 +22,7 @@ spec:
           {
             "ffmpeg": {
               "targetResolution": "1080",
-              "transcode": "disabled",
+              "transcode": "required",
               "realtime": {
                 "enabled": true,
                 "videoCodecs": ["h264", "hevc"],


### PR DESCRIPTION
**Temporary maintenance change — a revert PR to `disabled` follows immediately.**

## Why
immich-kiosk serves Immich's transcoded video to the Frameo frames, whose WebView 101 only decodes H.264. The ImmichFrame album has one HEVC clip that won't play. With `ffmpeg.transcode: disabled`, a targeted `transcode-video` job no-ops (verified live), so the policy must briefly be `required` to let Immich produce a stored h264 transcode for that asset.

## Scope / safety
- Only the album's asset ID(s) get a transcode job triggered. **Changing the policy does not re-transcode the existing library** — Immich only transcodes assets a job is explicitly run on.
- The only exposure is auto-transcode-on-upload for any *new* video uploaded during the brief window; verified via encoded-file delta before revert.
- Steady state returns to `disabled` in the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)