### PR TITLE
feat(local-cron): unsuspend the local-model summarizer tier

### DIFF
--- a/kubernetes/apps/ai/local-cron/README.md
+++ b/kubernetes/apps/ai/local-cron/README.md
@@ -64,10 +64,14 @@ ingress. Two holes were punched:
   no ingress rules (only intra-ns Grafana/Vector via baseline), so this
   cross-ns caller had to be listed explicitly or it would silent-drop.
 
-## Activation (shipped suspended)
+## Activation
 
-Both the Flux `ks.yaml` and the CronJob ship `suspend: true`. Activate in
-order:
+**Status: ACTIVE as of 2026-08-23** — the ks and both CronJobs are
+unsuspended and running on their schedules. To pause, re-add
+`spec.suspend: true` to the CronJob (fast, keeps objects) or to the ks
+(prunes the app's objects on next reconcile).
+
+The original first-time activation order, for reference:
 
 1. **Confirm the model is pullable/loadable.** `qwen2.5:7b` is already the
    khoj default and Open WebUI-selectable on this Ollama, so it is

--- a/kubernetes/apps/ai/local-cron/app/cronjob-loki-error-skim.yaml
+++ b/kubernetes/apps/ai/local-cron/app/cronjob-loki-error-skim.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: local-cron
 spec:
-  # SHIPPED SUSPENDED (see ./README.md → Activation). Even with the ks
-  # unsuspended, this CronJob does not fire until `spec.suspend` is removed.
-  suspend: true
+  # ACTIVE (unsuspended 2026-08-23). Governed by the claude-runner trial
+  # policy (.agents/instructions/claude-runner-routing.md) — re-add
+  # `suspend: true` to pause without tearing down objects.
   # 0 12 * * * UTC = 08:00 EDT / 07:00 EST, daily. Well after the 00:00 UTC
   # Longhorn recurring-job window and off the mcp-gateway 04:30 rotation, so
   # the P40 model load doesn't collide with other scheduled bursts. Local

--- a/kubernetes/apps/ai/local-cron/app/cronjob-renovate-pr-digest.yaml
+++ b/kubernetes/apps/ai/local-cron/app/cronjob-renovate-pr-digest.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: local-cron
 spec:
-  # SHIPPED SUSPENDED (see ./README.md → Activation). Even with the ks
-  # unsuspended, this CronJob does not fire until `spec.suspend` is removed.
-  suspend: true
+  # ACTIVE (unsuspended 2026-08-23). Governed by the claude-runner trial
+  # policy (.agents/instructions/claude-runner-routing.md) — re-add
+  # `suspend: true` to pause without tearing down objects.
   # 30 12 * * * UTC = 08:30 EDT / 07:30 EST, daily — 30 min after the
   # loki-error-skim (0 12) so the two don't share a P40 model-load spike,
   # and off the mcp-gateway 04:30 rotation. Daily is justified here: this

--- a/kubernetes/apps/ai/local-cron/ks.yaml
+++ b/kubernetes/apps/ai/local-cron/ks.yaml
@@ -5,14 +5,12 @@ kind: Kustomization
 metadata:
   name: &app local-cron
 spec:
-  # SHIPPED SUSPENDED. Phase 2 of the local-model cron tier: a daily Loki
-  # error-pattern skim summarized by the in-cluster Ollama (NOT Claude /
-  # Anthropic — no API key anywhere) and pushed to Pushover. Activation is
-  # a two-step unsuspend documented in ./app/README.md. Do not remove this
-  # `suspend` on a whim; it runs against a prod cluster. The CronJob inside
-  # is ALSO `suspend: true`, so even an unsuspended ks reconciles the
-  # objects without firing a run until the CronJob is explicitly enabled.
-  suspend: true
+  # ACTIVE (unsuspended 2026-08-23). Phase 2 of the local-model cron tier:
+  # local-model (Ollama — NOT Claude/Anthropic, no API key anywhere)
+  # summarizers pushed to Pushover. Both CronJobs (Loki error-skim +
+  # Renovate PR digest) are now unsuspended and run on their schedules.
+  # Retention is governed by the claude-runner trial policy
+  # (.agents/instructions/claude-runner-routing.md).
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app


### PR DESCRIPTION
## What

Activates Phase 2 (the local/Ollama summarizer tier). Removes `spec.suspend: true` from:

- `local-cron/ks.yaml` (Flux Kustomization)
- `cronjob-loki-error-skim.yaml` — daily **12:00 UTC**
- `cronjob-renovate-pr-digest.yaml` — daily **12:30 UTC**

Flux then reconciles the ExternalSecret (`local-cron-secret`) + CNP + RBAC + both CronJobs; the jobs run on schedule, summarizing on the in-cluster Ollama (`qwen2.5:7b`, P40) and posting one Pushover message each. **Zero Anthropic tokens** (HOMELAB-SPEC L6). Both are silent on empty input (no error lines / no open Renovate PRs → exit 0, no notification).

## Note

Neither job has had a live in-cluster run yet (they shipped suspended). `kubectl` isn't reachable from my environment and the cluster MCP is read-only, so I couldn't run the documented out-of-band `create job --from=cronjob` test first. I'll watch the first scheduled runs via the read-only MCP (job success + a delivered/`silent` outcome) and report. If either misfires, re-adding `suspend: true` to that CronJob pauses it without teardown.

## Verified here
- No `spec.suspend` fields remain in the app.
- `kubectl kustomize` renders clean (2 CronJobs).
- All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)