### PR TITLE
chore(immich): revert transcode policy to disabled (frame-album video complete)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -22,7 +22,7 @@ spec:
           {
             "ffmpeg": {
               "targetResolution": "1080",
-              "transcode": "required",
+              "transcode": "disabled",
               "realtime": {
                 "enabled": true,
                 "videoCodecs": ["h264", "hevc"],


### PR DESCRIPTION
Reverts the temporary flip in #13736. The ImmichFrame album's one HEVC clip now has a stored h264 transcode (verified: `/video/playback` returns h264 1080). That transcode **persists** across this revert — Immich only removes a transcode when a job re-runs on the asset under a non-transcoding policy, which won't happen.

Leak check confirmed only the targeted album asset was transcoded during the window (encoded-file delta = exactly 1).

Steady state restored: `ffmpeg.transcode: disabled` — nothing in the library auto-transcodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)