### PR TITLE
feat(collab): pump set-note dictation → self-hosted whisper

### DIFF
--- a/kubernetes/apps/collab/pump/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump/app/cnp-allow.yaml
@@ -35,6 +35,20 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
+    # Wyoming faster-whisper in home ns — set-note dictation relays
+    # browser-captured PCM through pump's /api/stt to this ASR service
+    # (WHISPER_WYOMING_ADDR), so audio stays on the network. The
+    # controller label pins it to the whisper sub-service, not kokoro/
+    # openwakeword which share app.kubernetes.io/name: wyoming-services.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: wyoming-services
+            app.kubernetes.io/controller: whisper
+      toPorts:
+        - ports:
+            - port: "10300"
+              protocol: TCP
   # Intra-ns pump-cv:8080 (PUMP_CV_URL admin/preview proxy) is
   # covered by baseline allow-intra-namespace.
   ingress:

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -81,6 +81,13 @@ spec:
               # autosave. Env-only — there is no Settings toggle for it, unlike
               # CVAutoLog.
               VOLTRA_AUTOLOG: "true"
+              # Self-hosted speech-to-text for set-note dictation. The workout
+              # page captures mic audio, downsamples to 16 kHz mono PCM, and
+              # POSTs it to pump's /api/stt, which relays it to this Wyoming
+              # faster-whisper service — audio never leaves the network (the
+              # browser's cloud Web Speech API is what this replaced). Egress
+              # to home ns :10300 is punched in cnp-allow.yaml.
+              WHISPER_WYOMING_ADDR: wyoming-services-whisper.home.svc.cluster.local:10300
 
             envFrom:
               - secretRef:

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.6@sha256:6cc030ff924cfb05df6e5817e989b21a42d216fb1a5e7b9050c81da7b51350fc
+              tag: v0.2.7@sha256:536c86298bbc924ab7849687f2044e0df2baef4574549464d78c615d6446d7f5
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Wires pump's new `/api/stt` (rwlove/PUMP#132, `pump-v0.2.7`) to the in-cluster Wyoming faster-whisper service, so mic dictation of set notes runs **locally** instead of the browser's cloud Web Speech API — audio never leaves the network.

- `WHISPER_WYOMING_ADDR` → `wyoming-services-whisper.home.svc.cluster.local:10300`
- CNP egress `collab`→`home:10300`, pinned to the whisper sub-service via `app.kubernetes.io/controller: whisper` (kokoro/openwakeword share `name: wyoming-services`). Mirrors the existing EMQX egress rule.

Protocol framing was validated against the live whisper service before merge. `pump-v0.2.7` image is building; this can merge once it's published (Flux pulls the digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)