### PR TITLE
feat(home): allow pump→whisper ingress for set-note dictation

### DIFF
--- a/kubernetes/apps/home/wyoming-services/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/wyoming-services/app/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: wyoming-whisper-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: wyoming-services
+      app.kubernetes.io/controller: whisper
+  # Additive — the home-ns default-deny is the lockdown; this punches a hole.
+  # HA's own voice pipeline reaches whisper intra-namespace (allow-intra-
+  # namespace covers it); this only adds the cross-namespace pump consumer.
+  # Scoped to the whisper sub-service via the controller label so kokoro /
+  # openwakeword (same app name) are untouched.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # pump (collab ns) set-note dictation: pump's /api/stt relays browser-
+    # captured audio here over the Wyoming protocol (10300). Mirrors the
+    # pump ingress rule in emqx-allow; the matching egress hole is in
+    # collab/pump/app/cnp-allow.yaml.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: pump
+      toPorts:
+        - ports:
+            - port: "10300"
+              protocol: TCP

--- a/kubernetes/apps/home/wyoming-services/app/kustomization.yaml
+++ b/kubernetes/apps/home/wyoming-services/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
 resources:
   - ./helmrelease.yaml
+  - ./cnp-allow.yaml
 configMapGenerator:
   - files:
       - hey_piper.tflite=./resources/hey_piper.tflite


### PR DESCRIPTION
Completes the dictation path from rwlove/PUMP#132 (`pump-v0.2.7`, home-ops #13739).

**Why:** the `home`-ns `default-deny` drops cross-namespace ingress, and `wyoming-services` had no CiliumNetworkPolicy. So even with the egress hole open on the pump side (#13739), pump's `/api/stt` timed out dialing `whisper:10300` — verified live: `dial tcp 10.43.119.249:10300: i/o timeout`.

**Fix:** add the matching ingress allow on the whisper sub-service (scoped via `app.kubernetes.io/controller: whisper` so kokoro/openwakeword are untouched; HA's own intra-namespace voice path is unaffected). Mirrors the `collab/pump` ingress rule already in `emqx-allow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)