### PR TITLE
fix(dragonfly): correct dragonfly-cache CNP selector (renovate cross-ns drop)

### DIFF
--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-cache.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-cache.yaml
@@ -5,9 +5,15 @@ kind: CiliumNetworkPolicy
 metadata:
   name: dragonfly-cache-allow
 spec:
+  # The dragonfly-operator stamps app.kubernetes.io/name=dragonfly on EVERY
+  # instance and puts the instance name in `app` (mirrors the Service
+  # selector). Selecting on app.kubernetes.io/name=dragonfly-cache matched
+  # zero pods, so this policy was a no-op and renovate's cross-namespace
+  # connections were default-denied (silent drop → 5s timeout → every
+  # renovate run failed since the split landed, #13733).
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: dragonfly-cache
+      app: dragonfly-cache
   # Additive — default-deny is what triggers the lockdown; these rules
   # punch holes through it.
   enableDefaultDeny:


### PR DESCRIPTION
## Incident

Every RenovateJob has failed on **Redis connection timeout** since the Dragonfly cache-tier split (#13733) landed at **09:07 EDT today**. Discovery exits non-zero → no per-repo jobs spawn → no PRs created → the Renovate dashboard's checked boxes never get processed. This is why nothing has been merging.

## Root cause

The dragonfly-operator stamps `app.kubernetes.io/name=dragonfly` on **every** instance and carries the instance name in the `app` label (mirroring the Service selector). The cache tier's ingress policy added in #13733 selected:

```yaml
endpointSelector:
  matchLabels:
    app.kubernetes.io/name: dragonfly-cache   # matches ZERO pods
```

So `dragonfly-cache-allow` was a no-op, and renovate's cross-namespace connections to `dragonfly-cache:6379` were default-denied (silent drop → 5s connect timeout).

## Verification (live)

- `dragonfly-cache-0` serves locally → `PONG`; no `requirepass`; pod Ready.
- Reachable **intra-namespace** (durable `dragonfly-0` → cache service → `PONG`), via `allow-intra-namespace`.
- **Cross-namespace** from `renovate` times out — the only broken edge.
- Pod labels confirm: `app.kubernetes.io/name=dragonfly`, `app=dragonfly-cache`.

## Fix

Select on `app: dragonfly-cache` (matches the pod and the Service selector).

## Blast radius

Contained to the `renovate` cache path. The durable `dragonfly` instance (authelia sessions, immich, netbox, paperless, romm) is separate and was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)