### PR TITLE
fix(renovate): correct dragonfly-cache egress selector on job pods

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
@@ -31,10 +31,16 @@ spec:
     # repository cache shared across runs. This is the dedicated evicting
     # cache instance, NOT the durable `dragonfly` instance — renovate was
     # split off so its cache churn can't jam sessions/queues there.
+    # The dragonfly-operator stamps app.kubernetes.io/name=dragonfly on
+    # EVERY instance and carries the instance name in `app` (mirrors the
+    # Service selector). Selecting the cache by app.kubernetes.io/name
+    # matched zero pods, so this egress allow was a no-op and the job
+    # pods' Redis connections were default-denied at source (silent drop
+    # → 5s timeout). Twin of the cache-side ingress fix (#13741).
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: databases
-            app.kubernetes.io/name: dragonfly-cache
+            app: dragonfly-cache
       toPorts:
         - ports:
             - port: "6379"


### PR DESCRIPTION
Twin of #13741. After the cache-side **ingress** fix landed, renovate executor pods **still** hit @redis/client connection timeout — because the job pods' **egress** allow had the same label defect.

`renovate-jobs-allow` selected the cache egress target by `app.kubernetes.io/name: dragonfly-cache`, which the dragonfly-operator never sets (it stamps `app.kubernetes.io/name=dragonfly` on every instance and carries the instance name in `app`). So the egress allow matched zero pods, the job pods' Redis connections were default-denied at source, and every run failed on a 5s connect timeout.

## Verification
- #13741 fixed the cache **ingress** policy, but per-repo processing pods still timed out on Redis.
- Root: source-side **egress** drop. This is the missing half.

## Fix
Select on `app: dragonfly-cache` (matches the pod and the Service selector), mirroring #13741. Both the cache's ingress and the job pods' egress now resolve to a real endpoint.

## Blast radius
Contained to the renovate cache path. Durable `dragonfly` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
