### PR TITLE
fix(immichkiosk): raise memory to 1Gi/2Gi for video playback (OOMKilled)

### DIFF
--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -119,9 +119,13 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 256Mi
+                # Video playback (KIOSK_SHOW_VIDEOS, #13732) downloads +
+                # decodes clips in-memory, spiking well past the old
+                # 512Mi (OOMKilled 2026-08-23). Matches the video-sized
+                # immichkiosk-party variant.
+                memory: 1Gi
               limits:
-                memory: 512Mi
+                memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Problem

`immichkiosk-0` is OOMKilling (exit 137, restart #4, last kill 2026-08-23 13:14:58 EDT).

## Root cause

#13732 enabled video playback on the main kiosk via the correct `KIOSK_SHOW_VIDEOS` key, but left the **pre-video** `256Mi request / 512Mi limit` in place. Video download + in-memory decode spikes past 512Mi. The log line immediately before each kill is `Downloaded video path=/tmp/immich-kiosk/videos/…mp4`.

Steady-state working set is only 40–95 MiB, so the spike is transient and video-triggered — which is why 5-minute Prometheus samples never show memory climbing toward the limit.

## Fix

Match the video-sized `immichkiosk-party` variant (`1Gi request / 2Gi limit`), which has shown videos without OOM all along.

## Impact

One pod roll on merge (Renee-facing photo display, `media` ns). No data risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)