### PR TITLE
feat(ai): add adoption-scout claude-runner cron (discovery-only)

### DIFF
--- a/.agents/instructions/claude-runner-routing.md
+++ b/.agents/instructions/claude-runner-routing.md
@@ -102,7 +102,8 @@ maintenance cost exceeds value; or it just isn't used.
    CronJobs, the shell, the vault-bridge, and the (ceph-block, regenerable) PVCs.
 2. Revert the cross-ns CNP ingress additions (`prometheus-allow`, `loki`,
    `obsidian-couchdb-allow`) added for the runner.
-3. Delete the `claude-runner` OAuth token from 1Password.
+3. Delete the `claude-runner` OAuth token **and the `github_issue_token`
+   fine-grained PAT** from the 1Password `claude-runner` item.
 4. **Leave intact** (independent of the trial): the Obsidian `claude` CouchDB db + vault
    sync, the Flatpak fix, the `containers` tmux image.
 

--- a/.agents/skills/feature-adoption.md
+++ b/.agents/skills/feature-adoption.md
@@ -1,0 +1,54 @@
+---
+name: feature-adoption
+description: Turn an adoption-scout feature candidate into a verified, pre-submitted PR
+---
+
+# Feature adoption
+
+The interactive back-end for the **feature** half of the `adoption-scout`
+digest (the workaround half is `upstream-watcher.md`). The scout only reports
+candidates in a public GitHub issue; this skill turns one into a PR.
+
+## When to use
+
+When a digest line (or your own reading of a chart/image bump) proposes a new
+upstream feature home-ops should adopt, and you want to author the change.
+
+## Inputs
+
+- An `adoption-scout` issue candidate: app, deployed version, the feature, the
+  proposed next action (file / values key).
+- The deployed version of the chart/image (from the HelmRelease /
+  OCIRepository — Git is canonical).
+
+## Workflow
+
+1. **Re-verify against the DEPLOYED version.** This is the load-bearing step —
+   release-note research skews optimistic, and roughly half of candidates
+   evaporate here (see `feedback_verify_adoptable_features_against_deployed_version`
+   in memory). Confirm the feature/option actually exists in the version we
+   pin — not upstream main — by checking that version's chart `values.yaml` /
+   CRD / release notes. If it isn't there yet, stop and note the version it
+   lands in.
+2. **Confirm it fits our architecture.** A feature that assumes a component,
+   runtime, or topology we don't run is not adoptable. Check the relevant
+   per-domain instruction file (`storage-class`, `helmrelease.security`,
+   `gpu-routing`, …) before proposing the change.
+3. **Make the change** in a dated worktree per `CLAUDE.md` "Worktree
+   isolation". Keep it small and reviewable; one feature per PR. If it retires a
+   `# workaround:`, fold in the annotation removal and `Closes #N` the tracking
+   issue (that's the `upstream-watcher` overlap).
+4. **Run pre-submit** (`.agents/skills/pre-submit.md`) — kustomize build, schema
+   validation, sorting. Per HOMELAB-SPEC Layer 2 #6 the PR is the artifact of a
+   passing local run.
+5. **Open the PR.** Respect the 50-file blast-radius limit; scrub restricted
+   app names / media names / hostnames from the title and body
+   (`data-classification.md`).
+
+## What this is NOT
+
+- Not automated — the `adoption-scout` cron deliberately does not open PRs. The
+  ~50%-optimism rate and the pre-submit invariant make human authorship the
+  gate.
+- Not a version-bump tool — Renovate owns bumps. This adopts a *feature* a bump
+  made available.

--- a/.agents/skills/upstream-watcher.md
+++ b/.agents/skills/upstream-watcher.md
@@ -11,7 +11,13 @@ still necessary upstream.
 
 ## When to use
 
-Manually, ~weekly. Future: scheduled.
+Manually, ~weekly, to author the removal PRs. The **discovery** step is now
+scheduled: the `adoption-scout` claude-runner CronJob
+(`kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml`) re-checks
+`# workaround:` annotations + `workaround`-labeled issues weekly and reports
+retirable candidates in a public GitHub issue. This skill is the interactive
+**back-end**: it turns a scout candidate (or your own find) into a verified
+removal PR. The scout only reports; it never opens PRs.
 
 ## Inputs
 

--- a/kubernetes/apps/ai/claude-runner/README.md
+++ b/kubernetes/apps/ai/claude-runner/README.md
@@ -44,10 +44,31 @@ The Flux `ks.yaml` ships `suspend: true`. Activate in order:
 | Workflow | Schedule (UTC) | Tier | What |
 |---|---|---|---|
 | `flux-longhorn-drift-digest` | `0 13 * * 1` (Mon 09:00 EDT) | Claude | Read Flux/Longhorn health from Prometheus, reason about real drift + a fix, send ONE Pushover digest (private — reuses the alertmanager Pushover app). Silent when clean. |
+| `adoption-scout` | `0 14 * * 3` (Wed 10:00 EDT) | Claude | Shallow-clone the repo, review recently-bumped charts/images for adoptable new features (verified against the DEPLOYED version), and re-check `# workaround:` annotations + `workaround`-labeled issues for retirement. Posts ONE **public GitHub issue** (create-or-comment, label `adoption-scout`), naming only public-tier apps. Discovery-only — never opens PRs. Silent when clean. Kill if useful-output rate <30% after 2 weeks. |
 
 Summarize/triage-style checks (Renovate-PR summaries, log skims, doc-drift)
 do **not** go here — they are the local-model (`sgpt`) tier per HOMELAB-SPEC
 Layer 6.
+
+### `adoption-scout` — extra one-time setup
+
+Beyond Gate 0 (token + image + unsuspend), the scout needs:
+
+1. **GitHub write token.** A fine-grained PAT scoped to **Issues: Read+Write on
+   `rwlove/home-ops` only** (nothing else), stored on the 1P `claude-runner`
+   item: `op item edit "claude-runner" --vault Kubernetes github_issue_token=<pat>`.
+   The runner shell (not Claude) uses it to post the digest.
+2. **Label.** Create the `adoption-scout` GitHub label once — GitHub rejects
+   issue creation with a non-existent label:
+   `gh label create adoption-scout -R rwlove/home-ops -c FBCA04 -d "weekly adoption/workaround digest"`.
+3. **Image deps.** The runner image must ship `git` (for the shallow clone) and
+   `jq` (to build the issue JSON). Verify in the test run below; if `jq` is
+   missing, add it in the `containers` repo and bump the tag.
+4. **Test suspended → unsuspend.**
+   `kubectl -n ai create job --from=cronjob/claude-runner-adoption-scout adoption-scout-test`,
+   confirm it clones, produces a two-section digest naming **no** restricted-tier
+   apps, and opens exactly one labeled issue (a second run comments, not
+   duplicates), then remove `spec.suspend`.
 
 ## Interactive shell (survives laptop sleep)
 

--- a/kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml
@@ -1,0 +1,219 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: claude-runner-adoption-scout
+  labels:
+    app.kubernetes.io/name: claude-runner
+spec:
+  # Shipped SUSPENDED (trial). Discovery-only: this reviews recently-bumped
+  # charts/images for adoptable features and re-checks tracked workarounds for
+  # retirement, then posts ONE digest to a public GitHub issue. It NEVER opens
+  # PRs or edits the repo — PR authoring stays interactive (the ~50%-optimism
+  # lesson + the pre-submit invariant). See
+  # .agents/instructions/claude-runner-routing.md.
+  suspend: true
+  # 0 14 * * 3 UTC = Wed 10:00 EDT / 09:00 EST. Weekly, offset from the Mon
+  # drift-digest to spread the shared Max quota.
+  schedule: "0 14 * * 3"
+  timeZone: Etc/UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # 60 min: a shallow clone (~1 min) + one multi-turn review over ~15
+      # candidates with per-candidate release-note fetches.
+      activeDeadlineSeconds: 3600
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: claude-runner
+          annotations:
+            k8tz.io/inject: "false"
+        spec:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          serviceAccountName: claude-runner
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          containers:
+            - name: runner
+              image: ghcr.io/rwlove/claude-runner:v2.1.239
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ceu
+                - |
+                  echo "adoption-scout: shallow-cloning home-ops (public, read-only)..."
+                  rm -rf /scratch/repo
+                  # --shallow-since keeps ~40d of history so `git log --since=30d`
+                  # sees the recent bumps, while staying small. Public repo, no auth.
+                  git clone --shallow-since="40 days ago" --single-branch \
+                    https://github.com/rwlove/home-ops /scratch/repo || {
+                    echo "FATAL: clone failed"; exit 1; }
+
+                  # The analysis prompt (quoted heredoc — no shell expansion).
+                  cat > /tmp/prompt.md <<'PROMPT'
+                  You are the **adoption-scout** for the home-ops Kubernetes GitOps repo.
+                  Your working directory is a shallow clone of the repo (~40 days of
+                  history). Produce ONE markdown digest with two sections. You do NOT open
+                  PRs or edit files — you only report.
+
+                  ## DATA CLASSIFICATION — this digest becomes a PUBLIC GitHub issue
+                  - Apps under `kubernetes/apps/media/` or `kubernetes/apps/security/` are
+                    RESTRICTED. Do NOT name them, their charts, or their images. If you find
+                    adoptable candidates there, collapse them to ONE line per section:
+                    "N candidate(s) in restricted namespaces — review interactively."
+                  - Never include media file names, internal hostnames, IP/MAC addresses, or
+                    any secret value. Prefer roles ("the gateway") over names.
+                  - Public-tier app names, chart names, and versions ARE fine (public repo).
+
+                  ## SECTION 1 — Adoptable new features
+                  1. `git log --since="30 days ago" --oneline` and find commits that BUMPED a
+                     chart or image version (Renovate "chore(deps)"/"feat" bumps or manual
+                     version edits). Focus on minor/major bumps; skip pure patch bumps.
+                  2. For each bumped app, read its HelmRelease / OCIRepository / values in the
+                     working tree to confirm the version we ACTUALLY deploy now (use
+                     `git show`/`git diff` to see the prior version).
+                  3. WebFetch the upstream release notes/CHANGELOG for the range between the
+                     prior and current version. Identify any new feature/option home-ops
+                     would benefit from (security hardening, a capability we hand-roll today,
+                     a workaround we could drop, a resource-efficiency win).
+                  4. CRITICAL: verify the feature exists in the version we DEPLOY, not
+                     upstream main. Release-note research skews optimistic — ~half of
+                     candidates evaporate when checked against the pinned version. If you
+                     cannot confirm the feature is in our version, DROP it.
+                  5. Rank by value. Report at most 15. If you drop candidates for the cap or
+                     for failing verification, state HOW MANY you dropped and why (never
+                     silently truncate).
+
+                  For each surviving candidate: **app** - deployed **version** - the specific
+                  **feature** - **why** it helps here - concrete **next action** (which file /
+                  values key to change).
+
+                  ## SECTION 2 — Retirable workarounds
+                  1. `Grep` for `# workaround:` annotations across the repo (format in
+                     `.agents/instructions/workarounds.md`): each carries an upstream URL and
+                     a "remove when" condition.
+                  2. `curl` the GitHub API (read-only, unauthenticated):
+                     https://api.github.com/repos/rwlove/home-ops/issues?labels=workaround&state=open
+                     for the tracking issues.
+                  3. For each, check whether upstream RESOLVED and the fix SHIPPED in a
+                     release <= the version we pin. Apply the verification discipline from
+                     `.agents/skills/upstream-watcher.md`:
+                     - "issue closed" is NOT enough — find the closing PR and confirm it
+                       shipped in our deployed version.
+                     - check the DEPLOYED version, not the version named in the annotation.
+                     - for defects invisible to static rendering, note that removal needs a
+                       live server-dry-run or the removal PR's own CI as final proof (flag
+                       it; you cannot run it here).
+                  4. Only report workarounds you believe are genuinely retirable now.
+
+                  For each: **workaround** (file + what it compensates for, generic if
+                  restricted) - **upstream resolution** - **deployed version** vs fix version -
+                  **next action** (retire via the upstream-watcher skill; note if CI/dry-run
+                  proof is still required).
+
+                  ## OUTPUT
+                  - Emit ONLY the markdown digest (the two sections). No preamble.
+                  - If BOTH sections are empty, output exactly: NOTHING-TO-REPORT
+                  PROMPT
+
+                  echo "adoption-scout: running headless review..."
+                  # Claude reads the repo + fetches release notes + reasons, printing the
+                  # digest to stdout. It gets NO write tools and NEVER touches
+                  # GITHUB_ISSUE_TOKEN: the RUNNER SHELL posts the issue below (claude
+                  # --print auto-denies any Bash call that reads a secret env var AND hits
+                  # the network, so the token cannot leak through a tool call anyway).
+                  DIGEST=$(cd /scratch/repo && claude --print \
+                    --allowedTools Read Grep Glob WebFetch "Bash(git log:*)" "Bash(git show:*)" "Bash(git diff:*)" "Bash(curl:*)" \
+                    --max-turns 60 < /tmp/prompt.md 2>&1) || {
+                    echo "adoption-scout: claude run failed"; exit 1; }
+
+                  SIG=$(printf '%s' "$DIGEST" | tr -d '[:space:]')
+                  if [ -z "$SIG" ] || [ "$SIG" = "NOTHING-TO-REPORT" ]; then
+                    echo "adoption-scout: nothing to report (silent)"; exit 0
+                  fi
+
+                  # Build the issue payload with jq (encodes markdown safely as JSON).
+                  printf '%s' "$DIGEST" > /tmp/digest.md
+                  BODY=$(jq -Rs . < /tmp/digest.md)
+                  TITLE=$(printf 'adoption-scout digest %s' "$(date -u +%Y-%m-%d)" | jq -Rs .)
+                  API=https://api.github.com/repos/rwlove/home-ops
+
+                  # De-dupe: comment on the standing open issue if one exists, else create.
+                  EXIST=$(curl -sS --max-time 30 \
+                        -H "Authorization: Bearer $GITHUB_ISSUE_TOKEN" \
+                        -H "Accept: application/vnd.github+json" \
+                        "$API/issues?labels=adoption-scout&state=open" | jq -r '.[0].number // empty')
+
+                  if [ -n "$EXIST" ]; then
+                    H=$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -X POST \
+                          -H "Authorization: Bearer $GITHUB_ISSUE_TOKEN" \
+                          -H "Accept: application/vnd.github+json" \
+                          -d "{\"body\":$BODY}" \
+                          "$API/issues/$EXIST/comments") || { echo "adoption-scout: comment failed"; exit 1; }
+                    echo "adoption-scout: commented on #$EXIST (HTTP $H)"
+                  else
+                    H=$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -X POST \
+                          -H "Authorization: Bearer $GITHUB_ISSUE_TOKEN" \
+                          -H "Accept: application/vnd.github+json" \
+                          -d "{\"title\":$TITLE,\"body\":$BODY,\"labels\":[\"adoption-scout\"]}" \
+                          "$API/issues") || { echo "adoption-scout: create failed"; exit 1; }
+                    echo "adoption-scout: created issue (HTTP $H)"
+                  fi
+              env:
+                - name: HOME
+                  value: /workspace
+                - name: TZ
+                  value: America/New_York
+              # Subscription token (CLAUDE_CODE_OAUTH_TOKEN) + GITHUB_ISSUE_TOKEN
+              # (fine-grained PAT, Issues:RW on rwlove/home-ops only). Pushover
+              # creds ride along unused.
+              envFrom:
+                - secretRef:
+                    name: claude-runner-secret
+                    optional: false
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 512Mi
+                limits:
+                  cpu: "2"
+                  memory: 2Gi
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+                - name: workspace
+                  mountPath: /workspace
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            # Disk-backed (not tmpfs): holds the ~40-day shallow clone. Discarded
+            # when the Job pod ends.
+            - name: scratch
+              emptyDir:
+                sizeLimit: 2Gi
+            - name: workspace
+              emptyDir:
+                medium: Memory
+                sizeLimit: 512Mi
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 128Mi

--- a/kubernetes/apps/ai/claude-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/externalsecret.yaml
@@ -20,6 +20,14 @@ spec:
       remoteRef:
         key: claude-runner
         property: claude_code_oauth_token
+    # Fine-grained GitHub PAT — Issues Read+Write on rwlove/home-ops ONLY. Used
+    # by the adoption-scout runner SHELL to post the digest as a public GitHub
+    # issue (create-or-comment). Claude never sees it: claude --print auto-denies
+    # a Bash call that reads a secret env var AND hits the network.
+    - secretKey: GITHUB_ISSUE_TOKEN
+      remoteRef:
+        key: claude-runner
+        property: github_issue_token
     # Pushover — the digest sink (private). Reuses the same app the
     # alertmanager path uses (1P item `Pushover`), so digests can safely carry
     # restricted-tier Kustomization names a public GitHub issue must not.

--- a/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cnp-allow.yaml
+  - ./cronjob-adoption-scout.yaml
   - ./cronjob-jobs-runner.yaml
   - ./deployment-shell.yaml
   - ./externalsecret.yaml


### PR DESCRIPTION
## What

A new weekly Claude-tier CronJob in `ns ai`, **shipped suspended**, that reviews
recently-bumped charts/images for adoptable upstream features and re-checks
tracked workarounds for retirement — posting **one digest to a public GitHub
issue** (create-or-comment on label `adoption-scout`). **Discovery-only: it
never opens PRs or edits the repo.**

Answers "should the runner review release notes + workarounds and act?" — yes to
the review, no to the acting. PR authoring stays interactive, gated by two skills.

## Why discovery-only (not auto-PR)

Three existing constraints point the same way:

- Release-note adoption research skews optimistic — roughly half of candidates
  evaporate when verified against the **deployed** chart/image version rather
  than upstream main. An unattended loop would author PRs off that optimistic
  reading.
- HOMELAB-SPEC Layer 2 #6 — agents don't open PRs that haven't passed local
  pre-submit.
- The claude-runner routing gate — unattended workflows are read-mostly, and
  their only write is a report to a sink. A config-change PR is neither.

## How

- **Shallow-clone** the public repo (`--shallow-since="40 days ago"`) so
  `git log --since=30d` sees the bumps while staying small.
- Headless `claude --print` with a **widened read-only allowlist**
  (`Read Grep Glob WebFetch git log/show/diff curl`) and an inlined two-section
  prompt. Verifies each feature against the **deployed** version; caps at 15 and
  logs what it drops.
- The **runner shell** (not Claude) posts the issue, so `GITHUB_ISSUE_TOKEN`
  never reaches a Claude tool call (the auto-deny on secret-env + network is a
  second backstop).
- **Data classification:** names only public-tier apps; restricted-namespace
  candidates collapse to a generic count line — the sink is public.
- De-dupe: comments on the standing open `adoption-scout` issue if one exists,
  else creates. Silent when clean.

## Files

- **new** `kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml`
- **new** `.agents/skills/feature-adoption.md` — interactive PR back-end for the
  feature half (mirrors `upstream-watcher.md`, which covers the workaround half)
- `externalsecret.yaml` — adds `GITHUB_ISSUE_TOKEN` (fine-grained PAT,
  Issues:RW on this repo only)
- `kustomization.yaml`, `README.md`, `claude-runner-routing.md`,
  `upstream-watcher.md`

## Human-gated activation (before it does anything)

Shipped suspended. Per the README subsection: create the fine-grained PAT + store
on the 1P `claude-runner` item, create the `adoption-scout` label, confirm the
image ships `git`+`jq`, then run the suspended test job and verify the digest
before unsuspending.

## Trial note

Adds a second Claude-tier weekly cron on the shared Max quota (offset to Wed to
spread load). Weigh as part of the ~2026-09-21 claude-runner trial review.

## Validation

`yq` parse + in-YAML heredoc terminator check + `sh -n` on the runner script all
clean; every kustomization resource resolves. `kustomize`/`kubeconform` not
available on the authoring host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)