### PR TITLE
fix(immichkiosk): disable KIOSK_USE_GPU on both kiosk variants

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -43,7 +43,10 @@ spec:
               KIOSK_DURATION: 30
               KIOSK_DISABLE_SCREENSAVER: false
               KIOSK_OPTIMIZE_IMAGES: false
-              KIOSK_USE_GPU: true
+              # No GPU on the nodes kiosk schedules to, and nothing to
+              # accelerate (OPTIMIZE_IMAGES off; video is client-decoded).
+              # true just makes ffmpeg attempt hwaccel then fall back.
+              KIOSK_USE_GPU: false
               # Asset sources — Party Album, cycled in random order with
               # replacement (same model as the main immichkiosk / familyroom
               # frame). No shuffle-without-replacement: the kiosk never

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -43,7 +43,10 @@ spec:
               KIOSK_DURATION: 30
               KIOSK_DISABLE_SCREENSAVER: false
               KIOSK_OPTIMIZE_IMAGES: false
-              KIOSK_USE_GPU: true
+              # No GPU on the nodes kiosk schedules to, and nothing to
+              # accelerate (OPTIMIZE_IMAGES off; video is client-decoded).
+              # true just makes ffmpeg attempt hwaccel then fall back.
+              KIOSK_USE_GPU: false
               # Asset sources
               KIOSK_SHOW_ARCHIVED: false
               KIOSK_ALBUMS: "ad782b0e-9e90-453c-98e7-086455300ef1"


### PR DESCRIPTION
## Why

`KIOSK_USE_GPU: true` was set on both `immichkiosk` and `immichkiosk-party`, but:

- The kiosk pods schedule onto **GPU-less nodes** (`master1`/`worker6`).
- There's nothing to accelerate: `KIOSK_OPTIMIZE_IMAGES` is off, and video is **decoded by the client** (browser/ImmichFrame), not transcoded server-side.
- So the flag is a no-op at best; at worst ffmpeg attempts hwaccel, fails, and falls back to CPU with extra log noise.

Not wiring it to the P40 on purpose: that card is the only inference GPU, is VRAM-tight, and serves Renee-facing Whisper + Immich CLIP — a slideshow's occasional video decode isn't worth competing for that budget.

## Change

`KIOSK_USE_GPU: false` on both variants so config matches reality. No functional loss — videos already work without it.

## Impact

Two pod rolls on merge (Renee-facing photo displays, `media` ns). No data risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)