### PR TITLE
fix(collab): MediKeep upload durability + health envsubst opt-out

### DIFF
--- a/kubernetes/apps/collab/health/app/kustomization.yaml
+++ b/kubernetes/apps/collab/health/app/kustomization.yaml
@@ -18,3 +18,9 @@ configMapGenerator:
       - default.conf=./resources/default.conf
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # The static assets — minified uPlot JS (${...} template literals) and the
+    # nginx config ($host / $uri) — contain sequences Flux's postBuild envsubst
+    # mis-parses ("missing closing brace"). Opt these ConfigMaps out of variable
+    # substitution; the HelmRelease (route ${SECRET_DOMAIN}) still gets substituted.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/collab/medikeep/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/medikeep/app/helmrelease.yaml
@@ -111,7 +111,16 @@ spec:
         globalMounts:
           - path: /app/matplotlib
       uploads:
-        type: emptyDir
+        # Uploaded medical documents (lab-result PDFs, patient photos) are stored
+        # on disk here — irreplaceable, so Longhorn (survives cluster loss via the
+        # NFS backup target) not emptyDir, which lost them on every pod reschedule.
+        # Auto-covered by Longhorn's `default` recurring-job group (daily snapshot
+        # + weekly/monthly backup). MediKeep runs as 999 and the pod already sets
+        # fsGroup 999, so the volume root is writable.
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: longhorn
         globalMounts:
           - path: /app/uploads
 


### PR DESCRIPTION
MediKeep stores uploaded documents on disk at `/app/uploads` (`lab_result_files/`, `photos/` subdirs confirmed on the live pod) — irreplaceable records, but the mount was `emptyDir`, so anything uploaded would be **lost on every pod reschedule**. The structured DB is already durable (CNPG + Barman offsite); only file attachments were exposed.

Move `uploads` to a **5Gi Longhorn PVC** (survives cluster loss via the NFS backup target; auto-covered by Longhorn's `default` recurring-job group — daily snapshot + weekly/monthly backup). MediKeep runs as uid/gid 999 and the pod already sets `fsGroup: 999`, so the volume root is writable.

No data migration — the dir is currently empty (0 files), so this is purely preventative before medical documents start being uploaded. Deploy triggers a MediKeep pod restart (collab ns, routine window).