### PR TITLE
fix(collab): bump pump-voltra to v0.1.11 (stop healthz 422 crash-loop)

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.10@sha256:fb7406f0a242c2bac2f5123247fdd76c470128c0651970cbc113c566805a7b33
+              tag: v0.1.11@sha256:d1ba70306d04f183b4c766be539cfa52a03d9f94ba5e5bd491ff9e55566802d9
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Hotfix: v0.1.10's liveness `/healthz` returned 422 (FastAPI Response-injection broke under `from __future__ import annotations`), crash-looping the sidecar every ~90s. v0.1.11 (rwlove/PUMP#134) returns JSONResponse instead. Verified with the now-running healthz test.