### PR TITLE
fix(ai): harden adoption-scout against restricted-name leak to public issue

### DIFF
--- a/kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml
@@ -65,9 +65,15 @@ spec:
 
                   ## DATA CLASSIFICATION — this digest becomes a PUBLIC GitHub issue
                   - Apps under `kubernetes/apps/media/` or `kubernetes/apps/security/` are
-                    RESTRICTED. Do NOT name them, their charts, or their images. If you find
-                    adoptable candidates there, collapse them to ONE line per section:
+                    RESTRICTED. Do NOT name them, their charts, their images, or their
+                    directory paths ANYWHERE in your output. If you find adoptable
+                    candidates there, collapse them to ONE line per section that contains
+                    ONLY a bare count and nothing that could identify the app, EXACTLY:
                     "N candidate(s) in restricted namespaces — review interactively."
+                    NEVER put an app/chart/image name in parentheses or anywhere on that
+                    line. A single restricted name anywhere in your output is a HARD
+                    FAILURE that gets the whole digest withheld — when unsure whether a
+                    name is restricted, omit it.
                   - Never include media file names, internal hostnames, IP/MAC addresses, or
                     any secret value. Prefer roles ("the gateway") over names.
                   - Public-tier app names, chart names, and versions ARE fine (public repo).
@@ -138,6 +144,20 @@ spec:
                   if [ -z "$SIG" ] || [ "$SIG" = "NOTHING-TO-REPORT" ]; then
                     echo "adoption-scout: nothing to report (silent)"; exit 0
                   fi
+
+                  # FAIL-SAFE backstop: never let a restricted (media/security) app name
+                  # reach the public issue, even if the model ignored the prompt rule.
+                  # Enumerate the restricted app dir names from the clone and REFUSE to
+                  # post if any appears in the digest — fail closed (data-classification,
+                  # HOMELAB-SPEC L2 #2). The name is not echoed (pod logs are internal).
+                  RESTRICTED=$(find /scratch/repo/kubernetes/apps/media /scratch/repo/kubernetes/apps/security \
+                    -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null | sort -u)
+                  for app in $RESTRICTED; do
+                    if printf '%s' "$DIGEST" | grep -Fiqw -- "$app"; then
+                      echo "adoption-scout: BLOCKED — a restricted-namespace name appears in the digest; refusing to post (data-classification). Digest withheld."
+                      exit 1
+                    fi
+                  done
 
                   # Build the issue payload with jq (encodes markdown safely as JSON).
                   printf '%s' "$DIGEST" > /tmp/digest.md


### PR DESCRIPTION
## What

Follow-up to #13764. The suspended-cronjob **test run** worked end-to-end and
produced a genuinely useful digest, but surfaced one defect: the model collapsed
a restricted-namespace (media) candidate to the "review interactively" line while
naming the app in a parenthetical — a data-classification leak into the public
GitHub issue (HOMELAB-SPEC L2 #2). The test issue was deleted immediately.

## Fix (two layers — prompt-only proved insufficient for a public sink)

- **Prompt hardening:** the collapsed restricted line must contain ONLY a bare
  count — no app/chart/image name or path, not even in parentheses; "when unsure,
  omit".
- **Mechanical fail-safe backstop:** the runner enumerates `media/` + `security/`
  app directory names from the clone and **refuses to post** (exit 1) if any
  appears in the digest. The name is not echoed. A prompt regression can no
  longer leak — it fails closed.

## Notes

- Section 1 (public infra: loki, cilium, external-dns, …) leaked nothing; the
  review quality itself is sound and the concept is validated.
- CI's "Scan for restricted-tier names" gates the repo diff, not issue bodies —
  hence the runtime backstop.
- Still ships suspended. After this merges + reconciles I'll re-run the test to
  confirm a clean post, then unsuspend as a final one-liner.

## Validation

`yq` parse + `sh -n` clean on the edited runner script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)