### PR TITLE
feat(ai): unsuspend adoption-scout after clean test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Production-grade Kubernetes for a household._
 ![apps](https://img.shields.io/badge/apps-162-blue?style=for-the-badge)
 ![helmreleases](https://img.shields.io/badge/HelmReleases-173-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
-![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
+![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-95-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 

--- a/kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-adoption-scout.yaml
@@ -7,13 +7,14 @@ metadata:
   labels:
     app.kubernetes.io/name: claude-runner
 spec:
-  # Shipped SUSPENDED (trial). Discovery-only: this reviews recently-bumped
-  # charts/images for adoptable features and re-checks tracked workarounds for
-  # retirement, then posts ONE digest to a public GitHub issue. It NEVER opens
-  # PRs or edits the repo — PR authoring stays interactive (the ~50%-optimism
-  # lesson + the pre-submit invariant). See
+  # ACTIVE (trial — reviewed manually via the test job before go-live; a clean
+  # digest with no restricted-name leak was confirmed). Discovery-only: this
+  # reviews recently-bumped charts/images for adoptable features and re-checks
+  # tracked workarounds for retirement, then posts ONE digest to a public GitHub
+  # issue. It NEVER opens PRs or edits the repo — PR authoring stays interactive
+  # (the ~50%-optimism lesson + the pre-submit invariant). See
   # .agents/instructions/claude-runner-routing.md.
-  suspend: true
+  suspend: false
   # 0 14 * * 3 UTC = Wed 10:00 EDT / 09:00 EST. Weekly, offset from the Mon
   # drift-digest to spread the shared Max quota.
   schedule: "0 14 * * 3"


### PR DESCRIPTION
Go-live for the adoption-scout discovery cron (#13764, hardened in #13770).

## Why now
The suspended-cronjob test run (post leak-fix) produced a **clean** digest — 0
restricted-name hits, fail-safe backstop verified in the deployed spec — so the
weekly loop is safe to activate. First scheduled run posts/updates the standing
`adoption-scout` issue.

## Changes
- `suspend: false` on `cronjob-adoption-scout.yaml` (+ comment updated to ACTIVE).
- Corrects pre-existing README badge drift the `readme-drift` hook flagged
  (`Postgres_clusters` 22→21, left stale by #13771 SparkyFitness DB removal) —
  bundled only because the hook blocks any commit until badges match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)