### PR TITLE
chore(renovate): drop minimumReleaseAge soak on first-party rwlove images

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -77,13 +77,20 @@
       ignoreTests: false,
     },
     {
-      description: "Auto-merge rwlove personal container images",
+      // First-party images: Rob builds and pushes these himself, so
+      // there is no upstream release to be yanked and the 3-day soak
+      // the docker rules above stamp on every bump protects against
+      // nothing here — it only delays a known-good rebuild. This rule
+      // is last, so its minimumReleaseAge override wins the merge and
+      // drops these off the dashboard's "Pending Status Checks" wait.
+      description: "Auto-merge rwlove personal container images (no soak — first-party)",
       matchDatasources: ["docker"],
       automerge: true,
       automergeType: "pr",
       matchPackageNames: [
         "/^ghcr\\.io\\/rwlove\\//",
       ],
+      minimumReleaseAge: "1 minute",
       ignoreTests: true,
     },
   ],


### PR DESCRIPTION
## What

Adds a \`minimumReleaseAge: "1 minute"\` override to the rwlove personal-images rule in \`.github/renovate/autoMerge.json5\`.

## Why

The two docker package rules above it stamp \`minimumReleaseAge: "3 days"\` onto every bump (digest + minor/patch). The rwlove personal-images rule is last but only set \`ignoreTests: true\` — it never overrode the soak, so Renovate merged the 3-day value onto first-party images and they sat in the Dependency Dashboard's **Pending Status Checks** for 3 days:

- \`ghcr.io/rwlove/pump\`
- \`ghcr.io/rwlove/pump-voltra\`
- \`ghcr.io/rwlove/claude-runner\`
- \`ghcr.io/rwlove/comfyui-mcp\`

The soak exists to give a **bad upstream release** time to be yanked before it auto-merges. These are images Rob builds and pushes himself — there is no upstream to yank them, so the wait delays a known-good rebuild and protects against nothing.

Being the last matching rule, the override wins the package-rule merge for the \`^ghcr\.io/rwlove/\` set only; every other docker bump keeps its 3-day belt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)