### PR TITLE
fix(actions-runner): right-size arc-runner-set-home-ops requests

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops.yaml
@@ -66,16 +66,22 @@ spec:
                     fieldPath: status.hostIP
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                 value: "false"
-            # flux-local Test/Diff are bursty CPU-heavy kustomize builds that run
-            # in-pod. Request 1 core so the scheduler costs/spreads them honestly;
-            # allow bursting to 4 so a build isn't throttled when the node is free.
+            # Right-sized 1c/2Gi → 300m/1Gi (limits 4c/6Gi → 2c/2Gi). The heavy
+            # in-pod flux-local Test/Diff jobs that justified a full core have
+            # moved to ubuntu-latest (flate rewrite); the only jobs still landing
+            # here are light — actionlint/yamllint/markdownlint, the shell checks
+            # (cnp-empty-rules/envsubst-shell-vars/readme-drift), labeler, and the
+            # docs mkdocs build. At maxRunners:16 the old 1c request reserved 16
+            # cores at full burst and deadlocked scale-up runners on the busy
+            # workers (Pending on node-pinned openebs-hostpath PVs). 300m keeps the
+            # scheduler honest; 2c limit leaves burst headroom for the mkdocs build.
             resources:
               requests:
-                cpu: "1"
-                memory: 2Gi
+                cpu: "300m"
+                memory: 1Gi
               limits:
-                cpu: "4"
-                memory: 6Gi
+                cpu: "2"
+                memory: 2Gi
 
   valuesFrom:
     - kind: Secret


### PR DESCRIPTION
## What

Drop `arc-runner-set-home-ops` runner requests **1c/2Gi → 300m/1Gi** and limits **4c/6Gi → 2c/2Gi**.

## Why

Three scale-up runners sat `Pending` for **~6.4h** today, tripping `KubePodNotReady`. Root cause was a scheduling deadlock, not a crash: each runner's `openebs-hostpath` work PVC is **node-pinned** (WaitForFirstConsumer), and at `maxRunners:16` the stale **1-core** request reserved 16 cores at full burst — saturating worker CPU *request-accounting* (worker4 99%, worker8 94%, worker3 93%) so runners couldn't schedule onto the node their PV was pinned to. Live node usage was `<35% CPU`: the pressure was **reservation, not load**.

The 1c/2Gi sizing was for the heavy in-pod `flux-local` Test/Diff jobs — those **moved to `ubuntu-latest`** (flate rewrite). Every job still on this runner set is light: `actionlint`/`yamllint`/`markdownlint`, the shell checks (`cnp-empty-rules`/`envsubst-shell-vars`/`readme-drift`), `labeler`, and the `docs` mkdocs build.

## Effect

Full-burst reservation drops **16c+32Gi → 4.8c+16Gi** (CPU reservation −70%, memory halved). The `2c` limit keeps burst headroom for the mkdocs build. Removes the deadlock precondition so scale-up runners schedule on the busy workers.

The 3 wedged runners were already cleared out-of-band (deleted their EphemeralRunner CRs; ARC recreated a healthy runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)