### PR TITLE
disable-media-apps: immichkiosk-party, av1corrector, videodupfinder

### DIFF
--- a/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
   values:
     controllers:
       av1corrector:
+        enabled: false # disabled 2026-08-23 to relieve memory pressure; revert to re-enable
         annotations:
           reloader.stakater.com/auto: "true"
 

--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
   values:
     controllers:
       immichkiosk-party:
+        enabled: false # disabled 2026-08-23 to relieve memory pressure; revert to re-enable
         pod:
           securityContext:
             runAsNonRoot: true

--- a/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
   values:
     controllers:
       videodupfinder:
+        enabled: false # disabled 2026-08-23 to relieve memory pressure; revert to re-enable
         pod:
           securityContext:
             fsGroup: 1000


### PR DESCRIPTION
## What

Disable three non-critical media StatefulSets via app-template `enabled: false`.

## Why

Follow-on to #13782. Worker memory-request allocation was 80–97% (worker5 97%, worker7 96%, master1 94%) while actual usage was ~65% — the same request-accounting pressure that deadlocked arc-runner scale-up today. These three are non-critical and were among the larger reclaimable footprints.

## Method — `enabled: false` (not `suspend: true`)

The repo's `disable-<app>` convention uses `suspend: true` on the HR, but that only pauses Flux reconciliation — **pods keep running, no memory freed**. `enabled: false` on the controller removes the StatefulSet entirely, so requests are actually reclaimed.

Data-safe: `existingClaim` PVCs (`av1corrector-library-pvc`, `videodupfinder-scan-pvc`) and the separate CNPG databases are untouched; `immichkiosk-party` is emptyDir-only.

## Notes

- `av1corrector` is **Spark-pinned** → frees Spark memory, not worker CPU.
- Reversible: revert this PR (or drop the three `enabled: false` lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)