### PR TITLE
fix(media): disable via replicas:0 not enabled:false (app-template render fail)

### DIFF
--- a/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   values:
     controllers:
       av1corrector:
-        enabled: false # disabled 2026-08-23 to relieve memory pressure; revert to re-enable
+        replicas: 0 # disabled 2026-08-23 to relieve memory pressure; scale back to 1 to re-enable
         annotations:
           reloader.stakater.com/auto: "true"
 

--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
   values:
     controllers:
       immichkiosk-party:
-        enabled: false # disabled 2026-08-23 to relieve memory pressure; revert to re-enable
+        replicas: 0 # disabled 2026-08-23 to relieve memory pressure; scale back to 1 to re-enable
         pod:
           securityContext:
             runAsNonRoot: true

--- a/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   values:
     controllers:
       videodupfinder:
-        enabled: false # disabled 2026-08-23 to relieve memory pressure; revert to re-enable
+        replicas: 0 # disabled 2026-08-23 to relieve memory pressure; scale back to 1 to re-enable
         pod:
           securityContext:
             fsGroup: 1000


### PR DESCRIPTION
## Problem

#13783 disabled `immichkiosk-party` / `av1corrector` / `videodupfinder` with controller `enabled: false`. app-template 5.1.0 validates that `service`/`persistence` blocks reference an **enabled** controller — disabling the only controller left them dangling, so `helm upgrade` failed to render:

```
No enabled controller found with identifier 'av1corrector'. Available controllers: []
```

Result: reconcile failed on all three, the **old release stayed up**, pods never terminated, no memory freed. No outage — just a persistently failing HelmRelease. (Note: the render CI check did not catch this — #13783 merged green.)

## Fix

`controllers.<app>.replicas: 0` instead. The controller stays enabled so `service`/`persistence` resolve, but the StatefulSet scales to 0 → pod terminates, request freed, `existingClaim` PVCs retained.

Verified with `helm template app-template@5.1.0` — renders a StatefulSet at `replicas: 0` with Service + PVC, no error.

Re-enable: scale back to `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)