### PR TITLE
fix(dragonfly): split auth + immich onto dedicated noeviction instances

### DIFF
--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -112,7 +112,12 @@ data:
           expiration: '1 hour'
           remember_me: '1 month'
       redis:
-        host: 'dragonfly.databases.svc.cluster.local'
+        # Dedicated auth-session instance — see
+        # kubernetes/apps/databases/dragonfly/cluster/cluster-auth.yaml.
+        # Authelia is the auth SPOF; its own noeviction instance means no
+        # co-tenant burst can fill --maxmemory and reject session writes
+        # (as immich BullMQ did to the shared `dragonfly` on 2026-08-24).
+        host: 'dragonfly-auth.databases.svc.cluster.local'
         port: 6379
         database_index: 5
 

--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-auth.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-auth.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-auth
+spec:
+  labels:
+    dragonflydb.io/cluster: dragonfly-auth
+  image: ghcr.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
+  # Dedicated auth-session tier. Authelia is the auth choke point for
+  # every gated app — losing its session store locks users out of all of
+  # them (it is THE SPOF). It used to share the noeviction `dragonfly`
+  # instance, where a co-tenant burst (immich BullMQ, 2026-08-24) filled
+  # --maxmemory and made the whole instance reject writes — including
+  # authelia session writes. Its own instance means no other tenant's
+  # churn can ever reach it. 3 replicas: same HA posture as `dragonfly`,
+  # justified here because it protects the auth SPOF.
+  replicas: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 512Mi
+  networkPolicyEnabled: false
+  # Noeviction (no --cache_mode): sessions must never be silently evicted
+  # out from under a logged-in user. The store is tiny (~7 keys), so
+  # --maxmemory=256Mi is enormous headroom — the dragonfly
+  # memory-non-reclamation caveat (see cluster-immich.yaml) would take a
+  # very long time to ratchet a store this small to the cap. --maxmemory
+  # stays strictly below limits.memory (RSS overhead sits on top).
+  args:
+    - "--maxmemory=256Mi"
+    - "--proactor_threads=2"
+    - "--cluster_mode=emulated"

--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-immich
+spec:
+  labels:
+    dragonflydb.io/cluster: dragonfly-immich
+  image: ghcr.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
+  # Dedicated immich (BullMQ) tier. immich is the heavy, bursty tenant: a
+  # nightly "queue-all" style job (storageTemplateMigration /
+  # backgroundTask) transiently allocated ~750Mi of job data on
+  # 2026-08-24, which — combined with the reclamation caveat below — hit
+  # --maxmemory on the shared noeviction `dragonfly` and made it reject
+  # ALL tenants' writes (auth included). Its own instance contains that
+  # blast radius to immich: when it fills, only immich's own jobs stall.
+  # Single replica: the BullMQ queue is regenerable (immich re-detects
+  # outstanding work), so node-loss HA is not worth 2-3x the (large) RAM
+  # — same rationale as dragonfly-cache. Core immich (photos, upload,
+  # browse) reads from Postgres and is unaffected by a queue-pod restart.
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 3Gi
+    limits:
+      memory: 3Gi
+  networkPolicyEnabled: false
+  # Noeviction (NO --cache_mode): BullMQ on an evicting Redis corrupts
+  # queue state (jobs vanish mid-lifecycle), so immich MUST stay
+  # noeviction. --maxmemory=2Gi is ~67% of the 3Gi cgroup limit: mimalloc
+  # RSS overhead (and, per #7947, block-size charged to small TTL keys)
+  # sits above --maxmemory, so keep real headroom below limits.memory or
+  # the kernel OOM-kills the pod. --default_lua_flags=allow-undeclared-keys
+  # is REQUIRED for BullMQ's EVALSHA scripts (same as the origin
+  # `dragonfly` instance).
+  #
+  # workaround: https://github.com/dragonflydb/dragonfly/issues/4418 —
+  # dragonfly does not return freed memory to used_memory after a
+  # delete/trim under noeviction (aggravated for BullMQ's small TTL keys
+  # by v1.40.0 PR #7947, which charges full mimalloc block size to
+  # used_memory). A noeviction instance thus ratchets toward --maxmemory
+  # across bursts and eventually self-wedges until restarted. The generous
+  # cap is containment; shrink it (and stop expecting periodic self-wedge)
+  # when a delete/trim returns used_memory below --maxmemory without a
+  # restart. Replace this URL with our own filed issue once opened.
+  args:
+    - "--maxmemory=2Gi"
+    - "--proactor_threads=2"
+    - "--cluster_mode=emulated"
+    - "--default_lua_flags=allow-undeclared-keys"

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-auth.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-auth.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly-auth-allow
+spec:
+  # Select on `app: <instance>`, NOT app.kubernetes.io/name — the
+  # operator stamps app.kubernetes.io/name=dragonfly on EVERY instance
+  # and only `app` carries the instance name. Selecting on the shared
+  # label would over-match; selecting the instance name that DOESN'T
+  # exist would be a silent no-op (the #13733 label trap).
+  endpointSelector:
+    matchLabels:
+      app: dragonfly-auth
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Consumers of `dragonfly-auth.databases.svc.cluster.local:6379`:
+    #   auth/authelia — session store (db5)
+    # fromEntities: cluster on 6379 (same rationale as the other tiers).
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-immich.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-immich.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly-immich-allow
+spec:
+  # Select on `app: <instance>` — see cnp-allow-auth.yaml for the label
+  # trap this avoids (#13733).
+  endpointSelector:
+    matchLabels:
+      app: dragonfly-immich
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Consumers of `dragonfly-immich.databases.svc.cluster.local:6379`:
+    #   media/immich — BullMQ task queue (db1)
+    # fromEntities: cluster on 6379 (same rationale as the other tiers).
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow.yaml
@@ -14,16 +14,19 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Durable tier (sessions + queues, noeviction). Consumers of
+    # Durable tier (small queues + caches, noeviction). Consumers of
     # `dragonfly.databases.svc.cluster.local:6379`, by db index:
-    #   auth/authelia    db5 — session store
-    #   media/immich     db1 — BullMQ task queue
     #   home/netbox      db3 — task queue   / db4 — django cache
     #   collab/paperless db7 — celery broker
     #   media/romm       db2 — RQ task queue
     #   collab/nametag   db6 — session / cache
     # The pure-cache hog (renovate) lives on the separate evicting
     # `dragonfly-cache` instance so its churn can't jam this tier.
+    # The auth SPOF (authelia) and the heavy/bursty tenant (immich
+    # BullMQ) were split off to dedicated `dragonfly-auth` /
+    # `dragonfly-immich` instances after immich burst-filled this
+    # noeviction tier on 2026-08-24 and made it reject every tenant's
+    # writes, auth included (cluster-immich.yaml / cluster-auth.yaml).
     # Enumerating each per-pod selector across 6 namespaces is fragile.
     # Use fromEntities: cluster on port 6379 — the cross-cluster /
     # default-deny boundary is what matters; missing a consumer here

--- a/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
@@ -3,10 +3,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cluster-auth.yaml
   - ./cluster-cache.yaml
+  - ./cluster-immich.yaml
   - ./cluster.yaml
+  - ./cnp-allow-auth.yaml
   - ./cnp-allow-cache.yaml
+  - ./cnp-allow-immich.yaml
   - ./cnp-allow.yaml
+  - ./podmonitor-auth.yaml
   - ./podmonitor-cache.yaml
+  - ./podmonitor-immich.yaml
   - ./podmonitor.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/databases/dragonfly/cluster/podmonitor-auth.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/podmonitor-auth.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dragonfly-auth
+spec:
+  selector:
+    matchLabels:
+      app: dragonfly-auth
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin

--- a/kubernetes/apps/databases/dragonfly/cluster/podmonitor-immich.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/podmonitor-immich.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dragonfly-immich
+spec:
+  selector:
+    matchLabels:
+      app: dragonfly-immich
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin

--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -57,7 +57,13 @@ spec:
               IMMICH_CONFIG_FILE: /config/system.json
               PUBLIC_IMMICH_SERVER_URL: https://photos.${SECRET_DOMAIN}
               REDIS_DBINDEX: "1"
-              REDIS_HOSTNAME: dragonfly.databases.svc.cluster.local
+              # Dedicated immich (BullMQ) instance — see
+              # kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml.
+              # immich's bursty queue used to share the noeviction
+              # `dragonfly`; a burst filled --maxmemory and made that
+              # instance reject every tenant's writes, auth included
+              # (2026-08-24). Its own instance contains that to immich.
+              REDIS_HOSTNAME: dragonfly-immich.databases.svc.cluster.local
               REDIS_PORT: "6379"
               REVERSE_GEOCODING_PRECISION: "2"
             envFrom:


### PR DESCRIPTION
## Problem

The shared noeviction `dragonfly` durable tier co-tenanted the **authelia session store (the auth SPOF)** with **immich's bursty BullMQ queue**. On 2026-08-24 an immich burst (storageTemplateMigration/backgroundTask) drove `used_memory` to `--maxmemory`. Dragonfly does not return freed memory to `used_memory` after a delete/trim (upstream [#4418](https://github.com/dragonflydb/dragonfly/issues/4418), aggravated for small-TTL keys by v1.40.0 [#7947](https://github.com/dragonflydb/dragonfly/pull/7947)), so the instance stayed pinned at the cap and **rejected every tenant's writes — authelia session writes included** (a login outage triggered by a co-tenant). Live data at the time was only ~6 MB; the 768 MiB was retained/phantom.

## Fix — containment (v1.40.1 is the newest release, so isolation is the fix, not an upgrade)

Give the two problem tenants their own instances:

| Instance | Tenant | Replicas | Cap / limit | Mode |
|---|---|---|---|---|
| `dragonfly-auth` (new) | authelia sessions (db5) | 3 | 256Mi / 512Mi | noeviction |
| `dragonfly-immich` (new) | immich BullMQ (db1) | 1 | 2Gi / 3Gi (~67%) | noeviction + `allow-undeclared-keys` |
| `dragonfly` | romm, netbox, paperless, nametag | 3 | 768Mi / 1Gi | noeviction (unchanged) |
| `dragonfly-cache` | renovate | 1 | 1024Mi / 1280Mi | evicting (unchanged) |

- authelia (`host`) and immich (`REDIS_HOSTNAME`) repointed. Their egress CNPs already select `app.kubernetes.io/name=dragonfly` (the operator stamps it on every instance), so no egress change needed.
- New per-instance ingress CNPs + PodMonitors use the `app:<instance>` selector (the #13733 label trap).
- `prometheusrule.yaml` is instance-generic and auto-covers both new noeviction instances.
- `--maxmemory` set to ~67% of the cgroup limit for RSS headroom (mimalloc overhead + #7947 block-size charging sit above the cap).

## Rollout

1. Merge → Flux provisions `dragonfly-auth` + `dragonfly-immich`; authelia + immich repoint to the fresh instances and recover on their own (sessions reset → re-login; immich queue rebuilds).
2. The old `dragonfly` was manually restarted at deploy time to clear the phantom memory (done); it is durable now that immich no longer lives on it.

## Follow-ups (not in this PR)

- File a dedicated upstream dragonfly issue for the noeviction `used_memory`-pinned-after-delete write-rejection (referencing #7947) and swap the workaround URL to it.
- Add the `workaround`-labeled tracking issue linking `cluster-immich.yaml` ↔ upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)