### PR TITLE
disable-media-apps: remove 3 media apps from kustomize (supersedes replicas:0)

### DIFF
--- a/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
@@ -13,7 +13,6 @@ spec:
   values:
     controllers:
       av1corrector:
-        replicas: 0 # disabled 2026-08-23 to relieve memory pressure; scale back to 1 to re-enable
         annotations:
           reloader.stakater.com/auto: "true"
 

--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -16,7 +16,6 @@ spec:
   values:
     controllers:
       immichkiosk-party:
-        replicas: 0 # disabled 2026-08-23 to relieve memory pressure; scale back to 1 to re-enable
         pod:
           securityContext:
             runAsNonRoot: true

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -14,7 +14,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml
-  - ./av1corrector/ks.yaml
+  # - ./av1corrector/ks.yaml # disabled 2026-08-24, memory pressure; uncomment to re-enable (NFS data on server is retained)
   # Disabled: needs a Batocera target on the LAN (planned host: multicade)
   # - ./batocera-webdashboard-pro/ks.yaml
   - ./beets/ks.yaml
@@ -24,7 +24,7 @@ resources:
   - ./immich-power-tools/ks.yaml
   - ./immich/ks.yaml
   - ./immichkiosk/ks.yaml
-  - ./immichkiosk-party/ks.yaml
+  # - ./immichkiosk-party/ks.yaml # disabled 2026-08-24, memory pressure; uncomment to re-enable
   - ./janitorr-radarr/ks.yaml
   - ./janitorr-sonarr/ks.yaml
   - ./jellyfin/ks.yaml
@@ -43,4 +43,4 @@ resources:
   - ./stash/ks.yaml
   - ./suggestarr/ks.yaml
   - ./theme-park/ks.yaml
-  - ./videodupfinder/ks.yaml
+  # - ./videodupfinder/ks.yaml # disabled 2026-08-24, memory pressure; uncomment to re-enable (NFS data on server is retained)

--- a/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
@@ -13,7 +13,6 @@ spec:
   values:
     controllers:
       videodupfinder:
-        replicas: 0 # disabled 2026-08-23 to relieve memory pressure; scale back to 1 to re-enable
         pod:
           securityContext:
             fsGroup: 1000


### PR DESCRIPTION
## What

Disable `immichkiosk-party` / `av1corrector` / `videodupfinder` by commenting them out of `kubernetes/apps/media/kustomization.yaml` so Flux **prunes** each app entirely, instead of the `replicas: 0` from #13784. Matches the existing `batocera-webdashboard-pro` disable convention in that file.

Prune removes each app's HR, StatefulSet, Service, CNP, SecurityPolicy, ExternalSecret, and the static NFS PV/PVC objects — a clean "off" with no lingering inert objects.

## Data-safe

`av1corrector-library` and `videodupfinder-scan` are **static NFS PVs** (`kind: PersistentVolume` → `nfs: ${NFS_HOST}:${NFS_PATH}`, no provisioner, default `Retain`). Pruning the k8s objects does **not** delete the files on the NFS server; re-enabling recreates the PV/PVC against the same path and re-binds. The separate CNPG databases are untouched. `immichkiosk-party` is emptyDir-only.

Also drops the `replicas: 0` lines (from #13784) back to the original HR state, so the now-dormant files re-enable cleanly when the kustomize lines are uncommented.

## Re-enable

Uncomment the three lines in `kustomization.yaml`.

Note: `av1corrector` is Spark-pinned → frees Spark memory, not worker CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)