### PR TITLE
fix(dragonfly): dragonfly-auth below 256MiB/thread floor won't start

### DIFF
--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-auth.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-auth.yaml
@@ -25,12 +25,15 @@ spec:
       memory: 512Mi
   networkPolicyEnabled: false
   # Noeviction (no --cache_mode): sessions must never be silently evicted
-  # out from under a logged-in user. The store is tiny (~7 keys), so
-  # --maxmemory=256Mi is enormous headroom — the dragonfly
-  # memory-non-reclamation caveat (see cluster-immich.yaml) would take a
-  # very long time to ratchet a store this small to the cap. --maxmemory
-  # stays strictly below limits.memory (RSS overhead sits on top).
+  # out from under a logged-in user. The store is tiny (~7 keys).
+  # Dragonfly requires --maxmemory >= 256MiB PER proactor thread or it
+  # refuses to start ("N threads, so N*256MiB are required. Exiting").
+  # One thread is ample for authelia's tiny, low-throughput session load,
+  # so proactor_threads=1 lets --maxmemory=384Mi (well above the 256MiB
+  # floor, still enormous headroom for ~7 keys) sit ~75% under the 512Mi
+  # cgroup limit (RSS overhead sits on top). HA comes from the 3 replicas,
+  # not the thread count.
   args:
-    - "--maxmemory=256Mi"
-    - "--proactor_threads=2"
+    - "--maxmemory=384Mi"
+    - "--proactor_threads=1"
     - "--cluster_mode=emulated"


### PR DESCRIPTION
## Problem

Follow-up to #13785. `dragonfly-auth` shipped with `--maxmemory=256Mi` + `--proactor_threads=2`. Dragonfly requires **≥256 MiB maxmemory per proactor thread**, so 2 threads need ≥512 MiB — it refused to start:

```
There are 2 threads, so 512.00MiB are required. Exiting...
```

The instance CrashLoopBacked-off, which crashlooped **authelia** (`session backend: redis connection error: i/o timeout`) — a live auth outage (auth is the SPOF).

## Fix

`proactor_threads=1` (ample for authelia's tiny ~7-key, low-throughput session store) with `--maxmemory=384Mi` — above the 256 MiB single-thread floor, ~75% of the 512Mi cgroup limit. HA still comes from the 3 replicas.

Applied live via a CR patch to restore auth immediately; this PR codifies the identical values so Flux does not revert to the broken config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)