### PR TITLE
fix(zot): right-size memory request 2Gi → 512Mi

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -57,7 +57,10 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 2Gi
+                # Right-sized 2Gi→512Mi: steady working set ~271Mi (13% of
+                # the old request); 512Mi keeps ~1.9x headroom. Limit stays
+                # 5Gi to absorb large pull-through spikes.
+                memory: 512Mi
               limits:
                 memory: 5Gi
 


### PR DESCRIPTION
## What

Drop zot's memory **request** from `2Gi` to `512Mi`. Limit unchanged at `5Gi`.

## Why

zot's pull-through registry cache steady working set is **~271Mi** — 13% of the old 2Gi request. That fat request was the single clean over-provisioning found while auditing worker memory-request pressure (workers sitting at 88–100% requests while actual usage is far lower).

`512Mi` keeps ~1.9× headroom over steady state; the `5Gi` limit stays to absorb large pull-through spikes. Reclaims ~1.5Gi of schedulable memory on zot's node (currently worker6).

## Safety

- zot carries `descheduler.alpha.kubernetes.io/prefer-no-eviction: "true"` (a ~4–5min cold-start recovery blocks cluster-wide pulls), so a **request trim is the correct lever** — no eviction involved. The rollout is a single controlled StatefulSet restart.
- Request-only change; the 5Gi limit means burst behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)