### PR TITLE
fix(dragonfly): scope TSC to app:dragonfly to stop descheduler evict loop

### DIFF
--- a/kubernetes/apps/databases/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster.yaml
@@ -25,10 +25,19 @@ spec:
     - "--cluster_mode=emulated"
     - "--default_lua_flags=allow-undeclared-keys"
 
+  # Scope the spread selector to THIS instance's own replicas (`app:
+  # dragonfly`), not the operator's shared `app.kubernetes.io/part-of:
+  # dragonfly` — that label is stamped identically on every Dragonfly
+  # instance (dragonfly, -auth, -cache, -immich), so selecting on it
+  # pools all instances under one constraint. The descheduler's
+  # RemovePodsViolatingTopologySpreadConstraint plugin then evicts the
+  # single-replica -immich/-cache pods every ~5 min whenever they share a
+  # node with these replicas. Same shared-label class as the CNP trap in
+  # #13733, different key. See reference_descheduler_evicts_dragonfly_singletons.
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: "kubernetes.io/hostname"
       whenUnsatisfiable: "DoNotSchedule"
       labelSelector:
         matchLabels:
-          app.kubernetes.io/part-of: dragonfly
+          app: dragonfly


### PR DESCRIPTION
## Problem (live-confirmed 2026-08-24)

`dragonfly-immich-0` **and** `dragonfly-cache-0` were being evicted + rescheduled every ~5 minutes by the descheduler's `RemovePodsViolatingTopologySpreadConstraint` plugin (both observed `PodInitializing` on master1, their Prometheus scrape targets mostly down). This undermined the #13785/#13787 split that isolated the immich cache onto its own single-replica instance for stability.

## Root cause

The 3-replica `dragonfly` instance's `topologySpreadConstraint` selected on `app.kubernetes.io/part-of: dragonfly` — a label the dragonfly-operator stamps **identically on every instance** (`dragonfly`, `-auth`, `-cache`, `-immich`). That pooled all 8 dragonfly pods under one constraint; the descheduler then evicted whichever single-replica pod was 'extra' on an over-represented node (master1 hosts 3). Same shared-label failure class as the CNP selector trap fixed in #13733, on a different label key + consumer.

## Fix

Scope the selector to `app: dragonfly` — the per-instance label (`dragonfly-0` carries `app=dragonfly`, `dragonfly-immich-0` carries `app=dragonfly-immich`), matching the repo's established CNP selector convention. The constraint now balances only this instance's own 3 replicas.

Validated with `kubectl kustomize kubernetes/apps/databases/dragonfly/cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)