### PR TITLE
fix(observability): stop KubePodPendingBrief page-flood; pin tempo datasource UIDs

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -235,12 +235,14 @@ spec:
               prometheusType: Prometheus
             name: Prometheus
             type: prometheus
+            uid: prometheus
             url: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
           - access: proxy
             jsonData:
               maxLines: 1000
             name: Loki
             type: loki
+            uid: loki
             url: http://loki.observability.svc.cluster.local:3100
           - access: proxy
             jsonData:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -22,6 +22,16 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: "="
+      # KubePodPendingBrief (warning) is intentionally Grafana-only for
+      # trend visibility — it must NOT page. The inhibitRule below can't
+      # suppress it (that requires the same alertname as the critical, and
+      # the critical is KubePodStuckPending), so route it to null here or
+      # every >2m Pending during a routine rollout pages Pushover.
+      - receiver: "null"
+        matchers:
+          - name: alertname
+            value: KubePodPendingBrief
+            matchType: "="
   # Routing is by ALERTNAME, not by severity. The two routes above are
   # the only suppression: everything else — critical, warning, and info
   # alike — falls through to the root `pushover` receiver and notifies.


### PR DESCRIPTION
Two low-risk observability hardening fixes found in the 2026-08-24 cluster review.

## 1. KubePodPendingBrief was paging on every rollout (High)

`prometheusrule-pod-pending.yaml` documents `KubePodPendingBrief` (warning) as Grafana-only trend visibility, but it was falling through to the `pushover` receiver. The AlertmanagerConfig's only severity-aware suppression is an `inhibitRule` requiring the **same alertname**+namespace as a firing critical — but the critical is a different alertname (`KubePodStuckPending`), so the inhibit never linked them. Result: every pod Pending >2m, including any routine rolling update, paged Pushover. Repeated false pages train dismissal, which is what buries the real 5m critical.

Fix: null-route `KubePodPendingBrief`, matching the existing `Watchdog`/`InfoInhibitor` pattern already in the file.

## 2. Tempo datasource UIDs were implicit (Medium)

The Prometheus and Loki Grafana datasources set no explicit `uid:`, but `tempo/app/configmap-grafana-datasource.yaml` hardcodes `datasourceUid: prometheus` / `loki` for trace→metrics and trace→logs correlation. A future rename of either datasource would silently break the correlation links with no error. Pin the uids explicitly (matching the existing `uid: alertmanager`).

Note: dashboards reference datasources by name (`datasource: Prometheus`), not uid, so this is additive; the only consumer of the uids is the tempo config, which already assumes these exact values.

Both validated with `kubectl kustomize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)