### PR TITLE
fix(immich-pet-tagger): add disableWait to prevent silent upgrade rollback

### DIFF
--- a/kubernetes/apps/media/immich-pet-tagger/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich-pet-tagger/app/helmrelease.yaml
@@ -12,6 +12,16 @@ spec:
   dependsOn:
     - name: immich
       namespace: media
+  # disableWait — the upstream (root) image downloads yolov8n.pt to /app on
+  # first poll; the startup probe budgets 10 min (60×10s), but helm-controller
+  # only waits 5 min by default, then marks the upgrade Failed and rolls back
+  # the just-applied spec while the pod keeps running on it (the same silent-
+  # revert failure immich-machine-learning hit). Matches the sibling GPU/ML
+  # HRs (ollama, immich, comfyui-spark, vllm/tei-*), which all set this.
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
   values:
     controllers:
       immich-pet-tagger:


### PR DESCRIPTION
Found in the 2026-08-24 cluster review (ML operator).

`immich-pet-tagger` was the only GPU/ML HelmRelease in the cluster **without** `install/upgrade.disableWait`, despite budgeting a 10-minute startup probe (`failureThreshold: 60 × periodSeconds: 10`) for the upstream image's first-poll `yolov8n.pt` download.

Without `disableWait`, helm-controller's 5-minute default wait times out, marks the upgrade `Failed`, and rolls back the just-applied spec while the pod keeps running on the new one — the exact silent-revert failure `immich-machine-learning` already guards against (and the pattern every sibling ML HR — ollama, immich, comfyui-spark, vllm/tei-* — already uses).

Additive, no runtime behavior change. Validated with `kubectl kustomize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)