### PR TITLE
fix(renovate): match bare CNPG postgresql tags so bump PRs actually open

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -31,7 +31,11 @@
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/cloudnative-pg/postgresql"],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<compatibility>.+)$"
+      // The compatibility suffix must be OPTIONAL: every cluster pins a bare
+      // `major.minor` tag (e.g. 17.7), but the old regex required a `-suffix`
+      // and so matched nothing — Renovate silently opened zero bump PRs while
+      // the engine under all CNPG clusters drifted patch releases behind.
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(-(?<compatibility>.+))?$"
     },
     {
       description: 'Loose versioning for non-semver packages',


### PR DESCRIPTION
Found in the 2026-08-24 cluster review (storage operator + live confirmation).

## Problem

`.github/renovate/packageRules.json5` sets the `ghcr.io/cloudnative-pg/postgresql` versioning to `regex:^(?<major>\d+)\.(?<minor>\d+)-(?<compatibility>.+)$` — which **requires** a hyphenated suffix. But every CNPG cluster pins a **bare** `major.minor` tag:

- `17.7` × 16 clusters
- `17.5` × 1
- `16.11` × 1
- (live `cnpg_collector_postgres_version` also shows `14.17` on 3 clusters)

The regex matched **none** of them, so Renovate has been silently opening **zero** bump PRs. The engine under every Postgres database (HA recorder, immich, auth, paperless, …) is drifting patch releases behind — 17.7 vs upstream **17.11** — missing whatever security/correctness fixes landed in 17.8–17.11, with no automation catching it.

## Fix

Make the compatibility group optional: `regex:^(?<major>\d+)\.(?<minor>\d+)(-(?<compatibility>.+))?$`. Verified against real tags — bare `17.7`/`17.5`/`16.11`/`17.11` now parse, and suffixed variants (`17.7-1`, `17.7-standard-bookworm`) still parse. JSON5 parses clean.

## Follow-up (not in this PR)

Once Renovate opens the bumps, roll 17.7→17.11 through a normal PR (CNPG does this one instance at a time; PVCs stay attached, primary fails over — no data risk). **Review the major-version PRs (16.11→17.x, and any PG14 path) deliberately** rather than batch-merging — PG major upgrades need care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)