### PR TITLE
fix(emqx): hard pod anti-affinity to spread brokers across nodes

### DIFF
--- a/kubernetes/apps/home/emqx/app/helmrelease.yaml
+++ b/kubernetes/apps/home/emqx/app/helmrelease.yaml
@@ -18,16 +18,19 @@ spec:
   values:
     affinity:
       podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values: ["emqx"]
-              topologyKey: kubernetes.io/hostname
-
-            weight: 100
+        # Hard spread across nodes. The `preferred` rule (in place since Dec
+        # 2025) was ignored under scheduling pressure and 2-of-3 brokers
+        # colocated on worker3; when that node flapped (2026-08-22) it wedged
+        # MQTT and took HA↔Z-Wave down. `required` forces each of the 3
+        # brokers onto a distinct node — always satisfiable (11 nodes), and no
+        # rolling-update deadlock (a replaced pod has 8 free nodes to land on).
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values: ["emqx"]
+            topologyKey: kubernetes.io/hostname
     emqxConfig:
       EMQX_ALLOW_ANONYMOUS: "false"
       EMQX_AUTH__MNESIA__PASSWORD_HASH: plain


### PR DESCRIPTION
Found in the 2026-08-24 cluster review (smart-home operator + live confirmation).

## Problem

The EMQX `preferredDuringSchedulingIgnoredDuringExecution` podAntiAffinity has existed since Dec 2025, but a soft rule is ignored under bin-packing/preemption pressure. On 2026-08-22, 2-of-3 brokers were colocated on worker3; when that node flapped it wedged MQTT and took HA↔Z-Wave down — a real SPOF for the Renee-facing smart-home path.

## Fix

Switch to `requiredDuringSchedulingIgnoredDuringExecution` so each of the 3 brokers must land on a distinct node.

**Safe to apply now** (live-verified): brokers are currently on 3 distinct nodes (worker3/worker7/master1), and with 11 nodes (8 free) the constraint is already satisfied and a StatefulSet rolling replacement always has a free node — no Pending-pod deadlock, which was the one risk the smart-home reviewer flagged for a small cluster.

## Impact on merge

Applying this rolls the EMQX StatefulSet (one pod at a time). MQTT clients briefly reconnect to the surviving 2/3 brokers — a short blip on the Renee-facing HA↔Z-Wave/Zigbee path, not an outage. Merging outside a maintenance window is per Rob's explicit 'do everything now' on 2026-08-24.

Validated with `kubectl kustomize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)