### PR TITLE
docs(dragonfly): point cluster-immich workaround at filed issue #8149

### DIFF
--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml
@@ -36,7 +36,7 @@ spec:
   # is REQUIRED for BullMQ's EVALSHA scripts (same as the origin
   # `dragonfly` instance).
   #
-  # workaround: https://github.com/dragonflydb/dragonfly/issues/4418 —
+  # workaround: https://github.com/dragonflydb/dragonfly/issues/8149 —
   # dragonfly does not return freed memory to used_memory after a
   # delete/trim under noeviction (aggravated for BullMQ's small TTL keys
   # by v1.40.0 PR #7947, which charges full mimalloc block size to
@@ -44,7 +44,7 @@ spec:
   # across bursts and eventually self-wedges until restarted. The generous
   # cap is containment; shrink it (and stop expecting periodic self-wedge)
   # when a delete/trim returns used_memory below --maxmemory without a
-  # restart. Replace this URL with our own filed issue once opened.
+  # restart. Tracked in rwlove/home-ops#13793.
   args:
     - "--maxmemory=2Gi"
     - "--proactor_threads=2"


### PR DESCRIPTION
Comment-only. Swaps the interim upstream anchor (#4418) in `cluster-immich.yaml` for our filed issue dragonflydb/dragonfly#8149, tracked by #13793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)