### PR TITLE
fix(frigate): tuned NFS mountOptions on the 3 camera PVs

### DIFF
--- a/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
+++ b/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
@@ -15,6 +15,10 @@ spec:
   nfs:
     server: "${NFS_HOST_SECURITY}"
     path: /mnt/frigate-media/frigate/recordings
+  # Tier B (active camera-write path). security-storage already serves
+  # NFSv4.2; nconnect=8 is the throughput lever for continuous recording
+  # writes. No aggressive actimeo — Frigate must see file changes promptly.
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
 
 ---
 apiVersion: v1
@@ -47,6 +51,8 @@ spec:
   nfs:
     server: "${NFS_HOST_SECURITY}"
     path: /mnt/frigate-media/frigate/clips
+  # Tier B (active camera-write path). See recordings PV above.
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
 
 ---
 apiVersion: v1
@@ -79,6 +85,9 @@ spec:
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/kubernetes/frigate-exports
+  # Tier B. beast already serves this at NFSv4.2; low-traffic write-once
+  # export path, so nconnect is mostly for consistency with the other mounts.
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Found in the 2026-08-24 cluster review (storage operator). The three Frigate NFS PVs had **no** `mountOptions` — the only NFS PVs in the repo missing the tuned set — leaving throughput on the table for continuous camera writes (Renee-facing).

Live probe of worker4 confirmed both servers already negotiate **NFSv4.2**; the gap is `nconnect` (single TCP connection today) and `noatime` (vs `relatime`). Applying the standard Tier-B set: `nfsvers=4.2, nconnect=8, hard, noatime`.

`mountOptions` is immutable, so this is being landed together with a coordinated PV recreate (frigate scaled down, PVCs+PVs deleted — `Retain` policy, NFS data untouched — Flux recreates, frigate scaled up). Executed live under Rob's 'do everything now' authorization on 2026-08-24.

Validated with `kubectl kustomize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)