### PR TITLE
fix(frigate): clips PV capacity 300G->400G to match its PVC request

### DIFF
--- a/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
+++ b/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   storageClassName: frigate-clips-storage-class
   capacity:
-    storage: 300G
+    storage: 400G
   accessModes:
     - ReadWriteOnce
   nfs:


### PR DESCRIPTION
Follow-up to #13796 (the NFS mountOptions swap). Recreating the clips PV fresh surfaced a pre-existing manifest inversion: the PV declared **300G** while its PVC requests **400G**, which the old grandfathered claimRef had masked. Fresh, the bind failed with `requested PV is too small`.

NFS capacity is nominal, so bump the PV to 400G (>= the 400G claim). The live PV was already patched to 400G during the swap so Frigate is up now; this lands it in Git so Flux's desired state matches and it won't drift back / re-break on a future recreate.

Validated with `kubectl kustomize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)