### PR TITLE
fix(spark): nodeSelect on auto-discovered nvidia.com/gpu.family=blackwell

### DIFF
--- a/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
       comfyui-spark:
         pod:
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           tolerations:
             # Spark is tainted kubernetes.io/arch=arm64:NoSchedule to keep

--- a/kubernetes/apps/ai/tei-embed-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       tei:
         pod:
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           # Spark taints: arm64 (keeps amd64-only workloads off — kubelet
           # only catches arch mismatch at pull time, too late) and the

--- a/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       tei:
         pod:
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           # Spark taints: arm64 (keeps amd64-only workloads off — kubelet
           # only catches arch mismatch at pull time, too late) and the

--- a/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
 
         pod:
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           tolerations:
             - key: kubernetes.io/arch

--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
 
         pod:
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           # Spark taints: arm64 (keeps amd64-only workloads off) + the
           # nvidia.com/gpu reservation. Mirrors ollama-spark / tei-spark.

--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
           # cutover — the new image won't run on P40 (sm_61 isn't in
           # TORCH_CUDA_ARCH_LIST for the nvcr.io stack).
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           tolerations:
             # Spark is tainted kubernetes.io/arch=arm64:NoSchedule to

--- a/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
             fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch
           nodeSelector:
-            node-role.kubernetes.io/gpu: blackwell
+            nvidia.com/gpu.family: blackwell
 
           tolerations:
             # Spark is tainted kubernetes.io/arch=arm64:NoSchedule to keep


### PR DESCRIPTION
Resolves review finding M5. Seven Spark workloads nodeSelected on **`node-role.kubernetes.io/gpu: blackwell`** — a label applied **manually** to the Spark node with no producer in Git. On a Spark reprovision the label vanishes and all seven go Pending → violates 'Git is canonical' (HOMELAB-SPEC L2 #4).

**Fix:** gpu-operator's GFD already auto-labels the node with **`nvidia.com/gpu.family=blackwell`** (verified live; P40 = `family=pascal`, Spark-unique, self-heals on reprovision). Repoint the seven nodeSelectors to it — no NodeFeatureRule, no NFD loosening, no manual-label dependency.

The `node-role.kubernetes.io/gpu` label stays as a cosmetic `gpu` role; no longer load-bearing. All 7 dirs validated with `kubectl kustomize`. On merge: rolls the active Spark inference fleet once (brief blip, deliberate per Rob 2026-08-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)