### PR TITLE
feat(claude-runner): unsuspend the vault-driven jobs runner

### DIFF
--- a/kubernetes/apps/ai/claude-runner/app/cronjob-jobs-runner.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-jobs-runner.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     app.kubernetes.io/name: claude-runner
 spec:
-  # Shipped SUSPENDED (trial). This is the vault-driven runner: the JOBS live
-  # as private notes in the Obsidian vault (never in this public repo) under
-  # `automation/jobs/claude/`; this CronJob is only the reviewed CAGE. See
-  # .agents/instructions/claude-runner-routing.md.
-  suspend: true
+  # ACTIVE (unsuspended 2026-08-24, trial). This is the vault-driven runner:
+  # the JOBS live as private notes in the Obsidian vault (never in this public
+  # repo) under `automation/jobs/claude/`; this CronJob is only the reviewed
+  # CAGE. Governed by .agents/instructions/claude-runner-routing.md — re-add
+  # `suspend: true` to pause without tearing down objects.
   # 0 13 * * 1 UTC = Mon 09:00 EDT / 08:00 EST. Weekly — every note in the
   # folder runs on this cadence (finer cadence = a second runner).
   schedule: "0 13 * * 1"


### PR DESCRIPTION
## What

Activates the Claude-tier runner. Removes `spec.suspend: true` from the `claude-runner-jobs` CronJob (weekly **Mon 13:00 UTC** / 09:00 EDT).

On each run, the native `vault-bridge` sidecar materialises the private `claude` Obsidian vault, and the runner executes every note under `automation/jobs/claude/` (currently **drift + oom + cert**) through caged `claude --print`, delivering one Pushover digest per note (or staying silent on `CLEAN`). Job prompts stay private in the vault — never in this repo ("no jobs in git"); only the reviewed cage is here.

The ks and the vault-bridge were already active (the interactive shell runs off the same ks); only this CronJob was individually suspended.

## Confidence

Live-verified end-to-end earlier this session: 3 notes ran, `oom` → Pushover HTTP 200 (real Dragonfly finding, since fixed), `drift` + `cert` → CLEAN/silent. The local tier unsuspended yesterday and both its jobs ran clean today, so the shared plumbing (Pushover secret, egress, scheduling) is proven.

First scheduled run: **Mon 2026-08-25 13:00 UTC** — I'll confirm it via the read-only path.

## Verified here
- No `spec.suspend` remains on `claude-runner-jobs`.
- `kubectl kustomize` renders clean.
- All pre-commit hooks pass.

Retention governed by the claude-runner trial policy (`.agents/instructions/claude-runner-routing.md`); re-add `suspend: true` to pause without teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)