### PR TITLE
feat(pump): bump server image to v0.2.9

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.7@sha256:6660356390647f0fea112dc4c2b94e2c451ae1d1ca6e902339d02cd287fea72e
+              tag: v0.2.9@sha256:664786baf252dbb1b11af9d00ca91da05d7cbf33df04eed0cb0e8c595faed008
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps the pump server image `v0.2.7` → `v0.2.9`.

**PUMP #136** — rolling 28-day max trend line on the Progressive Overload chart, so a lighter / higher-rep day no longer reads as a strength regression. Frontend-only; **no schema migration**.

- Image: `ghcr.io/rwlove/pump:v0.2.9@sha256:664786baf252dbb1b11af9d00ca91da05d7cbf33df04eed0cb0e8c595faed008` (index digest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)