### PR TITLE
fix(paperless-mcp): stateful fork image to actually federate paperless (#138 + statelessness)

### DIFF
--- a/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
@@ -25,18 +25,20 @@ spec:
         containers:
           app:
             image:
-              # workaround: https://github.com/baruchiro/paperless-mcp/pull/140 — revert to ghcr.io/baruchiro/paperless-mcp `latest` once #140 merges and publishes
-              # Temporary fork build of baruchiro/paperless-mcp v2.0.1 carrying the
-              # PR #140 fix for upstream #138: the Kuadrant broker rejects the
-              # `type: ["T","null"]` union schema that zod-to-json-schema emits for
-              # `.nullable()` fields and de-federates the ENTIRE backend (invalid=3
-              # valid=41 → zero paperless_* tools). The fork collapses those unions
-              # to a scalar `type` in the advertised schema only (zod still accepts
-              # null at call time). Built from rwlove/paperless-mcp
-              # `fix/138-nullable-union-types`; tracked in home-ops #13804. Drop this
-              # pin and return to baruchiro `latest` (Renovate-tracked) when #140 ships.
+              # workaround: https://github.com/baruchiro/paperless-mcp/pull/140 — revert to ghcr.io/baruchiro/paperless-mcp `latest` once BOTH upstream fixes ship
+              # Fork build of baruchiro/paperless-mcp v2.0.1 carrying TWO fixes the
+              # Kuadrant broker needs to federate paperless:
+              #   1. #138 schema — collapse `type: ["T","null"]` unions (from
+              #      `.nullable()`) to scalar; the broker drops the whole backend
+              #      otherwise (PR baruchiro/paperless-mcp#140).
+              #   2. stateful transport — v2.x ran stateless (empty Mcp-Session-Id,
+              #      GET /mcp -> 405); the v0.9.0 broker won't federate a stateless
+              #      upstream (same wall as github/windmill/searxng, #13627). The
+              #      fork issues a real Mcp-Session-Id + notification stream.
+              # Built from rwlove/paperless-mcp `fix/stateful-transport`; tracked in
+              # home-ops #13804. Return to baruchiro `latest` when both land upstream.
               repository: ghcr.io/rwlove/paperless-mcp
-              tag: fix-138-20260825@sha256:8fb443a7e2c5506dedfdba5931077d8a59e42c7ccc746e9d3a6fd104c7fa088c
+              tag: fix-138-stateful-20260825@sha256:30b9d7ea0eb99350c1a44aed222da1e0d301454b1f10800296192821e7367882
             # v2.0.x makes a per-request `Authorization: Bearer` mandatory and drops
             # the env-token fallback, so every broker request 401s (the mcp-gateway
             # route strips Authorization so backends use their own env cred). The


### PR DESCRIPTION
Makes `paperless_*` tools appear on the mcp-gateway. Follow-up to #13805.

## Why #13805 was not enough
The #138 schema fix (union `type: ["T","null"]` → scalar) was necessary but not sufficient. paperless-mcp v2.x also runs a **stateless** streamable-HTTP server (empty `Mcp-Session-Id`, `GET /mcp` → 405). The Kuadrant v0.9.0 broker requires a **stateful** session and refuses to federate stateless upstreams — the same wall that keeps github/windmill/searxng off the gateway (#13627). So paperless stayed de-federated even with a clean schema.

## What
Point the image at a fork build carrying **both** fixes:
1. **#138 schema** — collapse nullable unions to scalar (upstream PR baruchiro/paperless-mcp#140).
2. **Stateful transport** — issue a real `Mcp-Session-Id` on initialize, reuse by header, serve the GET notification stream.

`ghcr.io/rwlove/paperless-mcp:fix-138-stateful-20260825@sha256:30b9d7ea…` (public, anonymously pullable), built from `rwlove/paperless-mcp` `fix/stateful-transport`. Registration stays enabled; `--no-auth` retained.

## Verified locally
`tsc` clean, 98/98 tests pass. Live MCP handshake against the built server: `initialize` returns `mcp-session-id: <uuid>`, and `tools/list` on that session returns **44 tools** with **0 nullable-union fields**.

## Post-merge (I will do)
Flux reconcile → rollout the pod → restart the broker so it re-dials → confirm `discover_tools` lists `paperless` and the `paperless_*` tools.

## Revert path
Return to stock `ghcr.io/baruchiro/paperless-mcp` `latest` once both fixes land upstream. Tracked in #13804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)