### PR TITLE
docs(dragonfly): correct immich noeviction root cause + record COMPACT-TABLE recovery

### DIFF
--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-immich.yaml
@@ -36,15 +36,23 @@ spec:
   # is REQUIRED for BullMQ's EVALSHA scripts (same as the origin
   # `dragonfly` instance).
   #
-  # workaround: https://github.com/dragonflydb/dragonfly/issues/8149 —
-  # dragonfly does not return freed memory to used_memory after a
-  # delete/trim under noeviction (aggravated for BullMQ's small TTL keys
-  # by v1.40.0 PR #7947, which charges full mimalloc block size to
-  # used_memory). A noeviction instance thus ratchets toward --maxmemory
-  # across bursts and eventually self-wedges until restarted. The generous
-  # cap is containment; shrink it (and stop expecting periodic self-wedge)
-  # when a delete/trim returns used_memory below --maxmemory without a
-  # restart. Tracked in rwlove/home-ops#13793.
+  # PRIME-TABLE NON-SHRINK (root cause, confirmed 2026-08-26 on
+  # dragonflydb/dragonfly#8149): under noeviction, deleting/trimming keys
+  # does NOT return used_memory. Dragonfly's prime hash table (DashTable)
+  # grows its segment/directory arrays on insert and never shrinks them on
+  # erase, so table_used_memory stays pinned at the high-water mark while
+  # object_used_memory correctly drops to 0. PR #7947 only makes the peak
+  # arrive sooner — it is NOT the persistent pin. A noeviction instance thus
+  # ratchets toward --maxmemory across bursts and eventually self-wedges.
+  # Upstream will NOT auto-compact the table (maintainer: no fair general
+  # heuristic), so this is PERMANENT, not awaiting an upstream fix — the
+  # generous cap is deliberate containment, not a temporary hedge.
+  #
+  # RECOVERY without a restart (keeps live keys — preferred over restarting,
+  # which drops the regenerable queue): `redis-cli DEBUG COMPACT-TABLE 1.0`
+  # merges the under-full segments in place and reclaims table_used_memory
+  # fully (verified 313MiB->633KiB, all live keys intact). See
+  # rwlove/home-ops#13793.
   args:
     - "--maxmemory=2Gi"
     - "--proactor_threads=2"

--- a/kubernetes/apps/databases/dragonfly/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/prometheusrule.yaml
@@ -24,7 +24,7 @@ spec:
         # noeviction (durable) tier without needing an instance-name match.
         - alert: DragonflyOutOfMemoryErrors
           annotations:
-            description: Dragonfly {{ $labels.pod }} in {{ $labels.namespace }} is rejecting writes with "Out of memory" ({{ printf "%.2f" $value }}/s). A noeviction instance has hit --maxmemory; writes (sessions, queue enqueues) are failing. Reclaim memory or raise --maxmemory.
+            description: Dragonfly {{ $labels.pod }} in {{ $labels.namespace }} is rejecting writes with "Out of memory" ({{ printf "%.2f" $value }}/s). A noeviction instance has hit --maxmemory; writes (sessions, queue enqueues) are failing. Recover in place without a restart (keeps live keys) with `redis-cli DEBUG COMPACT-TABLE 1.0` — the prime hash table does not shrink on delete, so table_used_memory stays pinned (home-ops#13793, dragonflydb#8149). Or raise --maxmemory.
             summary: Dragonfly is refusing writes (at maxmemory, noeviction).
           expr: |-
             sum by (namespace, pod) (
@@ -41,7 +41,7 @@ spec:
         # for 15m is genuinely filling toward the OutOfMemoryErrors cliff.
         - alert: DragonflyMemoryNearMaxmemory
           annotations:
-            description: Dragonfly {{ $labels.pod }} in {{ $labels.namespace }} is at {{ printf "%.0f" $value }}% of --maxmemory. A noeviction instance this full is approaching write rejection (ERR Out of memory). Reclaim keys or raise the cap before it hits the wall.
+            description: Dragonfly {{ $labels.pod }} in {{ $labels.namespace }} is at {{ printf "%.0f" $value }}% of --maxmemory. A noeviction instance this full is approaching write rejection (ERR Out of memory). Recover in place with `redis-cli DEBUG COMPACT-TABLE 1.0` (the prime hash table does not shrink on delete; keeps live keys — home-ops#13793), or raise the cap before it hits the wall.
             summary: Dragonfly noeviction instance is near maxmemory.
           expr: |-
             100 * (


### PR DESCRIPTION
## What

Follow-up to the resolution of [dragonflydb/dragonfly#8149](https://github.com/dragonflydb/dragonfly/issues/8149). Two doc-only edits to the dragonfly app, no behavior change:

1. **`cluster-immich.yaml`** — corrects the root-cause note and reclassifies it from a pending-upstream `# workaround:` to a permanent design accommodation.
2. **`prometheusrule.yaml`** — adds the concrete recovery command to both alert descriptions so an operator sees *how* to reclaim mid-incident, not just "reclaim memory."

## Why

The annotation previously blamed mimalloc object accounting / PR #7947 for the persistent `used_memory` pin. A minimal local repro (dragonfly v1.40.1, exact flags) plus the maintainer on #8149 confirmed the real cause: the **prime DashTable's segment/directory arrays grow on insert and are never shrunk on erase** — so `table_used_memory` stays at the high-water mark while `object_used_memory` correctly drops to 0. PR #7947 only makes the peak arrive sooner; it is not the persistent pin. Dragonfly's own source says so (`db_slice.cc` `PerformDeletionAtomic`: *"currently we do not shrink our tables upon deletion"*).

The maintainer stated upstream has **no plans to auto-compact** the table (no fair general heuristic), so this is permanent — not something to remove when upstream catches up.

## Recovery (verified)

`redis-cli DEBUG COMPACT-TABLE 1.0` merges the under-full segments in place and reclaims `table_used_memory` fully **without a restart and preserving all live keys** (verified in repro: 313 MiB → 633 KiB, `prime_capacity` 8.5M → 13.4k, all entries intact). This is now recorded in the annotation and both alert descriptions — preferred over a pod restart, which drops the queue.

## Follow-ups (not in this PR)

- **`workaround`-labeled tracking issue #13793** should be closed as upstream-wontfix (permanent), or repurposed as an *optional* automation candidate: a targeted `DEBUG COMPACT-TABLE` run after immich's integrity-check burst. Left to Rob's call.
- If we do automate it, validate the DEBUG command's db scope on the regenerable `dragonfly-immich` first (propose-then-execute).

## Test

- YAML parses; all pre-commit hooks pass (yamllint, secret scan, etc.).
- Comment-only + alert-description-string changes — no schema or rendered-manifest impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)