### PR TITLE
fix(claude-runner): wait for full vault sync before running notes

### DIFF
--- a/kubernetes/apps/ai/claude-runner/app/cronjob-jobs-runner.yaml
+++ b/kubernetes/apps/ai/claude-runner/app/cronjob-jobs-runner.yaml
@@ -99,16 +99,29 @@ spec:
                 - -ceu
                 - |
                   DIR=/vault/automation/jobs/claude
-                  echo "waiting for the vault-bridge sidecar to materialise $DIR ..."
-                  i=0
-                  while [ ! -d "$DIR" ] && [ "$i" -lt 72 ]; do
-                    i=$((i + 1)); sleep 5
+                  # The vault-bridge sidecar does an initial FULL replication of
+                  # the vault (~1200+ files) into this per-run scratch dir. The
+                  # jobs DIRECTORY can appear early — while its *.md notes are
+                  # still in flight — so waiting on the directory alone RACES: a
+                  # run can glob zero notes and exit 0 (the 2026-08-24 43s no-op).
+                  # Wait instead until the WHOLE /vault file count stops growing
+                  # for 4 consecutive 5s samples (initial sync settled), capped
+                  # at ~8 min so a stuck sidecar can't hang the job.
+                  echo "waiting for the vault-bridge sidecar to finish materialising the vault ..."
+                  prev=-1; stable=0; i=0
+                  while [ "$stable" -lt 4 ] && [ "$i" -lt 96 ]; do
+                    n=$(find /vault -type f 2>/dev/null | wc -l)
+                    if [ "$n" -gt 0 ] && [ "$n" -eq "$prev" ]; then
+                      stable=$((stable + 1))
+                    else
+                      stable=0
+                    fi
+                    prev=$n; i=$((i + 1)); sleep 5
                   done
+                  echo "vault settled at $prev file(s) after $((i * 5))s"
                   if [ ! -d "$DIR" ]; then
-                    echo "FATAL: vault jobs folder not materialised in time"; exit 1
+                    echo "FATAL: vault jobs folder $DIR never materialised"; exit 1
                   fi
-                  # let the mirror scan settle so all notes in the folder land.
-                  sleep 30
                   ran=0
                   for f in "$DIR"/*.md; do
                     [ -e "$f" ] || continue
@@ -137,7 +150,19 @@ spec:
                     echo "job $name: pushover HTTP $H"
                   done
                   echo "ran $ran job(s)"
-                  [ "$ran" -gt 0 ] || echo "NOTE: no job notes found in $DIR"
+                  # Guardrail (claude-runner-routing.md #10): a settled vault with
+                  # ZERO notes means the sync failed or the folder is unexpectedly
+                  # empty — make that VISIBLE instead of a silent success.
+                  notes=$(ls "$DIR"/*.md 2>/dev/null | wc -l)
+                  if [ "$notes" -eq 0 ]; then
+                    echo "WARNING: no job notes present in $DIR after the vault settled"
+                    curl -sS --max-time 30 -o /dev/null \
+                      --form-string "token=$PUSHOVER_TOKEN" \
+                      --form-string "user=$PUSHOVER_USER" \
+                      --form-string "title=claude-runner-jobs: no notes" \
+                      --form-string "message=Vault materialised but $DIR held no *.md notes — sync may have failed." \
+                      https://api.pushover.net/1/messages.json || true
+                  fi
               env:
                 - name: HOME
                   value: /workspace


### PR DESCRIPTION
## Problem

The first scheduled `claude-runner-jobs` run (2026-08-24) completed in **43 seconds with 0 notes processed** — a silent no-op. Root cause: the runner waited only for the notes *directory* to appear, then `sleep 30` and globbed `*.md`. But the vault-bridge sidecar does an initial full replication of ~1270 files into a fresh per-run scratch dir, and the directory can plateau early while its `.md` notes are still in flight. Glob matches nothing → `exit 0`. Racy: sometimes works, sometimes a no-op.

## Fix

- **Settle-wait:** poll the whole `/vault` file count until it stops growing for 4 consecutive 5s samples (initial sync settled), capped at ~8 min so a stuck sidecar can't hang the job. Replaces the directory-only wait + fixed `sleep 30`.
- **Guardrail (routing-policy #10):** if the vault settles but the notes folder is empty, send a Pushover warning instead of succeeding silently.

## Verification

- A live manual test run (before this fix, once the vault happened to fully sync) processed all three notes correctly: `cert` → CLEAN/silent, `drift` + `oom` → Pushover HTTP 200 — so the mechanism is sound; only the wait condition was wrong.
- `kubectl kustomize` renders clean; `sh -n` on the extracted runner script passes; the settle-loop dry-run terminates on a stable count and finds the note.
- claude-runner CronJobs get no Flux envsubst (unlike local-cron), so bare `$` is correct — the `envsubst-shell-vars` pre-commit check passes.

Next scheduled run: Mon 2026-08-25… → now correctly Mon 13:00 UTC weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)