### PR TITLE
fix(downloads): P2P client leech-only — stop sharing the music library

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -157,15 +157,16 @@ spec:
       media:
         existingClaim: slskd-downloads-pvc
 
-      # Soulseek peers deprioritize zero-share users → every transfer parks
-      # in "Queued, Remotely" indefinitely. Mount the music NFS read-only at
-      # /media/shared (the path slskd.yml's `shares.directories` lists) so
-      # slskd has something to share back and gets normal peer reciprocity.
+      # Leech-only (Rob's call 2026-08-26, privacy): share an EMPTY dir at
+      # /media/shared instead of the music-library NFS, so NOTHING from the
+      # library is ever served to peers. Accepted tradeoff: with zero real
+      # shares, peers deprioritize us ("Queued, Remotely") and downloads
+      # succeed less often. The now-unused slskd-shares-pvc (nfs-pvc.yaml)
+      # can be pruned in a follow-up.
       shares:
-        existingClaim: slskd-shares-pvc
+        type: emptyDir
         globalMounts:
           - path: /media/shared
-            readOnly: true
 
       tmp:
         type: emptyDir


### PR DESCRIPTION
## What

Reconfigure the P2P downloads client to mount an empty `emptyDir` at its share path (`/media/shared`) instead of the music-library NFS. No library content is served to peers anymore — the client runs download-only (leech).

## Why

Privacy — Rob's call (2026-08-26). The library should not be exposed to the P2P network.

## Tradeoff (accepted)

With zero real shares, peers deprioritize us (`Queued, Remotely`), so downloads succeed less often. Accepted.

## Follow-up

The now-unused NFS share PVC (`nfs-pvc.yaml`) can be pruned in a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)