### PR TITLE
feat(downloads): stale-session detection + auto-recovery for the P2P client

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -75,9 +75,49 @@ spec:
               # When the downloads-gateway VXLAN tunnel flaps, slskd loses its server
               # session and — without VPN integration — sits in "Disconnecting" forever
               # because connectionWatchdog never engages. The exec probe catches that
-              # state and restarts the pod after 10×30s = 5 min of stuck Disconnecting,
-              # which is the only path back to a logged-in state until upstream slskd
-              # exposes a real watchdog config.
+              # state and restarts the pod, which is the only path back to a
+              # logged-in state until upstream slskd exposes a real watchdog config.
+              #
+              # TODO: no upstream issue found that covers detecting a half-open
+              # server session while server.state still reports LoggedIn — closest
+              # hits are slskd/slskd#93 (reconnect-after-KNOWN-disconnect strategy)
+              # and jpdillingham/Soulseek.NET#468 (distributed-watchdog timer
+              # scoping), neither of which is this bug. Re-check on slskd version
+              # bumps and replace this TODO with a real `# workaround:` link (per
+              # .agents/instructions/workarounds.md) if a matching issue opens.
+              #
+              # Second failure mode, added 2026-08-26: the tunnel flap can leave the
+              # server session HALF-OPEN instead of visibly Disconnecting — isLoggedIn
+              # stays true and every check above still passes, but the transport is
+              # dead: every operation times out and ALL searches return 0 responses,
+              # until the ~15min OS TCP timeout forces a reconnect. isLoggedIn /
+              # isConnecting / isLoggingIn / isAwaitingVpn are all useless for this
+              # case — none of them change while stale. The one signal that's
+              # actually robust here is
+              # slskd_search_incoming_request_receive_rate_current — the live rate of
+              # distributed-mesh search requests flowing IN through this client. It
+              # keeps flowing even though this client is a zero-share leech (privacy
+              # change, 2026-08-26): incoming search traffic doesn't depend on us
+              # having shares to offer. Healthy is a rate in the low thousands/min
+              # (~3015 observed); a stale session flatlines it to exactly 0.
+              # Deliberately NOT dnet_has_parent (unreliable for a leech — rarely
+              # gets a distributed parent) and NOT incoming_responses_sent
+              # (legitimately 0 for a leech either way, so it can't distinguish
+              # healthy from stale).
+              #
+              # failureThreshold: 12 × periodSeconds: 30s = 6 min grace — inside the
+              # 5-8 min target window (comfortably under the ~15min TCP self-heal, so
+              # the probe wins the race and recovers faster) while giving a couple of
+              # spare probe cycles of tolerance for a single transient wget/jq
+              # hiccup across the three checks now bundled into one exec, since a
+              # false restart here is a full slskd restart (re-scan + reconnect), not
+              # free. If the downloads-gateway VPN tunnel itself is down (not just
+              # flapped), this restart-loops at ~6min cadence rather than thrashing
+              # faster — bounded by failureThreshold, not unbounded — until the
+              # tunnel recovers; SlskdServerSessionStale (prometheusrule.yaml) is the
+              # backstop alert for exactly that case, with its own 15m `for:` so a
+              # persistent VPN outage still pages even though the probe alone can't
+              # fix it.
               liveness:
                 enabled: true
                 custom: true
@@ -89,8 +129,12 @@ spec:
                       - |
                         wget -qO- http://localhost:5030/health >/dev/null || exit 1
                         wget -qO- http://localhost:5030/api/v0/application \
-                          | jq -e '.server.isLoggedIn or .server.isConnecting or .server.isLoggingIn or .connectionWatchdog.isAwaitingVpn' >/dev/null
-                  failureThreshold: 10
+                          | jq -e '.server.isLoggedIn or .server.isConnecting or .server.isLoggingIn or .connectionWatchdog.isAwaitingVpn' >/dev/null || exit 1
+                        rate=$(wget -qO- http://localhost:5030/metrics \
+                          | grep '^slskd_search_incoming_request_receive_rate_current ' \
+                          | cut -d' ' -f2)
+                        [ -n "$rate" ] && [ "${rate%.*}" -gt 0 ] 2>/dev/null || exit 1
+                  failureThreshold: 12
                   initialDelaySeconds: 0
                   periodSeconds: 30
                   timeoutSeconds: 5

--- a/kubernetes/apps/downloads/slskd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/slskd/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml
+  - ./prometheusrule.yaml
   - ./securitypolicy.yaml
 configMapGenerator:
   - files:

--- a/kubernetes/apps/downloads/slskd/app/prometheusrule.yaml
+++ b/kubernetes/apps/downloads/slskd/app/prometheusrule.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: slskd-rules
+spec:
+  groups:
+    - name: slskd.session
+      rules:
+        # Backstop for the "half-open server session" failure mode: the
+        # downloads-gateway VXLAN tunnel flaps, slskd's Soulseek SERVER
+        # connection goes half-open, but server.state stays "Connected,
+        # LoggedIn" — the app itself can't tell the transport is dead until
+        # the OS TCP timeout (~15m) forces a reconnect. server.state /
+        # isLoggedIn are therefore useless as a signal (see
+        # slskd_search_incoming_requests_received below for why this metric
+        # is the one that's actually robust).
+        #
+        # slskd_search_incoming_requests_received counts distributed-mesh
+        # search requests flowing IN through this client — it keeps flowing
+        # even though this client is a zero-share leech (2026-08-26 privacy
+        # change), because incoming search traffic doesn't depend on us
+        # having shares. Healthy rate ~15-21/s; a stale server session
+        # flatlines it to 0. Deliberately NOT using
+        # slskd_dnet_has_parent (unreliable for a leech — rarely gets a
+        # distributed parent) or slskd_search_incoming_responses_sent
+        # (legitimately 0 for a leech, so it can't distinguish healthy from
+        # stale).
+        #
+        # The liveness probe in helmrelease.yaml already restarts the pod on
+        # the same underlying signal (via the point-in-time gauge
+        # slskd_search_incoming_request_receive_rate_current) at ~5-8m, so
+        # in normal operation this alert should rarely fire — it exists as
+        # the backstop for the case where the probe's restart doesn't clear
+        # the fault (e.g. the VPN tunnel itself is down, so every restart
+        # just reconnects into the same dead egress path and re-flatlines).
+        #
+        # `for: 15m` matches the OS TCP timeout the pod would eventually
+        # self-heal on, so this alert should only ever fire when self-heal
+        # AND the liveness-probe restart have both failed to clear it —
+        # i.e. a real, unresolved outage, not a transient blip. A genuinely
+        # quiet moment on the Soulseek network (rare, and network-wide, not
+        # client-specific) is the false-positive risk; 15m of zero incoming
+        # distributed search traffic cluster-wide is not something a quiet
+        # moment produces.
+        - alert: SlskdServerSessionStale
+          annotations:
+            summary: slskd Soulseek server session is stale (0 incoming search traffic for 15m)
+            description: |
+              slskd has received zero incoming distributed-mesh search
+              requests for 15 minutes despite being scraped successfully.
+              This is the signature of a half-open Soulseek server session
+              (downloads-gateway VXLAN tunnel flap) — server.state will
+              still report "Connected, LoggedIn" even though the transport
+              is dead.
+
+              The liveness probe (helmrelease.yaml) should already have
+              restarted the pod on this same signal before this alert's
+              15m window elapses. If this is firing, either that restart
+              hasn't happened yet or it fired and the session is still
+              stale post-restart — check whether the downloads-gateway VPN
+              tunnel itself is down:
+                kubectl -n downloads get pods -l app.kubernetes.io/name=slskd
+                kubectl -n downloads logs -l app.kubernetes.io/name=slskd --tail=100
+                kubectl -n vpn get pods -l app.kubernetes.io/instance=downloads-gateway
+              Fix is a pod restart (reconnects the server session); if the
+              VPN gateway itself is down, restarting slskd alone won't
+              clear it.
+          expr: |-
+            (
+              up{job="slskd"} == 1
+            )
+            and
+            (
+              rate(slskd_search_incoming_requests_received{job="slskd"}[10m]) == 0
+            )
+          for: 15m
+          labels:
+            severity: warning


### PR DESCRIPTION
## Problem

The P2P downloads client's upstream server connection intermittently goes **half-open** (VPN gateway VXLAN tunnel flap). It still reports "connected / logged in", but the transport is dead — every operation times out and **all searches return 0 results** — until the OS TCP timeout (~15 min) forces a reconnect. The existing liveness probe trusts the "logged in" flag, so it never restarts the pod during this window.

## Signal

`slskd_search_incoming_requests_received` — incoming distributed-mesh search requests flowing through the client. Healthy rate ~15–21/s; a stale session flatlines it to **0**. It keeps flowing even in leech mode (unlike shares-based or distributed-parent signals), so it cleanly distinguishes healthy from stale. Verified live against the running pod.

## Changes

- **New `prometheusrule.yaml`** — `SlskdServerSessionStale`: fires when the pod is up but the incoming-search rate is 0 for `15m`. Routes to the default private (Pushover) receiver; no AlertManager change. Includes a runbook annotation (check the VPN gateway).
- **Liveness probe hardened** — adds a third check: if the point-in-time receive-rate gauge is 0 (or the metric is absent → fail closed), the probe fails. `failureThreshold` 10→12 (6-min grace), so a stale session restarts the pod at ~6 min — beating the ~15-min self-heal — without tripping on a transient hiccup.
- **`kustomization.yaml`** — registers the new rule.

## Validation

- Probe metric-parsing verified live against the real `/metrics` line format (anchored grep skips comment lines; `cut` yields the value; evaluates PASS at a healthy rate).
- Flap-safety: `for: 15m` matches the TCP self-heal window and is gated on `up == 1`; under a persistent VPN outage the probe restart-loops at a bounded ~6-min cadence and the alert pages.
- No `# workaround:` link (no matching upstream issue found) — a `# TODO:` documents the search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)