### PR TITLE
fix(downloads): escape probe shell vars for Flux envsubst

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -130,10 +130,10 @@ spec:
                         wget -qO- http://localhost:5030/health >/dev/null || exit 1
                         wget -qO- http://localhost:5030/api/v0/application \
                           | jq -e '.server.isLoggedIn or .server.isConnecting or .server.isLoggingIn or .connectionWatchdog.isAwaitingVpn' >/dev/null || exit 1
-                        rate=$(wget -qO- http://localhost:5030/metrics \
+                        rate=$$(wget -qO- http://localhost:5030/metrics \
                           | grep '^slskd_search_incoming_request_receive_rate_current ' \
                           | cut -d' ' -f2)
-                        [ -n "$rate" ] && [ "${rate%.*}" -gt 0 ] 2>/dev/null || exit 1
+                        [ -n "$${rate}" ] && [ "$${rate%.*}" -gt 0 ] 2>/dev/null || exit 1
                   failureThreshold: 12
                   initialDelaySeconds: 0
                   periodSeconds: 30


### PR DESCRIPTION
## Hotfix

The liveness-probe change in the previous PR used unescaped shell variables in the container command. Flux's strict-mode post-build `envsubst` treated them as undefined **cluster** variables and failed:

```
post build failed ... envsubst error: variable not set (strict mode): "rate"
```

This stalled the app's Flux reconciliation (Kustomization `READY=False`). No service impact — it kept running on the last-good config — but the new probe/alert never applied and further changes were blocked.

## Fix

Escape the shell vars with `$$` so `envsubst` passes them through to the shell unchanged (`$$(...)`, `$${rate}`, `$${rate%.*}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)