### PR TITLE
chore(immich): temporarily cap frame-album video (1080p/8Mbps)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -30,7 +30,7 @@ spec:
             "ffmpeg": {
               "targetResolution": "1080",
               "maxBitrate": "8000k",
-              "transcode": "disabled",
+              "transcode": "bitrate",
               "realtime": {
                 "enabled": true,
                 "videoCodecs": ["h264", "hevc"],


### PR DESCRIPTION
Automated flip-scope-revert step — see tools/immich-frame-video-transcode.sh.