### PR TITLE
chore(immich): revert transcode policy to disabled (frame-album video done)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -30,7 +30,7 @@ spec:
             "ffmpeg": {
               "targetResolution": "1080",
               "maxBitrate": "8000k",
-              "transcode": "bitrate",
+              "transcode": "disabled",
               "realtime": {
                 "enabled": true,
                 "videoCodecs": ["h264", "hevc"],


### PR DESCRIPTION
Restores global `ffmpeg.transcode: disabled` (steady state). The frame-transcode tool's automated revert failed on a stale local origin/main ref and left global policy on `bitrate`; this is the manual revert. Frame-video transcodes from #13820 persist through this.