### PR TITLE
fix(observability): correct broken label matcher on VPN gateway restart-loop alert

### DIFF
--- a/kubernetes/apps/observability/loki/app/configmap.yaml
+++ b/kubernetes/apps/observability/loki/app/configmap.yaml
@@ -142,6 +142,18 @@ data:
       # config change on our side — see project_downloads_gateway_gluetun_
       # silent_restart_loop.md.
       #
+      # IMPORTANT: this pod runs 3 containers (main, gluetun, netshoot)
+      # sharing ONE Loki stream — the vector-agent sink indexes only
+      # {app="pod-gateway", namespace="vpn", node, service_name} at the pod
+      # level; there is NO indexed `container` label in this cluster's Loki
+      # schema (confirmed 2026-08-28 via list_loki_label_names — the shipped
+      # v1 of this rule used a nonexistent `container="gluetun"` matcher and
+      # silently matched zero streams instead of erroring, per
+      # feedback_public_sink_llm_digest_needs_mechanical_restricted_backstop-
+      # style "worse than nothing" failure). The per-container name is only
+      # inside the JSON-encoded line body as `container_name`, so isolate it
+      # with `| json | container_name="gluetun"` instead.
+      #
       # A single normal reconnect (the design-intent CONNECTION_RETRY_COUNT
       # recovery baked into the pod-gateway settings) produces at most one
       # or two of these lines before the tunnel comes back — nowhere near
@@ -150,12 +162,14 @@ data:
       # cadence) to fire, so this rule is tuned to catch today's event
       # comfortably (45 >> 10) without paging on routine single retries.
       # `for: 5m` keeps a five-minute matching window so a loop has to
-      # persist across the whole window, not just spike once.
+      # persist across the whole window, not just spike once. Verified live
+      # against today's outage window (13:01-13:06 ET) post-fix: this exact
+      # matcher returns the historical restart-loop lines.
       - name: vpn-egress-gateway
         rules:
           - alert: DownloadPathVpnGatewayRestartLoop
             expr: |
-              sum(count_over_time({namespace="vpn", container="gluetun"} |~ "(?i)restarting vpn because it failed to pass the healthcheck"[5m])) > 10
+              sum(count_over_time({namespace="vpn"} | json | container_name="gluetun" |~ "(?i)restarting vpn because it failed to pass the healthcheck"[5m])) > 10
             for: 5m
             labels:
               severity: warning


### PR DESCRIPTION
## Summary

- Follow-up to #13828. Post-merge live verification found the shipped LogQL matcher used `container="gluetun"` — a label that **does not exist** in this cluster's Loki schema (confirmed via `list_loki_label_names`: only `app`, `hostname`, `namespace`, `node`, `service_name` are indexed for this stream).
- The download-path VPN egress gateway's pod runs 3 containers sharing **one** indexed Loki stream (`{app="pod-gateway", namespace="vpn", ...}`) — there's no per-container label at the index level. The container identity only exists inside the JSON-encoded log line body as `container_name`.
- The broken matcher silently matched **zero streams** (LogQL treats an unmatched label selector as "no results," not a syntax error) — the exact "worse than nothing, alert can never fire" failure mode this alert exists to prevent.
- Fixed by switching to `| json | container_name="gluetun"` to filter within the shared stream instead of a nonexistent label.

## Test plan

- [x] Corrected YAML parses (`yaml.safe_load` on both the outer ConfigMap and embedded LogQL rules doc)
- [x] `pre-commit run` passes
- [x] Re-verified live against Loki using the exact corrected `expr`, ranged over today's real outage window (2026-08-28, ~13:01-13:06 ET) — returns the expected time series: peaks at 49 occurrences during the loop, decays below the `> 10` threshold as the loop resolved. This is real historical data, not a synthetic test.
- [ ] Post-merge: confirm the ruler picks up the corrected group (same reload path already proven to work post-#13828 — sidecar rewrites `/rules/fake/...`, ruler evaluates on its normal interval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxmRJfvKVLnyy4ShRJQrXs