### PR TITLE
feat(romm): map newly-ingested console/disc platforms

### DIFF
--- a/kubernetes/apps/media/romm/app/resources/config.yml
+++ b/kubernetes/apps/media/romm/app/resources/config.yml
@@ -83,7 +83,16 @@ system:
   platforms:
     #bbc: bbcmicro
     fbneo: arcade
-    #dreamcast: dc
+    # multicade ingest (2026-08-28): console/disc systems added from the cabinet
+    # archive. atari2600/atari7800 auto-detect (folder == slug); the rest are
+    # folder-name -> IGDB-slug overrides (per docs.romm.app supported-platforms).
+    atari2600: atari2600
+    atari7800: atari7800
+    atarijaguar: jaguar
+    dreamcast: dc
+    gc: ngc
+    mastersystem: sms
+    psx: ps
     #gamecube: ngc
     #gamegear: gamegear
     #gb: gb


### PR DESCRIPTION
## What
Adds `system.platforms` mappings to RomM's `config.yml` for seven console/disc
systems whose folders were newly added to the ROM library:

| Folder | IGDB slug | Note |
|---|---|---|
| `atari2600` | `atari2600` | auto-detects (self-map for clarity) |
| `atari7800` | `atari7800` | auto-detects (self-map for clarity) |
| `atarijaguar` | `jaguar` | folder-name override |
| `dreamcast` | `dc` | folder-name override |
| `gc` | `ngc` | folder-name override |
| `mastersystem` | `sms` | folder-name override |
| `psx` | `ps` | folder-name override |

## Why
These platform folders use variant names that don't match RomM's canonical
slugs, so RomM won't catalogue them without the folder→IGDB-slug override
(verified against docs.romm.app supported-platforms). `atari2600`/`atari7800`
already match and are included only as explicit self-maps for a self-documenting
set. Handhelds and NES were intentionally excluded from the source ingest.

## Activation
RomM restarts to pick up the config, then a **COMPLETE** library scan is
required to create rows for the new platforms (the filesystem watcher only
emits UPDATE and won't create new-platform rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)