### PR TITLE
fix(romm): OIDC login 500 — allow egress to envoy:10443, not authelia:9091

### DIFF
--- a/kubernetes/apps/media/romm/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/romm/app/cnp-allow.yaml
@@ -55,22 +55,21 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). RomM uses Authlib server-side OIDC
-    # (OIDC_SERVER_METADATA_URL points at auth.${SECRET_DOMAIN}) to
-    # do the code exchange after user login redirect.
-    # toEntities:[world]:443 and matchPattern:auth.${SECRET_DOMAIN}
-    # DO NOT work for this in-cluster path: split-horizon DNS
-    # returns the LB IP and Cilium socket-lb rewrites the connect()
-    # to the envoy pod IP + targetPort 10443 BEFORE policy check, so
-    # neither rule matches the rewritten destination. Authelia's CNP
-    # already permits fromEntities:cluster on 9091. Mirrors
-    # paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia. RomM uses
+    # Authlib server-side OIDC with OIDC_SERVER_METADATA_URL pointing
+    # at the external issuer auth.${SECRET_DOMAIN}, so every OIDC
+    # request hits split-horizon DNS which returns the internal envoy
+    # LB IP. Cilium socket-lb rewrites the connect() to the envoy pod
+    # IP + targetPort 10443 BEFORE policy evaluation, so the policy
+    # must allow the envoy pod on its container port (10443) — NOT
+    # world:443 (doesn't match cluster LB IPs) and NOT authelia:9091
+    # (RomM never connects there directly given this config). Mirrors
+    # the working paperless egress (kubernetes/apps/collab/paperless).
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP


### PR DESCRIPTION
## Problem

`romm.${SECRET_DOMAIN}/api/login/openid` returned **HTTP 500**. The SSO button on the login page renders empty and clicking it fails. Local username/password auth is unaffected.

## Root cause

Live traceback from `romm-0`:

```
File "/backend/endpoints/auth.py", line 264, in login_via_openid
    return await oauth.openid.authorize_redirect(request, OIDC_REDIRECT_URI)
  ...
    resp = await client.request("GET", self._server_metadata_url, ...)   # OIDC_SERVER_METADATA_URL
  ...
httpx.ConnectTimeout
```

RomM fetches `OIDC_SERVER_METADATA_URL` (`https://auth.${SECRET_DOMAIN}/.well-known/openid-configuration`). That external issuer hostname resolves via split-horizon DNS to the **internal envoy LB IP**, and Cilium socket-lb rewrites the `connect()` to the **envoy pod IP + targetPort 10443** *before* policy evaluation.

The egress rule allowed `authelia:9091` in the `auth` namespace — which never matches the rewritten destination (`envoy:10443` in `network`). The SYN was dropped → `ConnectTimeout` → 500. This path never worked; the rule was mis-targeted. The rule's own comment correctly described the 10443 rewrite but then allowed the wrong endpoint.

## Fix

Point RomM's OIDC egress at the envoy pod on 10443 in the `network` namespace, matching the **working** paperless config (`kubernetes/apps/collab/paperless/app/cnp-allow.yaml`), which uses the identical external metadata URL.

Additive CNP, egress-only. Envoy is the shared ingress gateway and already accepts cluster ingress, so only RomM's egress edge needs the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)