### PR TITLE
fix(vpn): re-pin download-path VPN egress gateway off degraded Mullvad relay

### DIFF
--- a/kubernetes/apps/ai/opencode/app/resources/agent/network-operator.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/network-operator.md
@@ -82,9 +82,10 @@ decline politely and let it go back to the main thread.
   policies. `kube-apiserver` traffic is sensitive to ipBlock-only
   egress rules (Cilium 1.19 silently drops it — see
   `project_cilium_ipblock_apiserver.md`).
-- **Egress** — DataPacket 1:1 NAT (`us-nyc-wg-301`) for downloads
-  gateway; M247 NY is a NAT pool and trips news.newsgroup.ninja 2-IP
-  cap (see `project_mullvad_nat_egress_topology.md`).
+- **Egress** — DataPacket 1:1 NAT (`us-nyc-wg-302`, re-pinned
+  2026-08-28 off a degraded `us-nyc-wg-301`) for downloads gateway;
+  M247 NY is a NAT pool and trips news.newsgroup.ninja 2-IP cap (see
+  `project_mullvad_nat_egress_topology.md`).
 - **OOB recovery path** — wg-easy + the brain firewalld SSH pinhole
   on port 3231. **Treat these as untouchable.**
 

--- a/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
@@ -45,9 +45,10 @@ spec:
   egress:
     # VPN egress. ALL newsgroup connections (news.newsgroup.ninja, etc.)
     # route through the VXLAN tunnel to the gateway pod, then out via
-    # WireGuard. The DataPacket NY pin (us-nyc-wg-301) is what keeps
-    # the 2-IP-cap-sensitive newsgroup provider from rejecting flows
-    # — see memory project_mullvad_nat_egress_topology.md.
+    # WireGuard. The DataPacket NY pin (us-nyc-wg-302, re-pinned
+    # 2026-08-28 off a degraded wg-301) is what keeps the 2-IP-cap-
+    # sensitive newsgroup provider from rejecting flows — see memory
+    # project_mullvad_nat_egress_topology.md.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: vpn

--- a/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
@@ -81,8 +81,25 @@ spec:
               # Pin to a Mullvad relay with 1:1 NAT egress. Their M247 NY
               # servers share a multi-IP NAT pool (.135 / .190 observed),
               # which trips news.newsgroup.ninja's 2-simultaneous-IP cap.
-              # DataPacket NY (wg-301) egresses every flow as 143.244.47.71.
-              SERVER_HOSTNAMES: us-nyc-wg-301
+              # DataPacket NY egresses every flow as a single stable IP.
+              #
+              # Re-pinned 2026-08-28: wg-301 degraded into a sustained
+              # gluetun healthcheck-fail restart loop (dial tcp4 1.1.1.1:443
+              # i/o timeout) three separate times in one day (~13:01-13:06,
+              # ~17:05-17:48, ~18:42-18:47 ET) — not a one-off blip. No
+              # correlating config change on our side; Mullvad's own relay
+              # API (api.mullvad.net/www/relays/wireguard/) showed wg-301 as
+              # active with no status_messages throughout, so this reads as
+              # a wg-301-specific path/relay issue Mullvad hasn't surfaced
+              # publicly, not a provider-wide DataPacket outage. wg-302 is
+              # the same city (New York, NY) and same provider (DataPacket,
+              # confirmed via the same API — preserves the 1:1-NAT-egress
+              # property this pin exists for), just a different physical
+              # relay — no location/latency tradeoff. Public egress IP will
+              # change (was 143.244.47.7x on wg-301; wg-302 is
+              # 143.244.47.78) — nothing in this repo pins the old IP
+              # itself, only the hostname (grepped kubernetes/ tree clean).
+              SERVER_HOSTNAMES: us-nyc-wg-302
             envFrom:
               - secretRef:
                   name: downloads-gateway-vpnconfig


### PR DESCRIPTION
## Summary

- The download-path VPN egress gateway's pinned Mullvad relay (`us-nyc-wg-301`) degraded into a sustained gluetun healthcheck-fail restart loop (`dial tcp4 1.1.1.1:443: i/o timeout`) **three separate times today**: ~13:01-13:06 ET, ~17:05-17:48 ET, ~18:42-18:47 ET. Not an isolated blip — confirmed live at each occurrence, same signature every time (gluetun cycling every ~6s between the relay's IPv4 and IPv6 addresses, failing both).
- No correlating change on our side (`git log` on the affected app dirs is empty for the outage windows). Checked Mullvad's live relay API (`api.mullvad.net/www/relays/wireguard/`) during/around the outages — `us-nyc-wg-301` showed `active: true`, `status_messages: []` throughout, so Mullvad hasn't self-flagged it; this reads as a relay- or path-specific issue on their side that isn't yet reflected in their own status data, not a config regression here.
- **Current egress state as of this PR (19:41 ET):** healthy / self-cleared. No `restarting vpn because it failed to pass the healthcheck` lines in the last 30+ minutes; the downstream app that was crash-looping on the stale session reconnected successfully at 17:50:51 ET and has stayed up since. Re-pinning regardless per the 3-strikes-in-one-day pattern.
- **Replacement: `us-nyc-wg-302`.** Confirmed directly against Mullvad's live JSON (not guessed): same city (New York, NY), same provider (`DataPacket`) — this preserves the 1:1-NAT-egress property the original pin exists for (avoids Mullvad's M247 NY relays, which share a multi-IP NAT pool and trip a downstream newsgroup provider's 2-simultaneous-IP cap; see `project_mullvad_nat_egress_topology.md`). No location/latency tradeoff — same metro as before, just a different physical relay. A third same-city DataPacket option (`us-nyc-wg-303`) also exists if `-302` turns out to have its own issues.
- **Public egress IP will change** as a side effect (was `143.244.47.7x` resolving off wg-301; wg-302's advertised ingress is `143.244.47.78`, though gluetun's actual detected egress IP may differ slightly as observed previously). Confirmed nothing else in the repo pins the old IP itself — only the hostname is referenced, and only in comments (grepped the full `kubernetes/` tree). Two narrative comments (sabnzbd's CNP, the in-cluster opencode agent's persona doc) named the old relay; updated both so they don't go stale, no functional change to either (the CNP itself matches on Cilium pod labels, not the relay hostname).

## Test plan

- [x] `kubectl kustomize kubernetes/apps/vpn/downloads-gateway/app/` renders cleanly; `SERVER_HOSTNAMES: us-nyc-wg-302` confirmed in output
- [x] `kubectl kustomize kubernetes/apps/downloads/sabnzbd/app/` still renders cleanly (comment-only change)
- [x] `pre-commit run` passes (yamllint, envsubst shell-var check, credential scan, etc.)
- [x] Grepped `kubernetes/` for any other reference to the old hostname or its IP — none found beyond the three files changed here
- [ ] Post-merge: confirm gluetun connects cleanly to the new relay and the downstream apps stay stable (no restart-loop recurrence) — the alert from #13828/#13829 will page if it doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxmRJfvKVLnyy4ShRJQrXs