### PR TITLE
fix(dragonfly): split romm onto a dedicated noeviction instance

### DIFF
--- a/kubernetes/apps/databases/dragonfly/cluster/cluster-romm.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster-romm.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: dragonfly-romm
+spec:
+  labels:
+    dragonflydb.io/cluster: dragonfly-romm
+  image: ghcr.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
+  # Dedicated romm tier. Unlike the immich/auth wedges (table-bloat under
+  # #8149, cleared by DEBUG COMPACT-TABLE), romm's footprint is REAL object
+  # data: it caches the entire LaunchBox Games Database into Redis to match
+  # ROMs during scans — ~760Mi across four hash indexes
+  # (romm:launchbox_metadata_{name,folded_name,database_id,image}, 187k
+  # games). On the shared 768Mi `dragonfly` that single legitimate cache
+  # filled the whole noeviction cap and rejected every OTHER tenant's writes
+  # (paperless/netbox/nametag sessions) — the same fat-tenant blast radius
+  # that got immich (#13785) and auth (#13787) split off. Its own instance
+  # contains that: when romm fills, only romm's own scans stall. COMPACT-TABLE
+  # does NOT reclaim this (it's object_used_memory, not table_used_memory) —
+  # the levers are the cap below or dropping the LaunchBox source in the romm
+  # HelmRelease (LAUNCHBOX_API_ENABLED).
+  #
+  # Single replica: romm's Redis state is regenerable — the LaunchBox cache
+  # rebuilds from source, python-rq re-detects outstanding jobs, sessions
+  # re-login. Node-loss HA is not worth 2-3x the (large) RAM, same rationale
+  # as dragonfly-immich/-cache. Core romm (library, users) reads from
+  # Postgres and is unaffected by a queue-pod restart.
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 3Gi
+    limits:
+      memory: 3Gi
+  networkPolicyEnabled: false
+  # Noeviction (NO --cache_mode): romm's python-rq task queue on an evicting
+  # Redis corrupts job state (jobs vanish mid-lifecycle), so it MUST stay
+  # noeviction — same constraint as immich's BullMQ. --maxmemory=2Gi is ~67%
+  # of the 3Gi cgroup limit: mimalloc RSS overhead sits above --maxmemory, so
+  # keep real headroom below limits.memory or the kernel OOM-kills the pod.
+  # 2Gi ≈ 2.6x the ~760Mi LaunchBox baseline, leaving room for a scheduled
+  # LaunchBox rebuild (ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA) plus rq job
+  # churn during a COMPLETE scan of ~10k ROMs. --default_lua_flags=
+  # allow-undeclared-keys preserves parity with the shared `dragonfly`
+  # instance romm ran on (python-rq's atomic Lua scripts).
+  args:
+    - "--maxmemory=2Gi"
+    - "--proactor_threads=2"
+    - "--cluster_mode=emulated"
+    - "--default_lua_flags=allow-undeclared-keys"

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-romm.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow-romm.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly-romm-allow
+spec:
+  # Select on `app: <instance>` — see cnp-allow-auth.yaml for the label
+  # trap this avoids (#13733).
+  endpointSelector:
+    matchLabels:
+      app: dragonfly-romm
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Consumers of `dragonfly-romm.databases.svc.cluster.local:6379`:
+    #   media/romm — python-rq task queue + LaunchBox metadata cache
+    # fromEntities: cluster on 6379 (same rationale as the other tiers).
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
@@ -6,13 +6,16 @@ resources:
   - ./cluster-auth.yaml
   - ./cluster-cache.yaml
   - ./cluster-immich.yaml
+  - ./cluster-romm.yaml
   - ./cluster.yaml
   - ./cnp-allow-auth.yaml
   - ./cnp-allow-cache.yaml
   - ./cnp-allow-immich.yaml
+  - ./cnp-allow-romm.yaml
   - ./cnp-allow.yaml
   - ./podmonitor-auth.yaml
   - ./podmonitor-cache.yaml
   - ./podmonitor-immich.yaml
+  - ./podmonitor-romm.yaml
   - ./podmonitor.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/databases/dragonfly/cluster/podmonitor-romm.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/podmonitor-romm.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dragonfly-romm
+spec:
+  selector:
+    matchLabels:
+      app: dragonfly-romm
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin

--- a/kubernetes/apps/media/romm/app/externalsecret.yaml
+++ b/kubernetes/apps/media/romm/app/externalsecret.yaml
@@ -33,8 +33,12 @@ spec:
         DB_USER: "{{ .POSTGRES_USER }}"
         DB_PASSWD: "{{ .POSTGRES_PASS }}"
 
-        # Redis
-        REDIS_HOST: dragonfly.databases.svc.cluster.local
+        # Redis — dedicated dragonfly-romm instance. RomM caches the full
+        # LaunchBox Games DB (~760Mi) here to match ROMs; on the shared
+        # `dragonfly` that filled the 768Mi noeviction cap and rejected every
+        # other tenant's writes. Split off like immich (#13785) / auth
+        # (#13787) so romm's cache can only wedge romm.
+        REDIS_HOST: dragonfly-romm.databases.svc.cluster.local
         REDIS_PORT: "6379"
 
         # Postgres init

--- a/kubernetes/apps/media/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/media/romm/app/helmrelease.yaml
@@ -73,8 +73,9 @@ spec:
               # Runtime
               ROMM_PORT: &port 8080
               ROMM_DB_DRIVER: postgresql
-              # Redis (host/port from ExternalSecret). Own db index (db2)
-              # so RQ queue keys no longer share db0 with other tenants.
+              # Redis (host/port from ExternalSecret) — now a dedicated
+              # dragonfly-romm instance, so romm is the only tenant. db2 kept
+              # for continuity; the index no longer matters for isolation.
               REDIS_DB: "2"
 
               # Scrapers / scheduled jobs


### PR DESCRIPTION
## What

RomM caches the entire **LaunchBox Games Database** into Redis to match ROMs during scans — **~760 MiB** across four hash indexes (`romm:launchbox_metadata_{name,folded_name,database_id,image}`, 187k games). On the shared 768Mi noeviction `dragonfly` instance, that single legitimate cache filled the whole `--maxmemory` cap and started rejecting **every other tenant's** writes (paperless / netbox / nametag sessions) with `ERR Out of memory`, firing `DragonflyOutOfMemoryErrors` (critical).

This is the same fat-tenant blast radius that got immich (#13785) and auth (#13787) split off — RomM is just the next tenant to outgrow the shared instance.

## Why a dedicated instance (not COMPACT-TABLE / a bigger shared cap)

The immich/auth wedges were table-bloat under dragonflydb#8149, recoverable in place with `DEBUG COMPACT-TABLE`. RomM's pin is different: it's **real `object_used_memory`** (confirmed live — 765.9 MiB of live keys, `table_used_memory` only 2 MiB), so COMPACT-TABLE reclaims nothing. Containing a genuinely-large tenant on its own instance is the structural fix.

## Changes

- **`cluster-romm.yaml`** — dedicated `dragonfly-romm`, 1 replica (state is regenerable), noeviction, `--maxmemory=2Gi` in a 3Gi pod (~2.6× the LaunchBox baseline; headroom for a scheduled LaunchBox rebuild + python-rq churn during a COMPLETE scan).
- **`cnp-allow-romm.yaml`** + **`podmonitor-romm.yaml`** — per-instance ingress + scrape (`app: dragonfly-romm`). `prometheusrule` is instance-generic (excludes only `*-cache`), so the new noeviction instance is auto-covered by both alerts.
- **romm `ExternalSecret`** `REDIS_HOST` → `dragonfly-romm`; `reloader.stakater.com/auto` rolls the pod. The egress CNP already selects the shared operator label (`app.kubernetes.io/name=dragonfly`, stamped on every instance) so **no egress edit** — same as the immich/auth splits.

## Post-merge (manual, not in this PR)

Once RomM repoints and rebuilds its cache on the new instance, the orphaned ~760 MiB left in the **shared** instance's db0 is dead cache and should be cleared (`redis-cli -n 0 flushdb` or a pod restart) to unwedge the remaining session tenants.

## Test

`kubectl kustomize` renders all five Dragonfly instances including `dragonfly-romm`; pre-commit (yamllint, CNP-has-rules, envsubst-escape, secret scans) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)