### PR TITLE
feat(romm): add neogeo platform mapping (arcade reconciliation)

### DIFF
--- a/kubernetes/apps/media/romm/app/resources/config.yml
+++ b/kubernetes/apps/media/romm/app/resources/config.yml
@@ -93,6 +93,8 @@ system:
     gc: ngc
     mastersystem: sms
     psx: ps
+    # arcade reconciliation (2026-08-29): Neo Geo set copied from cabinet -> beast/neogeo.
+    neogeo: neogeoaes
     #gamecube: ngc
     #gamegear: gamegear
     #gb: gb


### PR DESCRIPTION
## What
Adds `neogeo: neogeoaes` to RomM's `config.yml` platform map.

## Why
The **arcade reconciliation** copied the cabinet's Neo Geo set (141 romsets + BIOS)
into a new `beast/neogeo/` folder. RomM has no `neogeo` platform, so it needs the
folder→IGDB-slug mapping (`neogeoaes`) to catalogue it on the next scan. The deduped
arcade set (1,477 romsets) went into the existing `fbneo/` folder, which is already
mapped, so no change is needed for those.

## Activation
RomM restarts to load config, then a COMPLETE (or targeted) scan catalogues the new
`neogeo` platform + the additions to `fbneo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)