### PR TITLE
fix(windmill): bump chart 4.0.247 → 4.0.251 to clear ImagePullBackOff

### DIFF
--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -13,7 +13,12 @@ spec:
         name: windmill
       # Pinned to 4.0.158 — first deploy on chart v4 line. Chart appVersion
       # 1.704.1. Re-pin when bumping; let Renovate manage the suffix.
-      version: 4.0.247
+      # 4.0.247/4.0.249 (appVersion 1.796.0) shipped with no
+      # ghcr.io/windmill-labs/windmill-extra:1.796.0 image published upstream
+      # → ImagePullBackOff. Bumped to 4.0.251 (appVersion 1.799.0, image
+      # exists) rather than reverting, so Renovate has nothing older to
+      # re-propose into the break.
+      version: 4.0.251
   install:
     disableWait: true
   interval: 30m


### PR DESCRIPTION
## Problem

windmill-extra rollout wedged in `ImagePullBackOff` for ~30h (`KubeDeploymentRolloutStuck` + `KubePodNotReady` firing). The old `1.794.0` ReplicaSet kept serving, so no outage.

## Cause

Renovate bumped the chart `4.0.246 → 4.0.247` (#13826). Chart `4.0.247` (and `4.0.249`) pin `appVersion 1.796.0`, but upstream **never published `ghcr.io/windmill-labs/windmill-extra:1.796.0`** — verified HTTP 404 (1.794.0 → 200). Renovate tracks the chart version, not the image, so it couldn't see the missing image; CI renders manifests but doesn't pull images, so it only failed at runtime.

## Fix

Bump to the **latest chart `4.0.251`** (`appVersion 1.799.0`, `windmill-extra:1.799.0` verified 200) rather than reverting to `4.0.246`:
- Reverting goes *older* than the running `1.794.0` and Renovate would immediately re-propose the broken `4.0.x`.
- `4.0.251` is the newest chart, so there's nothing for Renovate to re-bump into the break.

Verified image existence across the range: `4.0.250` (1.798.1) and `4.0.251` (1.799.0) both have published `-extra` images; `1.796.0` and `1.797.1` do not.

## Impact

Flux reconcile rolls windmill-extra from `1.794.0` → `1.799.0` (internal orchestration, not Renee-facing; `disableWait: true`).