### PR TITLE
feat(kuadrant): enable operator (Stage 1, MCP per-tool-authz track)

### DIFF
--- a/docs/src/mcp_tool_authz_design.md
+++ b/docs/src/mcp_tool_authz_design.md
@@ -105,7 +105,8 @@ are not deployed.
 
 The operator **is** staged in-repo at
 [`kubernetes/apps/kuadrant/kuadrant-operator`](https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/kuadrant)
-(chart `kuadrant-operator` 1.1.0) but is commented out of the top-level
+(chart `kuadrant-operator` 1.5.2 — an umbrella pulling in authorino,
+limitador, and dns-operator) but is commented out of the top-level
 kustomization:
 
 ```yaml

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
   - cert-manager
   - cilium-secrets
   - collab
-  # - kuadrant
   - databases
   - downloads
   - external-secrets
   - flux-system
   - home
   - istio-system
+  - kuadrant
   - kube-system
   - longhorn-system
   - mcp-system


### PR DESCRIPTION
## What

Enable the staged (disabled) `kuadrant-operator` app by uncommenting it in the top-level `kubernetes/apps/kustomization.yaml`, and move it to correct alphabetical order (`istio-system` → **`kuadrant`** → `kube-system`; it had been misplaced between `collab` and `databases` while commented). Also corrects the design-doc chart version (`1.1.0` → `1.5.2`, umbrella).

This is **Stage 1** of `docs/src/mcp_tool_authz_design.md` — the prerequisite for enforceable per-tool authz on the MCP gateway. It installs the operator **only**; no `AuthPolicy`/`Kuadrant` CR is attached, so it is inert.

## Why now

The MCP gateway broker has no enforceable per-tool authz today — the client allowlist is a context-budget control, not a security boundary. Attaching a Kuadrant `AuthPolicy` (a later stage) is the only real boundary. This stage just brings the operator online so that work can proceed.

## Pre-flight (read-only) findings

- Chart is an **umbrella 1.5.2**: `kuadrant-operator` + `authorino-operator` 0.25.2 + `limitador-operator` 0.18.3 + `dns-operator` 0.17.1 → 4 controller Deployments, 18 cluster-scoped CRDs, cluster-scoped RBAC. **No admission webhooks.**
- Verified inert via `helm template` + live cluster: no CRD/namespace collision (`kuadrant` ns doesn't exist; the 18 CRDs are disjoint from the live `mcp.kuadrant.io` broker CRDs), and the controllers reconcile against a Gateway/HTTPRoute/EnvoyFilter **only** when a `Kuadrant`/`AuthPolicy`/`RateLimitPolicy` CR targets it — none are staged anywhere in-repo. Envoy Gateways + Authelia `SecurityPolicy` extAuth are a different `gatewayClassName` and untouched.
- **Stage 0 gate cleared:** the 2026-03-31 `disable-kuadrant` was exploratory same-session churn, not a technical Istio conflict. The real Istio pain (ext_proc sidecar dropping the gRPC stream) was against the **mcp-gateway broker**, surfaced May 2, and is already fixed — unrelated to this operator app.

## Verification (post-merge, live-watched)

- `kuadrant-operator` Kustomization `Ready: True`; all 4 Deployments' pods `Running` in ns `kuadrant`.
- **Negative check (the point):** zero new events / Gateway/HTTPRoute status flaps / pod restarts in `mcp-system` and `network`; MCP data-path smoke test still works.
- Exactly 18 new CRDs, no replacements.

## Revert

Re-comment the line; Flux prunes the operator (empty `kuadrant` ns lingers, harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PCnZcvcYgiW2g64jXvZcm