### PR TITLE
feat(music-assistant): move to stable channel (2.10.1), Renovate stable-only

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -59,25 +59,20 @@
       ],
     },
     {
-      // Versioning for music-assistant server + built-in GA watch. We are
-      // held on the 2.10.0 beta line because it wrote a schema-52 library DB
-      // that stable 2.9.9 cannot read (a downgrade attempt cleared the DB and
-      // crashed, 2026-07-18). The `bN` suffix is captured as `prerelease`
-      // (NOT `build`) on purpose: that makes the eventual plain `2.10.0` GA
-      // sort ABOVE `2.10.0bN`, so Renovate auto-opens a PR the moment 2.10.0
-      // leaves beta — the path back to a stable channel with no schema
-      // downgrade (2.10.0 GA reads schema 52 natively). Meanwhile, because
-      // the pinned version is itself a prerelease, Renovate still offers
-      // newer TAGGED betas (bN) — carrying us toward the build where the
-      // Settings → Players refactor is complete — while the `.dev` nightlies
-      // are excluded by the `$` anchor. It never offers 2.9.x (lower than
-      // 2.10.0bN, so not an upgrade). Once we land on 2.10.0 GA, ignoreUnstable
-      // keeps us on the stable line. See memory: project_ma_schema52_stable_path.
-      description: 'Custom versioning for music-assistant server (beta + GA watch)',
+      // Music-assistant server: STABLE channel only (moved off the beta line
+      // 2026-08-29 when 2.10.1 GA landed; the 2.10.0 beta hold is over). The
+      // regex matches ONLY plain `major.minor.patch` stable tags, so the `bN`
+      // betas AND the `.dev` nightlies structurally fail to match and are
+      // never offered — no reliance on ignoreUnstable. Roll-forward within the
+      // stable line is safe (schema-52/55 reads forward); the one-way schema
+      // concern only bit on a downgrade to pre-2.10 stable. If you ever need to
+      // chase a specific beta again, widen the regex with an optional
+      // `(b(?<prerelease>\\d+))?` group. See memory: project_ma_schema52_stable_path.
+      description: 'Custom versioning for music-assistant server (stable channel only)',
       matchDatasources: [
         'docker',
       ],
-      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(b(?<prerelease>\\d+))?$',
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
       matchPackageNames: [
         'ghcr.io/music-assistant/server',
       ],

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -103,20 +103,17 @@ spec:
           app:
             image:
               repository: ghcr.io/music-assistant/server
-              # Held on the 2.10.0 beta line: it wrote a schema-52 library DB
-              # that stable 2.9.9 cannot read (downgrade to 2.9.9 cleared the
-              # DB and crashed — reverted 2026-07-18). Stay on 2.10 and roll
-              # FORWARD to the beta where the Settings → Players refactor is
-              # complete; do NOT downgrade to stable. Renovate tracks the beta
-              # channel (see packageRules.json5).
-              # Reverted b7 → b6 during the 2026-07-22 incident, but the
-              # version was a red herring: BOTH b6 and b7 crashloop on the
-              # WebRTC cert chmod when /data/webrtc_private_key.pem is owned by
-              # the wrong UID (see the 00-fix-webrtc-ownership initContainer).
-              # With that fix in place either beta boots. Staying on b6 for now
-              # to avoid an unnecessary Renee-facing restart; Renovate is free
-              # to roll forward to b7+ on the beta channel again.
-              tag: 2.10.0b15@sha256:4f8a16855a7b4c1141e8586643486e4a736c733e5f58ad2dd98b03924c9a165d
+              # On the 2.10 STABLE channel as of 2.10.1 (GA landed 2026-08-27;
+              # 2.10.1 on 2026-08-29). The 2.10.0 beta line wrote a schema-52/55
+              # library DB that stable 2.9.9 cannot read — but 2.10.0 GA and
+              # 2.10.1 read that schema natively, so b15 → 2.10.1 is a roll
+              # FORWARD (the one-way schema concern only bites on a downgrade).
+              # Renovate now tracks stable only: bN betas + .dev nightlies are
+              # structurally excluded by the regex in packageRules.json5; the
+              # beta-channel hold is over. The 00-fix-webrtc-ownership
+              # initContainer below is what keeps this line booting regardless
+              # of tag. Background: memory project_ma_schema52_stable_path.
+              tag: 2.10.1@sha256:e6edefe825b1cdc50223c16d9bc2fca909a158b36555a7763512b76ba04a1b9e
 
             env:
               # Smart Fades' Beat This! beat-tracking model downloads its


### PR DESCRIPTION
## What

Move Music Assistant off the 2.10.0 **beta** line onto the **stable** channel, and tighten Renovate so it only ever offers stable releases.

- **helmrelease.yaml** — pin `2.10.0b15` → **`2.10.1`** (new multi-arch digest `e6edefe8…`); rewrite the now-stale beta-hold comment.
- **packageRules.json5** — tighten the MA versioning regex from `…(b(?<prerelease>\d+))?$` to `…\d+$`. `bN` betas and `.dev` nightlies now **structurally fail to match**, so Renovate offers stable `major.minor.patch` only — no reliance on `ignoreUnstable`.

## Why

`2.10.1` is the current stable ("Latest", 2026-08-29); `2.10.0` GA landed 2026-08-27. That's the GA moment the old rule's comment was waiting for. `b15 → 2.10.1` is a roll **forward**, so the one-way schema-52/55 concern (only bites on a downgrade) doesn't apply.

## Impact

Renee-facing restart (~2.5 GB cold pull). helm `timeout` is already 15m to absorb the slow first pull. The `00-fix-webrtc-ownership` initContainer keeps the pod booting regardless of tag.

Background: memory `project_ma_schema52_stable_path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)