### PR TITLE
chore(privacy): scrub a private individual's name from public docs & comments

### DIFF
--- a/.agents/instructions/storage-class.instructions.md
+++ b/.agents/instructions/storage-class.instructions.md
@@ -176,7 +176,7 @@ retention), not provided by the tier itself.
 When declaring a direct-NFS PV, set `mountOptions` to its workload tier's full
 set in a **single** block — `mountOptions` are immutable, so each later change
 means deleting/recreating the PV and remounting the pod (a maintenance window;
-Renee-facing PVs → Tuesday 02:00–04:00). For the reference pattern
+household-facing PVs → Tuesday 02:00–04:00). For the reference pattern
 (`["nfsvers=4.2","nconnect=8","hard","noatime"]`) see the already-tuned PVs at
 `kubernetes/apps/media/immich/app/nfs-pvc.yaml` and
 `kubernetes/apps/storage/garage/app/nfs-pvc.yaml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Non-emergency disruptive changes wait for one of these windows
 - **Routine** (internal services, Windmill,
   MCP servers, observability, storage backends): any night,
   02:00–05:00.
-- **Renee-facing** (Home Assistant, Music Assistant, Jellyfin,
+- **household-facing** (Home Assistant, Music Assistant, Jellyfin,
   Frigate, voice services, lighting / climate / locks): Tuesday
   02:00–04:00 only.
 

--- a/docs/src/cluster_upgrade.md
+++ b/docs/src/cluster_upgrade.md
@@ -140,7 +140,7 @@ The per-node critical path dropped from ~40 min to ~7–10 min once these were i
 
 ### Stateful data integrity across reboots — MANDATORY (added after the 1.36.4 run)
 
-The 1.36.4 run **silently rewound a Renee-facing media-server config volume**
+The 1.36.4 run **silently rewound a household-facing media-server config volume**
 (its library index + watch history) to a weeks-old state, while the media files
 themselves — on a separate volume — were untouched. This is the most dangerous
 class of upgrade damage because it is invisible until a user notices, and the
@@ -182,7 +182,7 @@ flushed.
    is fresh and clean.
 
 3. **Make DB-heavy backups app-consistent.** Longhorn block snapshots are **not
-   crash-consistent** for a live SQLite DB. For the busiest Renee-facing DB apps
+   crash-consistent** for a live SQLite DB. For the busiest household-facing DB apps
    (the media server above all): enable the app's own scheduled DB backup to a
    separate PVC, **or** checkpoint the WAL (`PRAGMA wal_checkpoint(TRUNCATE)`)
    ahead of the snapshot, **or** scale the app down for the snapshot window.

--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -1272,7 +1272,7 @@ storage agree.
 
 Time budget: 2–3 m of downtime per HR. Pick a maintenance
 window per `CLAUDE.md` if the component is operator- or
-Renee-facing.
+household-facing.
 
 ### Local inference path down — escalation fallback
 

--- a/docs/src/orchestration_substrate.md
+++ b/docs/src/orchestration_substrate.md
@@ -32,7 +32,7 @@ decommission detail. What's left:
   and its HolmesGPT enrichment were removed 2026-07-06 (a separate,
   earlier decommission); AlertManager fires and pages Pushover
   directly.
-- **HA voice + ntfy notifications** for Renee-facing surfaces.
+- **HA voice + ntfy notifications** for household-facing surfaces.
   Currently end-user-driven, not agent-mediated.
 - **Known gap, not yet fixed:** the HA voice "inbox …" intent (a
   `rest_command` in `home-assistant-config`) still POSTs toward the
@@ -76,7 +76,7 @@ When the substrate exists, every task carries:
 - `trace_id` — OpenTelemetry-compatible
 - `origin` — `open-webui` | `ha-voice` | `android` | `observer` |
   `scheduled` | `manual`
-- `requester` — `rob` | `renee` | `system`
+- `requester` — `rob` | `member` | `system`
 - `intent` — natural-language string
 - `priority` — `low` | `normal` | `high` | `urgent`
 - `destructive` — bool, planner sets/confirms
@@ -89,9 +89,9 @@ When the substrate exists, every task carries:
 
 Tasks without this envelope are rejected at ingress.
 
-## Renee allowlist (forward-looking)
+## Household-user allowlist (forward-looking)
 
-When the substrate exists, Renee's intents are auto-approved when
+When the substrate exists, the household user's intents are auto-approved when
 they fall into these categories:
 
 - Media playback (Jellyfin, Music Assistant, Kodi)
@@ -100,8 +100,8 @@ they fall into these categories:
 - Scenes
 - Locks-unlock-when-already-home (NOT from-away)
 
-Anything else from Renee routes to Rob's queue with a Renee-originated
-tag. Renee never sees admin output, stack traces, or restricted-tier
+Anything else from the household user routes to Rob's queue with a household-originated
+tag. The household user never sees admin output, stack traces, or restricted-tier
 data.
 
 Start narrow — easier to widen than retract.

--- a/docs/src/vllm_spark_migration_plan.md
+++ b/docs/src/vllm_spark_migration_plan.md
@@ -310,7 +310,7 @@ open-webui + LightRAG + opencode.
 
 Each phase has a validation gate; do not proceed until it passes. Disruptive
 steps run in a **routine maintenance window (02:00–05:00 ET)** — the affected
-services (Open WebUI, LightRAG) are routine-tier, not Renee-facing.
+services (Open WebUI, LightRAG) are routine-tier, not household-facing.
 
 ### Phase 0 — Prerequisites (no cluster change)
 

--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
               # pins bge-m3 and qwen2.5-coder for longer. That is the real
               # cost: the resident FLOOR rises, where previously models
               # decayed between bursts, and that floor eats Immich CLIP
-              # burst headroom on a GPU that also serves Renee's whisper.
+              # burst headroom on a GPU that also serves the household user's whisper.
               # The measured ceiling is unchanged at 7.99 GiB.
               #
               # 30m rather than infinite: long enough that the 5-min
@@ -120,7 +120,7 @@ spec:
                 memory: 6G
                 # Right-sized from 2000m: ollama is GPU-bound, and the 2-core
                 # reservation monopolized worker8 (the only P40 node), starving
-                # co-scheduled GPU workloads that MUST land here (Renee-facing
+                # co-scheduled GPU workloads that MUST land here (household-facing
                 # wyoming-whisper, immich CLIP/pet-tagger). No CPU limit, so it
                 # still bursts under load.
                 cpu: 500m

--- a/kubernetes/apps/home/frigate/app/restart-cronjob.yaml
+++ b/kubernetes/apps/home/frigate/app/restart-cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   # Weekly restart to clear the upstream ffmpeg/recording memory leak
   # (frigate working-set sawtooths to ~14Gi and OOM-resets). Tuesday
-  # 02:00 is the Renee-facing maintenance window (CLAUDE.md). k8tz
+  # 02:00 is the household-facing maintenance window (CLAUDE.md). k8tz
   # transparently injects timeZone: America/New_York on this cluster, so
   # the schedule below is local ET — do NOT set an explicit timeZone
   # (matches frigate-snapshot). NOTE: a weekly cadence does not prevent

--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
   #
   # The recorder DB measures 8.5 GiB live (the 120Gi elsewhere is the
   # provisioned PVC, not the data). An ALTER TABLE on states/events at
-  # that size can still run past 5m, and this is Renee-facing — lights,
+  # that size can still run past 5m, and this is household-facing — lights,
   # locks and climate — so failing forward and staying visible as
   # Ready=False beats reverting into a version that cannot read its own
   # schema.

--- a/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
@@ -27,7 +27,7 @@ spec:
     # 2) Cilium LoadBalancer Service at 10.45.0.11:8096. LAN Kodi
     #    clients (kodi-familyroom 192.168.1.11, etc.) and other LAN
     #    consumers connect directly to the LB IP — these arrive at
-    #    the pod as `reserved:world`. Renee's primary playback path —
+    #    the pod as `reserved:world`. The household user's primary playback path —
     #    must remain reachable.
     - fromEntities:
         - world

--- a/tools/immich-frame-video-transcode.sh
+++ b/tools/immich-frame-video-transcode.sh
@@ -209,7 +209,7 @@ fi
 c "${#NEED[@]} video(s) need a (re-)transcode: ${NEED[*]}"
 
 if [ "$ASSUME_YES" != 1 ]; then
-  printf '\nThis will temporarily flip Immich transcode policy to "bitrate" (cap: 1080p / 8 Mbps) and RESTART %s TWICE (Renee-facing photo/frame blip). Proceed? [y/N] ' "$STS"
+  printf '\nThis will temporarily flip Immich transcode policy to "bitrate" (cap: 1080p / 8 Mbps) and RESTART %s TWICE (household-facing photo/frame blip). Proceed? [y/N] ' "$STS"
   read -r ans; [ "$ans" = y ] || [ "$ans" = Y ] || die "aborted by user"
 fi
 


### PR DESCRIPTION
A private household member's name appeared in public artifacts — `docs/src/`
pages that render to the public GitHub Pages site, `AGENTS.md`, an agent
instruction file, several HelmRelease/CronJob code comments, and one tool
script. Per the household privacy rule, replace every occurrence with the
neutral role descriptor **"the household user"** (and **"household-facing"**
for the maintenance-window / surface compounds).

- Docs and comments only — **no behavioral change**.
- 11 files, all prose/comments.
- Note: this removes the name from `HEAD` only; it remains in commit
  history. History rewrite (filter-repo + force-push) is a separate,
  deliberate decision that has not been taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9VX4vUgm2oEmBS9DBtnCk