### PR TITLE
fix(kuadrant): raise HelmRelease install/upgrade timeout to 15m

### DIFF
--- a/kubernetes/apps/kuadrant/kuadrant-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kuadrant/kuadrant-operator/app/helmrelease.yaml
@@ -13,6 +13,19 @@ spec:
         name: kuadrant
       version: 1.5.2
   interval: 30m
+  # 15m timeout tolerates a cold first-pull of the 4-image operator umbrella
+  # (kuadrant/authorino/limitador/dns from quay.io) exceeding Helm's default
+  # 5m --wait; retries self-heal a transient timeout instead of stalling on
+  # MissingRollbackTarget (no prior release to roll back to on first install).
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    cleanupOnFail: true
+    remediation:
+      retries: 3
   # https://artifacthub.io/packages/helm/kuadrant/kuadrant-operator
   # https://github.com/Kuadrant/kuadrant-operator/blob/main/charts/kuadrant-operator/values.yaml
   values:


### PR DESCRIPTION
## What

Add `install`/`upgrade` timeout (15m) + remediation retries to the `kuadrant` HelmRelease.

## Why

Follow-up to #13841 (Stage 1 operator enable). The operator umbrella pulls **4 images** (`kuadrant`/`authorino`/`limitador`/`dns` from quay.io) on first install. On a cold node that pull exceeded Helm's default **5m `--wait`**, so:

1. install timed out → `InstallFailed`
2. remediation found **no prior successful release** to roll back to
3. HR stalled terminally: `Stalled=True (MissingRollbackTarget)` — while the 4 Deployments were actually `Available=True`/healthy.

A stalled HR won't self-heal and blocks future Renovate chart bumps.

## Fix

- `timeout: 15m` tolerates a cold multi-image operator pull on any node.
- `remediation.retries: 3` self-heals a transient timeout instead of stalling.
- **Also clears the current stall**: the `.spec` change bumps the generation → Flux re-reconciles → images are now cached → release completes → `Ready: True`. GitOps-clean, no manual `flux --force`.

## Verify

`flux get hr -n kuadrant kuadrant` → `Ready: True`; operator pods stay 4/4; mcp-system untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PCnZcvcYgiW2g64jXvZcm