### PR TITLE
fix(downloads): raise qbittorrent memory limit 3Gi→6Gi for page-cache headroom

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -59,14 +59,19 @@ spec:
               QBT_WEBUI_PORT: &httpPort 8080
 
             # In-place resize (k8s 1.35 GA): a live memory/CPU bump applies
-            # without restarting the container. The OOM cause was libtorrent
-            # 2.x mmap disk IO + OS cache on the NFS download paths (working set
-            # ballooned to ~9 GiB of page cache while RSS stayed ~110 MB); fixed
-            # live in the WebUI (Disk IO type=POSIX, read/write mode=Disable OS
-            # cache) so it now holds ~110 MiB. 1Gi/3Gi replaces the old 8G/12G
-            # headroom that only existed for that eliminated balloon — 3Gi still
-            # covers recheck spikes ("Outstanding memory when checking" = 32 MiB
-            # x concurrent). Watching for OOM at the smaller ceiling.
+            # without restarting the container. libtorrent 2.x relies on the OS
+            # page cache for disk IO; disabling it (O_DIRECT) crippled write
+            # throughput on the NFS download paths, so OS cache is re-enabled in
+            # the WebUI. Disk IO type stays POSIX (not mmap): POSIX buffered
+            # pages are reclaimable and dirty-page writeback self-throttles, so
+            # the cache stays bounded rather than the unbounded whole-file mmap
+            # balloon that caused the original OOM. With cache on, page cache
+            # fills memory.current to the ceiling while working set stays ~110
+            # MiB (the cache is invisible to working-set metrics). 6Gi gives that
+            # reclaimable cache + recheck spikes ("Outstanding memory when
+            # checking" = 32 MiB x concurrent) headroom off the wall, still well
+            # under the ~9 GiB the mmap balloon hit. Request stays 1Gi — the
+            # cache is reclaimable, not a reservation. Watching memory.current.
             resizePolicy:
               - resourceName: cpu
                 restartPolicy: NotRequired
@@ -78,7 +83,7 @@ spec:
                 cpu: 35m
                 memory: 1Gi
               limits:
-                memory: 3Gi
+                memory: 6Gi
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Raise the qbittorrent container memory **limit** from 3Gi → 6Gi. Request stays 1Gi.

## Why

Downloads went very slow after OS cache was disabled. Disabling the OS cache (O_DIRECT) was bundled with the earlier POSIX-disk-IO fix to stop an OOM crashloop, but O_DIRECT on the NFS download paths kills write throughput — every write is a synchronous round-trip with no coalescing, which backpressures the peer connections and collapses download rate.

Re-enabling OS cache restores throughput. It's safe to do now **because the disk IO type stays POSIX, not mmap**: the original unbounded balloon was a whole-file-mmap phenomenon (dirty mapped pages couldn't be reclaimed on NFS → OOM at the old 12G ceiling). POSIX buffered page cache is reclaimable and dirty-page writeback self-throttles, so it stays bounded.

Observed after re-enabling cache: reclaimable page cache fills `memory.current` to the ceiling within minutes while working set stays ~110 MiB (the cache is invisible to working-set metrics). Pinned exactly at the 3Gi wall leaves zero margin for recheck spikes. 6Gi gives that reclaimable cache + recheck spikes headroom off the wall, still well under the ~9 GiB the mmap balloon hit.

## Notes

- **No restart:** the container already carries `resizePolicy` with `restartPolicy: NotRequired` (k8s 1.35 in-place resize), so the limit bump applies live — no pod restart, no interrupted downloads.
- worker3 (current host) has ~42 GiB available; the burst headroom is there.
- Stale OOM comment in the HelmRelease rewritten to match this decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)