### PR TITLE
ci: retire Fairwinds digest-mismatch tolerance in image-registry-check

### DIFF
--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -87,33 +87,10 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           shell: sh
-          # workaround: https://github.com/FairwindsOps/charts/issues/1879 — remove when Fairwinds re-indexes
-          # The Fairwinds Helm repo (charts.fairwinds.com) publishes an
-          # index.yaml whose `digest:` for vpa no longer matches the
-          # served .tgz, so flate's strict reconcile exits non-zero. flate still
-          # writes the full image list to stdout, so we keep images.json and
-          # tolerate ONLY when every reconcile failure is a `fairwinds-charts-*
-          # … digest mismatch`; any other error (or a transient failure) exits
-          # non-zero so retry / the job still fails loud. Same tolerance as
-          # flate.yaml's `test` job.
           command: |
-            set +e
             flate get images \
               --path "$GITHUB_WORKSPACE/kubernetes/flux" \
-              --output json > images.json 2> flate.err
-            rc=$?
-            set -e
-            cat flate.err >&2
-            [ "$rc" -eq 0 ] && exit 0
-            clean="$(sed 's/\x1b\[[0-9;]*m//g' flate.err)"
-            total="$(printf '%s\n' "$clean" | grep -oE 'reconcile completed with [0-9]+ failure' | grep -oE '[0-9]+' | tail -1)"
-            tolerated="$(printf '%s\n' "$clean" | grep -cE 'fairwinds-charts-.*digest mismatch' || true)"
-            if [ -n "$total" ] && [ "$total" -gt 0 ] && [ "$total" -eq "$tolerated" ]; then
-              echo "::warning::flate get images: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa) — see FairwindsOps/charts#1879. Image list still emitted."
-              exit 0
-            fi
-            echo "::error::flate get images failed with untolerated errors (failed=${total:-unknown}, tolerated Fairwinds digest mismatches=${tolerated})."
-            exit "$rc"
+              --output json > images.json
 
       # Multi-line heredoc avoids needing jq for this step — file is
       # already valid JSON, just plumb it through. printf ensures a


### PR DESCRIPTION
## What

Reverts the `Gather images` step in `.github/workflows/image-registry-check.yaml` back to a plain `flate get images ... > images.json`, dropping the Fairwinds `# workaround:` tolerance branch (the `sed`/`grep` "tolerate only `fairwinds-charts-* digest mismatch`" wrapper). The legitimate `nick-fields/retry` cold-cache wrapper is kept.

## Why now

[FairwindsOps/charts#1879](https://github.com/FairwindsOps/charts/issues/1879) is resolved. Verified **live** on 2026-08-29: the served `vpa`/`goldilocks` `.tgz` `sha256sum`s now match the `digest:` fields in `charts.fairwinds.com/index.yaml`, so the strict `flate get images` reconcile no longer exits non-zero on them. The tolerance is dead weight.

This mirrors the sibling `flate.yaml` `test` job, whose equivalent tolerance was already removed when #12758 closed. This copy in `image-registry-check.yaml` was orphaned behind that same (now-closed) tracking issue — no separate open `workaround`-labeled issue exists to close.

## Verification

Per the upstream-watcher discipline for CI-tolerance workarounds: **the removal PR's own CI run is the proof.** If `Image Registry Check` goes green here against current chart versions, the tolerance is confirmed obsolete; if it reds, the workaround still earns its keep and this PR should not merge. No cluster state is touched — do not `--admin`-merge past a red run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)