### PR TITLE
feat(github-mcp): scope to read-only tools

### DIFF
--- a/kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml
@@ -71,6 +71,17 @@ spec:
               - --base-path
               - /mcp
               - --trust-proxy-headers
+              # Least-privilege: expose read-only tools only. This is an
+              # internet-adjacent MCP (reachable via the mcp-gateway
+              # broker), and the default tool set includes destructive
+              # ops like delete_repository. --read-only makes the server
+              # skip every write tool (v1.10.0+ fails closed on invalid
+              # flags). GitHub writes remain available via `gh` in an
+              # interactive session; no automation depends on github-mcp
+              # writes (the claude-runner posts issues via its own PAT).
+              # Widen to an explicit `--toolsets`/`--tools` allowlist if a
+              # write workflow through the broker is ever needed.
+              - --read-only
             envFrom:
               - secretRef:
                   name: github-mcp-secret


### PR DESCRIPTION
## What
Adds `--read-only` to the `github-mcp-server` container args in `kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml`.

## Why
The server ran with **no tool scoping**, so the mcp-gateway broker exposed *every* tool — including destructive ops like `delete_repository` — on an internet-adjacent MCP. github-mcp-server v1.10.0+ added a fail-closed `--read-only` flag (invalid flags error at startup). Enabling it makes the server skip all write tools.

## No functional loss
- GitHub writes remain available via `gh` in an interactive session.
- No automation depends on github-mcp writes — the claude-runner posts issues via its own scoped PAT, not this MCP.
- Widen later to an explicit `--toolsets`/`--tools` allowlist if a write workflow through the broker is ever needed (one-line change).

## Verification
Post-reconcile: the broker's `tools/list` for the github upstream should no longer advertise write tools; the pod starts clean (a bad flag would fail closed at startup).

Source: adoption-scout digest #13772 Section 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)