### PR TITLE
feat(renovate-operator): gate UI behind Authelia extAuth

### DIFF
--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -86,6 +86,7 @@ data:
             - 'konflate.${SECRET_DOMAIN}'
             - 'monica.${SECRET_DOMAIN}'
             - 'opencode.${SECRET_DOMAIN}'
+            - 'renovate.${SECRET_DOMAIN}'
           policy: 'one_factor'
           subject: 'group:lldap_admin'
         # Household-tier (was authorization_policy: one_factor)

--- a/kubernetes/apps/renovate/renovate-operator/app/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/renovate/renovate-operator/app/securitypolicy.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/securitypolicy.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# extAuth via Authelia (#12767) — same pattern as the kube-ops-view
+# pilot (#12779) and every other internal UI in this cluster. The
+# renovate-operator route was the lone internal app with no SSO gate
+# in front of it; its own 6.x UI-authorization model was the only
+# guard. Put it behind Authelia like the rest instead of relying on
+# the operator's (unverified, OAuth-App-dependent) native auth.
+# failOpen stays false: Authelia down means deny, not an open app.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: renovate-operator-extauth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: renovate-operator
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - name: authelia
+          namespace: auth
+          port: 9091
+      path: /api/authz/ext-authz/
+      headersToBackend:
+        - Remote-User
+        - Remote-Groups
+        - Remote-Name
+        - Remote-Email


### PR DESCRIPTION
## What
Adds a standard Authelia `extAuth` SecurityPolicy in front of the `renovate-operator` HTTPRoute, wiring the renovate UI into cluster SSO.

## Why
The renovate route was the **only internal app with no Authelia gate** — the operator's own 6.x UI-authorization model was the sole guard. That model is unverified and depends on a GitHub OAuth App login backend we don't have wired: the token in `auth/github-auth-token.yaml` is a `GithubAccessToken` installation token used as `RENOVATE_TOKEN` (repo access for the runner), **not** a UI login mechanism. Rather than stand up the operator's bespoke auth (new moving part, OAuth-App dependency, lockout risk), this uses the cluster's established pattern.

Same extAuth SecurityPolicy shape as the kube-ops-view pilot (#12779) and every other internal UI (glance, monica, frigate, windmill, …). `failOpen: false` — Authelia down means deny, not an open app.

## Scope / safety
- Targets the `renovate-operator` HTTPRoute, which serves only `/` → svc port **8081** (the UI).
- The GitHub **webhook receiver is a separate service port (8082)**, not carried by this route → extAuth does **not** touch webhook delivery.
- Pure GitOps, reversible in one revert.

## Verification
After reconcile: hitting the renovate UI hostname unauthenticated should redirect to Authelia; an authenticated session with the right group passes through. Webhook-triggered renovate runs continue to fire.

Source: adoption-scout digest #13772 Section 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)