### PR TITLE
feat(mcp-authz): per-tool authz on an additive listener (Stages 2-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-173-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-95-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-98-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/docs/src/mcp_tool_authz_design.md
+++ b/docs/src/mcp_tool_authz_design.md
@@ -209,6 +209,61 @@ The second bullet is the whole point of the exercise. If a session can
 still reach a mutating tool by lifting its own client-side gate, nothing
 has been gained.
 
+#### Enumeration test (the wristband)
+
+The third bullet — `tools/list` omits denied tools — is enforced by the
+ES256 "wristband" (`x-mcp-authorized` header) and must be tested
+explicitly, because the invocation gate and the enumeration gate are
+independent code paths in the broker. Invocation denial passing does
+**not** imply enumeration filtering works.
+
+Run all three from a pod that can reach the istio Service, with the
+opencode bearer token:
+
+```sh
+TOKEN=$(kubectl -n mcp-system get secret mcp-gateway-opencode-jwt-current \
+  -o jsonpath='{.data.token}' | base64 -d)
+URL=http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp
+
+# tools/list on the AUTHENTICATED listener (Host selects mcp-authz).
+curl -s "$URL" -H "Host: mcp-authz.mcp.local" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | tee /tmp/authz.json | jq -r '.result.tools[].name' | sort > /tmp/authz-tools.txt
+```
+
+Assertions (the test passes only if all hold):
+
+1. **Returned set equals the allowlist.** `/tmp/authz-tools.txt` must equal
+   the 31 prefixed real-tool names the wristband `allowed-capabilities`
+   map enumerates (19 `kubectl_*` + 6 `prom_*` + 6 `time_*` reads) — the
+   same 31 the AuthPolicy `tool-access-check` predicate allows minus its
+   two meta-tools. `discover_tools` / `select_tools`
+   are broker-native meta-tools with no upstream `MCPServerRegistration`,
+   so the broker cannot map them to a server and they remain listed;
+   allow for them in the diff. `diff <(sort /tmp/authz-tools.txt) <(sort
+   allowlist.txt)` should show only those two meta-tools, nothing from
+   `omada_*`, `ha_*`, `arr_*`, `comfyui_*`, `kubectl_kubectl_apply`,
+   `kubectl_delete_resource`, etc.
+2. **Denied tools are absent, not merely un-callable.** Grep the returned
+   set for a known-mutating name (`grep -c kubectl_kubectl_apply
+   /tmp/authz-tools.txt` == 0, `grep -c '^omada_' == 0`). This is the new
+   property: on the pre-wristband build these names appeared in the list
+   (but 403'd on call); they must now be *gone from the enumeration*.
+3. **The `mcp` listener is unaffected.** The same `tools/list` sent with
+   `Host: mcp.example.com` (the public listener, no wristband) must still
+   return the full ~1300-tool catalogue — proving the wristband filtering
+   is scoped to the authenticated path and did not leak onto the shared
+   listener. `wc -l` on that path's tool names ≫ 31.
+
+Negative control for the fail-closed edge: a request to `mcp-authz` with a
+**malformed** `x-mcp-authorized` header (or a token the broker's public
+key can't verify) must return an **empty** tool list, not the full one
+(broker `applyAuthorizedCapabilitiesFilter` returns `[]` on validation
+failure). This confirms a forged wristband cannot widen enumeration.
+
 ## Proposed initial allowlist for opencode
 
 Read-only to start, matching the credential posture already chosen for

--- a/kubernetes/apps/kuadrant/kuadrant-operator/app/kuadrant.yaml
+++ b/kubernetes/apps/kuadrant/kuadrant-operator/app/kuadrant.yaml
@@ -1,0 +1,25 @@
+---
+# TODO: apply schema (kuadrant.io CRDs ship no upstream JSON schema; not in
+# datreeio/CRDs-catalog or k8s-schemas.home-operations.com as of 2026-08-29)
+#
+# The Kuadrant CR is the instance object the kuadrant-operator reconciles to
+# actually wire the data path: it deploys the Authorino instance (external
+# authorization service) and registers the Istio wasm-shim/EnvoyFilter that
+# lets an AuthPolicy take effect. Installing the operator chart alone (Stage 1)
+# does NOT do this — with no Kuadrant CR present the operator builds an EMPTY
+# wasm configuration (observed in kuadrant-operator logs: IstioExtensionReconciler
+# "build Wasm configuration" completes with nothing to inject, and
+# `kubectl get authorino -A` / `kubectl get wasmplugins -A` are both empty).
+#
+# BLAST RADIUS: the operator's Istio integration only touches gateways of
+# gatewayClassName: istio. In this cluster the ONLY istio-class Gateway is
+# mcp-system/mcp-gateway (network/external + network/internal are envoy class,
+# which Kuadrant's Istio path does not touch). Creating this CR deploys
+# Authorino + registers the shim but injects NO enforcing filter onto any
+# listener until an AuthPolicy targets it — so on its own it changes no
+# existing traffic. Empty spec: components/mtls/observability all default off.
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+spec: {}

--- a/kubernetes/apps/kuadrant/kuadrant-operator/app/kustomization.yaml
+++ b/kubernetes/apps/kuadrant/kuadrant-operator/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml
+  - ./kuadrant.yaml

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/authpolicy-opencode.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/authpolicy-opencode.yaml
@@ -1,0 +1,171 @@
+---
+# TODO: apply schema (kuadrant.io CRDs ship no upstream JSON schema; not in
+# datreeio/CRDs-catalog or k8s-schemas.home-operations.com as of 2026-08-29.
+# Field shape verified live against the installed CRD via `kubectl explain
+# authpolicy.spec` on 2026-08-29 — Authorino 0.25.2 / kuadrant-operator 1.5.2.)
+#
+# ===========================================================================
+# CORE ENFORCEMENT for the unattended in-cluster opencode agent.
+# This is the ACTUAL security boundary (unlike the MCPVirtualServer header,
+# which the client chooses for itself). It attaches to ONE listener
+# (sectionName: mcp-authz) so it cannot affect the unauthenticated `mcp`
+# listener that langgraph / Open WebUI / Rob's laptop ride.
+# See docs/src/mcp_tool_authz_design.md.
+#
+# Two independent gates, both must pass:
+#   1. IDENTITY  — a valid Authelia-issued JWT with audience `mcp-gateway-opencode`.
+#                  A caller with no token, or a token for a different audience,
+#                  is rejected at authentication (401). This proves the caller
+#                  is the opencode identity, not just any in-cluster pod.
+#   2. TOOL GATE — the MCP Router sets `x-mcp-toolname` from the JSON-RPC body
+#                  (the client cannot forge it). The request is allowed ONLY if
+#                  that tool name is in the read-only allowlist below. Every
+#                  mutating tool (kubectl apply/patch/delete/scale/rollout,
+#                  every omada_/ha_/arr_/comfyui_ write) is absent from the
+#                  list and therefore DENIED (403) — and denied even if the
+#                  session calls select_tools to try to widen its own view,
+#                  because select_tools changes the client's tools/list, not
+#                  the router-set x-mcp-toolname on a subsequent tools/call.
+#
+# WIDENING LATER IS A ONE-LINE CHANGE: add the tool name to the CEL list
+# literal in spec.rules.authorization.tool-access-check. Nothing else moves.
+#
+# ENUMERATION GATE (wristband) — NOW WIRED (see spec.rules.response below).
+# The broker-side mechanism was confirmed against the deployed broker source
+# (ghcr.io/kuadrant/mcp-gateway:v0.9.0):
+#   - broker reads the `x-mcp-authorized` REQUEST header
+#     (internal/broker/filtered_tools_handler.go:20 —
+#      authorizedCapabilitiesHeader = "x-mcp-authorized"),
+#   - validates it as an ES256 JWT with env TRUSTED_HEADER_PUBLIC_KEY
+#     (broker.go:28 os.Getenv("TRUSTED_HEADER_PUBLIC_KEY")), and
+#   - filters tools/list to the JWT's `allowed-capabilities` claim
+#     (a JSON STRING of {"tools": {"<mcp-server-name>": ["<unprefixed>",…]}};
+#      filtered_tools_handler.go:23,156,166,191 — the broker strips each
+#      server's registration prefix, so tool names in the claim are
+#      UN-prefixed and grouped by MCPServerRegistration name).
+# The public key is wired into the broker by setting trustedHeadersKey on the
+# MCPGatewayExtension (mcpgatewayextension.yaml). Enforcement is INERT on the
+# `mcp`/`mcps` listeners: they send no `x-mcp-authorized` header and the
+# broker's enforce-capability-filtering flag stays default `false` (fail-open
+# without the header), so only THIS listener's traffic (which carries the
+# wristband) is enumeration-filtered.
+#
+# IMPORTANT header-name caveat: the v0.9.0 broker header is `x-mcp-authorized`
+# and the claim key is `allowed-capabilities` — this DIFFERS from the Red Hat
+# reference article (`x-authorized-tools` / `allowed-tools`) and the Kuadrant
+# flow doc (`x-authorised-tools`). Verified from source, not the articles.
+# ===========================================================================
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: mcp-gateway-opencode
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: mcp-gateway
+    # Listener-scoped: enforcement applies ONLY to the mcp-authz listener.
+    # The `mcp` and `mcps` listeners carry no policy and are untouched.
+    sectionName: mcp-authz
+  rules:
+    authentication:
+      # Identity gate. Only an Authelia-issued JWT with the opencode audience
+      # is accepted. Same issuer + JWKS the Envoy SecurityPolicy already
+      # trusts (securitypolicy.yaml), but validated here by Authorino on the
+      # Istio path. Bearer token in the Authorization header (Authorino default).
+      authelia:
+        jwt:
+          issuerUrl: "https://auth.${SECRET_DOMAIN}"
+        # Require the opencode-specific audience so a token minted for the
+        # existing human `mcp-gateway` client (audience: mcp-gateway) cannot
+        # be replayed here to reach the authz listener. `aud` may be a string
+        # or an array in a JWT; normalise both to a list before membership.
+        # (auth.identity is the decoded token object in Authorino's auth JSON.)
+        when:
+          - predicate: |
+              has(auth.identity.aud)
+              && (type(auth.identity.aud) == string
+                    ? auth.identity.aud == 'mcp-gateway-opencode'
+                    : 'mcp-gateway-opencode' in auth.identity.aud)
+    authorization:
+      # Tool gate. Deny (403) unless x-mcp-toolname is in the read-only
+      # allowlist. WIDEN by adding a tool name to this single CEL list literal
+      # — one-line change, reviewable in Git. Every mutating tool (kubectl
+      # apply/patch/delete/scale/rollout, omada_/ha_/arr_/comfyui_ writes) is
+      # absent and therefore DENIED. The MCP Router sets x-mcp-toolname from
+      # the JSON-RPC body; the client cannot forge it, and select_tools cannot
+      # bypass it (it changes the client's tools/list, not this header).
+      tool-access-check:
+        patternMatching:
+          patterns:
+            - predicate: >-
+                request.headers['x-mcp-toolname'] in
+                ['discover_tools', 'select_tools',
+                'kubectl_get_pods', 'kubectl_get_nodes',
+                'kubectl_get_nodes_summary', 'kubectl_get_events',
+                'kubectl_get_pod_events', 'kubectl_get_deployments',
+                'kubectl_get_statefulsets', 'kubectl_get_services',
+                'kubectl_get_namespaces', 'kubectl_get_pvcs',
+                'kubectl_get_persistent_volumes', 'kubectl_get_logs',
+                'kubectl_describe', 'kubectl_health_check',
+                'kubectl_check_pod_health', 'kubectl_get_cluster_info',
+                'kubectl_gitops_apps_list_tool', 'kubectl_get_node_metrics',
+                'kubectl_get_pod_metrics', 'prom_execute_query',
+                'prom_execute_range_query', 'prom_list_metrics',
+                'prom_health_check', 'prom_get_targets',
+                'prom_get_metric_metadata', 'time_current_time',
+                'time_convert_time', 'time_relative_time',
+                'time_get_timestamp', 'time_days_in_month',
+                'time_get_week_year']
+    response:
+      success:
+        headers:
+          # ENUMERATION GATE. Authorino signs a "festival wristband" (ES256
+          # JWT) and injects it into the REQUEST to the broker under the header
+          # the v0.9.0 broker reads: `x-mcp-authorized` (set by `key:` below —
+          # the header name defaults to the config name otherwise). The broker
+          # validates it with TRUSTED_HEADER_PUBLIC_KEY and returns ONLY the
+          # tools named in the `allowed-capabilities` claim from tools/list, so
+          # a restricted caller cannot even SEE denied tools — closing the gap
+          # the invocation gate (authorization, above) left open.
+          x-mcp-authorized:
+            key: x-mcp-authorized
+            wristband:
+              # Issuer must NOT equal the caller's identity issuer
+              # (https://auth.${SECRET_DOMAIN}); Authorino SKIPS wristband
+              # generation when they match (authorino wristband.go Call()).
+              # `authorino` is distinct, so the wristband is always issued.
+              issuer: authorino
+              tokenDuration: 300
+              signingKeyRefs:
+                # Private half of the ECDSA P-256 pair. Secret entry MUST be
+                # `key.pem` (Authorino contract) and the Secret MUST carry the
+                # label authorino.kuadrant.io/managed-by: authorino to be
+                # watched (see externalsecret.yaml target template). Provided
+                # BYO via 1Password because the operator's generate path emits
+                # the wrong data-key name (`key`, not `key.pem`).
+                - name: mcp-gateway-trusted-headers-signing
+                  algorithm: ES256
+              customClaims:
+                # The claim the broker unmarshals. It is a STRING containing
+                # JSON: {"tools": {"<MCPServerRegistration name>":
+                # ["<tool name WITHOUT the server's registration prefix>", …]}}.
+                # The broker re-prepends each server's prefix
+                # (kubectl-tools->"kubectl_", prometheus-tools->"prom_",
+                # time-tools->"time_") before matching the merged tool list.
+                #
+                # KEEP IN SYNC with spec.rules.authorization.tool-access-check
+                # above. That list is FLAT + PREFIXED (invocation gate, matches
+                # x-mcp-toolname); this one is GROUPED-BY-SERVER + UN-prefixed
+                # (enumeration gate, matches the broker's server map). Authorino
+                # cannot derive one from the other here (different shapes), so
+                # they are two hand-maintained literals. A tool present in only
+                # one is a bug: authz-only -> callable but invisible;
+                # wristband-only -> visible but 403 on call. Any widening edits
+                # BOTH. discover_tools/select_tools are broker-native meta-tools
+                # (no upstream MCPServerRegistration), so they are NOT in this
+                # map — they remain visible regardless (the broker only filters
+                # tools it can map to a server).
+                allowed-capabilities:
+                  value: >-
+                    {"tools":{"kubectl-tools":["get_pods","get_nodes","get_nodes_summary","get_events","get_pod_events","get_deployments","get_statefulsets","get_services","get_namespaces","get_pvcs","get_persistent_volumes","get_logs","describe","health_check","check_pod_health","get_cluster_info","gitops_apps_list_tool","get_node_metrics","get_pod_metrics"],"prometheus-tools":["execute_query","execute_range_query","list_metrics","health_check","get_targets","get_metric_metadata"],"time-tools":["current_time","convert_time","relative_time","get_timestamp","days_in_month","get_week_year"]}}

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
@@ -124,3 +124,38 @@ spec:
               protocol: UDP
             - port: "443"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-gateway-opencode-jwt-rotator-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-gateway-opencode-jwt-rotator
+  # Additive — apiserver covered by baseline (rotator runs
+  # `kubectl create secret`); egress to Authelia goes via envoy.
+  # Sibling of mcp-gateway-jwt-rotator-allow for the opencode identity.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Authelia OIDC token endpoint:
+    # https://auth.${SECRET_DOMAIN}/api/oidc/token — routed via
+    # external envoy gateway, container port 10443.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+            # HTTP/3: envoy advertises Alt-Svc on :10443; allow the QUIC (UDP)
+            # sibling so a client upgrade isn't default-denied (would flap the
+            # CiliumPolicyDrop alerts even though QUIC falls back to TCP).
+            - port: "10443"
+              protocol: UDP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/externalsecret.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/externalsecret.yaml
@@ -19,3 +19,93 @@ spec:
   dataFrom:
     - extract:
         key: mcp-gateway-authelia
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  # Identity for the unattended in-cluster opencode agent. Separate Authelia
+  # OIDC client from the human `mcp-gateway` client above, so a token for one
+  # cannot be replayed as the other (different audience). See the
+  # mcp-gateway-opencode AuthPolicy (authpolicy-opencode.yaml).
+  name: mcp-gateway-opencode-authelia-client
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mcp-gateway-opencode-authelia-client
+    creationPolicy: Owner
+    template:
+      data:
+        OIDC_CLIENT_ID: "{{ .client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+  dataFrom:
+    # MANUAL PREREQUISITE (Rob): create a 1Password item named
+    # `mcp-gateway-opencode-authelia` (vault Kubernetes) with fields
+    # `client_id` and `client_secret` matching the new Authelia OIDC client
+    # added to the authelia OIDC_CLIENTS_YAML. See the apply plan.
+    - extract:
+        key: mcp-gateway-opencode-authelia
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  # Private half of the ECDSA P-256 (ES256) trusted-header signing key.
+  # Consumed by Authorino via the AuthPolicy wristband signingKeyRefs
+  # (authpolicy-opencode.yaml). Two hard requirements from Authorino:
+  #   1. the data entry MUST be named `key.pem` (AuthPolicy CRD contract:
+  #      "secrets must contain a `key.pem` entry ... formatted as PEM"), and
+  #   2. the Secret MUST carry label authorino.kuadrant.io/managed-by=authorino
+  #      or Authorino's secret controller won't watch it (secret_controller.go
+  #      LabelSelector). Set on the target template below.
+  name: mcp-gateway-trusted-headers-signing
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mcp-gateway-trusted-headers-signing
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          authorino.kuadrant.io/managed-by: authorino
+      data:
+        key.pem: "{{ .private_key_pem }}"
+  dataFrom:
+    # MANUAL PREREQUISITE (Rob): generate ONE ECDSA P-256 key pair and store
+    # both PEM halves in a 1Password item `mcp-gateway-trusted-headers`
+    # (vault Kubernetes) with fields `private_key_pem` and `public_key_pem`.
+    # See the apply plan for the exact openssl commands.
+    - extract:
+        key: mcp-gateway-trusted-headers
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  # Public half of the same ES256 pair. Named exactly as the
+  # MCPGatewayExtension trustedHeadersKey.secretName so the operator wires it
+  # into the broker's TRUSTED_HEADER_PUBLIC_KEY env (data entry `key`, per
+  # internal/controller/broker_router.go SecretKeyRef{key:"key"}). Public key
+  # material is not sensitive, but sourcing it from the SAME 1Password item as
+  # the private half guarantees they stay a matched pair.
+  name: mcp-gateway-trusted-headers-public
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mcp-gateway-trusted-headers-public
+    creationPolicy: Owner
+    template:
+      data:
+        key: "{{ .public_key_pem }}"
+  dataFrom:
+    - extract:
+        key: mcp-gateway-trusted-headers

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/gateway.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/gateway.yaml
@@ -40,3 +40,19 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
+    # Authenticated fan-out for unattended in-cluster agents (opencode).
+    # ADDITIVE: a Kuadrant AuthPolicy attaches to THIS listener only
+    # (sectionName: mcp-authz) so a policy mistake cannot affect the
+    # unauthenticated `mcp` listener that langgraph / Open WebUI / Rob's
+    # laptop ride. Distinct hostname so the MCPRouter/istio routes by
+    # authority: in-cluster clients still dial the mcp-gateway-istio
+    # Service by DNS but send Host: mcp-authz.mcp.local to land here.
+    # Same port 8080 (one istio Service LB); listener isolation is by
+    # hostname + sectionName-scoped policy, not by a separate port.
+    - name: mcp-authz
+      hostname: "mcp-authz.mcp.local"
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/httproute-broker-authz.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/httproute-broker-authz.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-gateway-broker-authz
+  annotations:
+    # Internal-only route on the istio gateway's authenticated listener;
+    # external-dns must not publish a record for this hostname (it is a
+    # .mcp.local name reached in-cluster by Host header, never public).
+    external-dns.alpha.kubernetes.io/controller: none
+spec:
+  # Distinct hostname pins traffic to the mcp-authz listener. In-cluster
+  # clients dial mcp-gateway-istio.mcp-system.svc:8080 (same Service as the
+  # unauthenticated path) but set Host: mcp-authz.mcp.local to select this
+  # route + listener. Same broker backend (mcp-gateway:8080) as the public
+  # mcp route — the AuthPolicy on sectionName: mcp-authz is the only
+  # difference in the request path.
+  hostnames:
+    - mcp-authz.mcp.local
+  parentRefs:
+    - name: mcp-gateway
+      sectionName: mcp-authz
+  rules:
+    - backendRefs:
+        - name: mcp-gateway
+          port: 8080
+      matches:
+        - path:
+            type: PathPrefix
+            value: /mcp

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
@@ -3,17 +3,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./authpolicy-opencode.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./gateway.yaml
   - ./helmrelease.yaml
+  - ./httproute-broker-authz.yaml
   - ./httproute-broker.yaml
   - ./httproute.yaml
   - ./mcpgatewayextension.yaml
   - ./mcpvirtualserver-opencode.yaml
   - ./ocirepository.yaml
   - ./podmonitor.yaml
+  - ./rotator-cronjob-opencode.yaml
   - ./rotator-cronjob.yaml
+  - ./rotator-rbac-opencode.yaml
   - ./rotator-rbac.yaml
   - ./securitypolicy.yaml
   - ./telemetry.yaml

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/mcpgatewayextension.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/mcpgatewayextension.yaml
@@ -13,6 +13,44 @@ spec:
   httpRouteManagement: Disabled
   privateHost: mcp-gateway-istio.mcp-system.svc.cluster.local:8080
   publicHost: mcp.${SECRET_DOMAIN}
+  # tools/list ENUMERATION filtering (the wristband). Verified against the
+  # deployed broker source (ghcr.io/kuadrant/mcp-gateway:v0.9.0):
+  #   internal/broker/filtered_tools_handler.go reads the `x-mcp-authorized`
+  #   request header, validates it as an ES256 JWT with the public key from
+  #   env TRUSTED_HEADER_PUBLIC_KEY, and filters tools/list to the JWT's
+  #   `allowed-capabilities` claim (a JSON string of
+  #   {"tools": {"<mcp-server-name>": ["<unprefixed-tool>", ...]}}).
+  # Setting trustedHeadersKey here makes the operator inject that env var into
+  # the broker deployment (internal/controller/broker_router.go lines 126-138:
+  # TRUSTED_HEADER_PUBLIC_KEY <- SecretKeyRef{name: <secretName>, key: "key"}).
+  #
+  # SCOPE / BLAST RADIUS: the broker is a SINGLETON serving all three
+  # listeners (mcp, mcps, mcp-authz), so this env is gateway-wide, NOT
+  # listener-scoped. That is SAFE because enumeration filtering is INERT
+  # unless the `x-mcp-authorized` header is present: the broker's
+  # `enforce-capability-filtering` flag stays at its default `false`
+  # (main.go:150), so a request WITHOUT the header gets the FULL, unfiltered
+  # tool list (filtered_tools_handler.go:105-110 "Returns original tools if
+  # header not present and enforcement is off"). Only the mcp-authz path
+  # (where the AuthPolicy injects the wristband) is filtered. The `mcp` /
+  # `mcps` listeners send no such header and are byte-for-byte unaffected.
+  #
+  # BYO key (generate: Disabled) — NOT operator-generated. The operator's
+  # `generate: Enabled` path (internal/controller/trusted_headers.go) writes
+  # BOTH halves with data key `key`, but Authorino's wristband signingKeyRefs
+  # REQUIRES the private key in a secret entry named `key.pem`
+  # (AuthPolicy CRD: "secrets must contain a `key.pem` entry"). The two
+  # contracts don't line up, so we materialise the pair ourselves:
+  #   - public  key -> Secret `mcp-gateway-trusted-headers-public` (entry
+  #                    `key`, plain manifest below) — read by the broker.
+  #   - private key -> Secret `mcp-gateway-trusted-headers-signing` (entry
+  #                    `key.pem`, from 1Password via ExternalSecret) — read
+  #                    by Authorino for signingKeyRefs.
+  # Both PEM halves are ONE generated ECDSA P-256 (ES256) pair; see the
+  # manual key-generation step in the apply plan.
+  trustedHeadersKey:
+    generate: Disabled
+    secretName: mcp-gateway-trusted-headers-public
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-cronjob-opencode.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-cronjob-opencode.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mcp-gateway-opencode-jwt-rotator
+spec:
+  # Daily rotation, mirroring the human mcp-gateway rotator. Token lifespan is
+  # 7d (set on the Authelia 'mcp-gateway-opencode' client via its custom
+  # lifespan policy); a daily refresh gives ~6d overlap so a long-running
+  # opencode session that captured the previous token keeps working across a
+  # rotation. A long-lived server should also refresh-on-401 (see the design
+  # doc open question on token lifetime vs. long agent sessions).
+  schedule: "35 4 * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            # Stable selector used by the mcp-gateway-opencode-jwt-rotator-allow
+            # CNP. The auto-generated `job-name` label rotates every run and
+            # can't be used in a Cilium endpointSelector.
+            app.kubernetes.io/name: mcp-gateway-opencode-jwt-rotator
+        spec:
+          serviceAccountName: mcp-gateway-opencode-jwt-rotator
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - name: rotator
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              command:
+                - /bin/sh
+                - -ceu
+                # Flux postBuild substitutes ${VAR} — escape all shell vars
+                # with $${VAR} so the rendered manifest has ${VAR} for sh.
+                - |
+                  RESPONSE=$(curl -fsSL -X POST "$${OIDC_TOKEN_ENDPOINT}" \
+                    -H "Content-Type: application/x-www-form-urlencoded" \
+                    --data-urlencode "grant_type=client_credentials" \
+                    --data-urlencode "client_id=$${OIDC_CLIENT_ID}" \
+                    --data-urlencode "client_secret=$${OIDC_CLIENT_SECRET}" \
+                    --data-urlencode "scope=mcp-gateway-opencode" \
+                    --data-urlencode "audience=mcp-gateway-opencode")
+                  TOKEN=$(printf '%s' "$${RESPONSE}" | jq -er '.access_token')
+                  EXPIRES_IN=$(printf '%s' "$${RESPONSE}" | jq -er '.expires_in // 604800')
+                  EXPIRES_AT=$(( $(date +%s) + EXPIRES_IN ))
+                  kubectl create secret generic mcp-gateway-opencode-jwt-current \
+                    --from-literal=token="$${TOKEN}" \
+                    --from-literal=expires_at="$${EXPIRES_AT}" \
+                    --dry-run=client -o yaml | kubectl apply -f -
+                  echo "Rotated mcp-gateway-opencode JWT; expires_at=$${EXPIRES_AT} (in $${EXPIRES_IN}s)"
+              envFrom:
+                - secretRef:
+                    name: mcp-gateway-opencode-authelia-client
+              env:
+                - name: OIDC_TOKEN_ENDPOINT
+                  value: "https://auth.${SECRET_DOMAIN}/api/oidc/token"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: kube
+                  mountPath: /.kube
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: kube
+              emptyDir: {}

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-rbac-opencode.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-rbac-opencode.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-gateway-opencode-jwt-rotator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcp-gateway-opencode-jwt-rotator
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["mcp-gateway-opencode-jwt-current"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-gateway-opencode-jwt-rotator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-gateway-opencode-jwt-rotator
+subjects:
+  - kind: ServiceAccount
+    name: mcp-gateway-opencode-jwt-rotator


### PR DESCRIPTION
## What

Enforce **per-tool authorization** for the unattended in-cluster **opencode** agent, on a dedicated authenticated **`mcp-authz`** listener of the `mcp-gateway` Istio Gateway. Completes Stages 2–4 of `docs/src/mcp_tool_authz_design.md`.

**Additive + `sectionName`-scoped** — the shared `mcp`/`mcps` listeners (langgraph, Open WebUI, laptop) are byte-unchanged and carry no policy.

## How

- **`kuadrant.yaml`** — the `Kuadrant` CR (was missing; Stage 1's operator was inert without it). Deploys Authorino + registers the Istio wasm-shim. Inert until an AuthPolicy targets a listener.
- **`gateway.yaml`** — additive `mcp-authz` listener (`mcp`/`mcps` untouched).
- **`authpolicy-opencode.yaml`** — `sectionName: mcp-authz`. Identity gate (Authelia JWT, audience `mcp-gateway-opencode`) + CEL tool gate on the router-set `x-mcp-toolname` (read-only allowlist; mutations denied **even after `select_tools`**). ES256 wristband (`response.success.headers.x-mcp-authorized`) filters `tools/list` to the allowed set.
- **`mcpgatewayextension.yaml`** — `trustedHeadersKey` so the broker validates the wristband. Inert unless `x-mcp-authorized` is present (only mcp-authz callers send it); `mcp`/`mcps` get the full unfiltered list.
- **`rotator-*-opencode.yaml`** — opencode identity (cloned from the proven rotator; client-credentials → token Secret).
- **`externalsecret.yaml`** — opencode OIDC client + ES256 signing/public keys from 1Password.

Wire format (`x-mcp-authorized` header, `allowed-capabilities` claim) verified against the **deployed broker source** `ghcr.io/kuadrant/mcp-gateway:v0.9.0`, not docs. Fails **closed** (empty list) on a bad/absent header.

## Out-of-band prerequisites (already done)

1Password items `mcp-gateway-opencode-authelia`, `mcp-gateway-trusted-headers`, and the `mcp-gateway-opencode` Authelia OIDC client (additive; existing 8 clients untouched).

## Service impact on apply

The `trustedHeadersKey` env rolls the **singleton broker** → a brief MCP interruption for all clients; plus the Kuadrant CR adds the wasm-shim. Authelia is restarted to load the new client. Verified live post-merge.

## Verify

Authorino up; `mcp`/`mcps` unaffected (full ~1300-tool catalogue, no pod flaps); mint opencode token → allowed read tool works → mutation **denied even after `select_tools`** → no/wrong-audience token 401 → **`tools/list` on mcp-authz omits denied tools** (grep = 0, fail-closed on forged header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PCnZcvcYgiW2g64jXvZcm