### PR TITLE
REVIEW ONLY (do not merge): trial Kubernetes ClusterNetworkPolicy (KCNP) on renovate-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-162-blue?style=for-the-badge)
+![apps](https://img.shields.io/badge/apps-163-blue?style=for-the-badge)
 ![helmreleases](https://img.shields.io/badge/HelmReleases-173-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)

--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -49,6 +49,27 @@ policyDenyResponse: icmp
 ipam:
   mode: "kubernetes"
 
+# KCNP trial (home-ops#13772 §1) — Kubernetes ClusterNetworkPolicy
+# (policy.networking.k8s.io/v1alpha2), the upstream sigs.k8s.io/network-policy-api
+# tiered cluster-scoped model. Alpha in Cilium 1.20 (flag is `MarkHidden` upstream —
+# undocumented/experimental surface, not a GA feature). Chart default is `false`.
+#
+# SCOPED TRIAL, not a migration: the per-namespace CiliumNetworkPolicy baseline
+# (kubernetes/components/network-policy/) remains the enforcement mechanism
+# everywhere. Enabling this flag cluster-wide only makes cilium-agent *watch* the
+# ClusterNetworkPolicy CRD; it does not affect any namespace unless a
+# ClusterNetworkPolicy resource actually exists and selects it. The one trial
+# resource (renovate/renovate-operator/app/cnp-trial-kcnp.yaml) uses
+# `action: Pass`, which explicitly falls through to existing per-namespace CNP
+# enforcement rather than substituting for it.
+#
+# Requires the external sigs.k8s.io/network-policy-api ClusterNetworkPolicy CRD —
+# NOT bundled in this chart. See
+# kubernetes/apps/kube-system/network-policy-api-crds/ and this Kustomization's
+# dependsOn in ../ks.yaml.
+k8sClusterNetworkPolicy:
+  enabled: true
+
 ingressController:
   enabled: false
   loadbalancerMode: shared

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -17,6 +17,21 @@ spec:
   # as soon as this one's resources are applied, not when the chart
   # has actually installed its CRDs. Mirrors cert-manager / kyverno.
   wait: true
+  # KCNP trial (home-ops#13772 §1): values.yaml sets
+  # k8sClusterNetworkPolicy.enabled: true, and cilium-agent watches the
+  # external sigs.k8s.io/network-policy-api ClusterNetworkPolicy CRD
+  # for that feature. The CRD is not bundled in this chart (unlike
+  # cilium's own CRDs) — network-policy-api-crds installs it
+  # separately. Sequenced here so the CRD exists before cilium-agent's
+  # informer for it starts, mirroring cilium's own dev-harness ordering
+  # (Makefile.kind: `get crd ... || apply CRD` before enabling the
+  # flag). Not strictly required for cilium-agent to stay up if
+  # reordered — its informer for this CRD is wired unconditionally and
+  # retries via the standard client-go reflector on a NotFound list —
+  # but there is no reason to rely on that when the ordering is free.
+  dependsOn:
+    - name: network-policy-api-crds
+      namespace: kube-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./k8tz/ks.yaml
   - ./kubelet-csr-approver/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./network-policy-api-crds/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./node-problem-detector/ks.yaml
   - ./node-tuning

--- a/kubernetes/apps/kube-system/network-policy-api-crds/crds/clusternetworkpolicy-crd.yaml
+++ b/kubernetes/apps/kube-system/network-policy-api-crds/crds/clusternetworkpolicy-crd.yaml
@@ -1,0 +1,605 @@
+---
+# TODO: apply schema (no yannh/kubernetes-json-schema or CRDs-catalog entry for
+# CustomResourceDefinition itself — this is the meta-schema, not an app CRD)
+# workaround: https://github.com/cilium/cilium/issues/33525 — remove when the cilium Helm chart bundles the sigs.k8s.io/network-policy-api CRDs itself (chart 1.20.1 requires the CRD to be installed separately; see docs.cilium.io/en/stable/network/kubernetes/policy/)
+#
+# Pinned to the "standard" channel ClusterNetworkPolicy CRD from the v0.2.0
+# tagged release (matches Cilium 1.20.1's vendored API type
+# policyv1alpha2.ClusterNetworkPolicy — apiVersion policy.networking.k8s.io/v1alpha2).
+# Upstream doc command: https://github.com/cilium/cilium/blob/v1.20.1/Documentation/network/kubernetes/policy.rst
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/347
+    # renovate: datasource=github-releases depName=kubernetes-sigs/network-policy-api
+    policy.networking.k8s.io/bundle-version: v0.2.0
+    policy.networking.k8s.io/channel: standard
+  name: clusternetworkpolicies.policy.networking.k8s.io
+spec:
+  group: policy.networking.k8s.io
+  names:
+    kind: ClusterNetworkPolicy
+    listKind: ClusterNetworkPolicyList
+    plural: clusternetworkpolicies
+    shortNames:
+      - cnp
+    singular: clusternetworkpolicy
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.priority
+          name: Priority
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Reason
+          priority: 1
+          type: string
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ClusterNetworkPolicy is a cluster level resource that is a
+            collection of rules that apply to all pods in namespaces that
+            match the subject selector.
+
+            <network-policy-api:experimental>
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of the desired behavior of ClusterNetworkPolicy.
+              properties:
+                egress:
+                  description: |-
+                    Egress is the list of Egress rules to be applied to the selected pods.
+
+                    A maximum of 25 rules is allowed in this block.
+
+                    The relative precedence of egress rules within a single CNP object
+                    (all of which share the priority) will be determined by the order
+                    in which the rule is written.
+                    Thus, a rule that appears at the top of the egress rules
+                    would take the highest precedence.
+                    CNPs with no egress rules do not affect egress traffic.
+                  items:
+                    description: |-
+                      ClusterNetworkPolicyEgressRule describes an action to take on a particular
+                      set of traffic originating from pods selected by a ClusterNetworkPolicy's
+                      Subject field.
+
+                      <network-policy-api:experimental:validation>
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching
+                          traffic.  Currently the following actions are supported:
+
+                          - Accept: Accepts the selected traffic, allowing it to
+                            egress. No further ClusterNetworkPolicy or NetworkPolicy
+                            rules will be processed.
+
+                          - Deny: Drops the selected traffic. No further
+                            ClusterNetworkPolicy or NetworkPolicy rules will be
+                            processed.
+
+                          - Pass: Skips all further ClusterNetworkPolicy rules in the
+                            current tier for the selected traffic, and passes
+                            evaluation to the next tier.
+                        enum:
+                          - Accept
+                          - Deny
+                          - Pass
+                        type: string
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than
+                          100 characters in length. This field should be used by the implementation
+                          to help improve observability, readability and error-reporting
+                          for any applied policies.
+                        maxLength: 100
+                        type: string
+                      ports:
+                        description: |-
+                          Ports allows for matching traffic based on port and protocols.
+                          This field is a list of destination ports for outgoing traffic.
+                          If Ports is not set then the rule does not filter traffic via port.
+                        items:
+                          description: |-
+                            NetworkPolicyPort describes how to select network ports on pod(s).
+                            This type is copied from the networking/v1 core API since the
+                            "all ports" behavior needs to be different.
+                          properties:
+                            endPort:
+                              description: |-
+                                EndPort indicates that the range of ports from Port to EndPort,
+                                if set, should be included within this rule.
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                Port is the port number or name to allow traffic on. If not
+                                set, an implementation is free to use its own conventions.
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol is the network protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults to
+                                TCP.
+                              type: string
+                          type: object
+                        maxItems: 100
+                        type: array
+                      to:
+                        description: |-
+                          To is the List of destinations whose traffic this rule applies
+                          to. If any AdminNetworkPolicyEgressPeer matches the destination
+                          of outgoing traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyEgressPeer defines a peer to allow traffic
+                            to. Exactly one of the selector pointers must be set for a given
+                            peer.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set
+                                of Namespaces.
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            networks:
+                              description: |-
+                                Networks defines a way to select peers via CIDR blocks.
+                              items:
+                                description: |-
+                                  CIDR is an IP address range in CIDR notation
+                                  (for example, "10.0.0.0/8" or "fd00::/8").
+                                maxLength: 43
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: Invalid CIDR format provided
+                                    rule: isCIDR(self)
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: set
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in a set of
+                                namespaces.
+                              properties:
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - to
+                    type: object
+                  maxItems: 25
+                  type: array
+                ingress:
+                  description: |-
+                    Ingress is the list of Ingress rules to be applied to the
+                    selected pods. A maximum of 25 rules is allowed in this block.
+
+                    CNPs with no ingress rules do not affect ingress traffic.
+                  items:
+                    description: |-
+                      ClusterNetworkPolicyIngressRule describes an action to take on a
+                      particular set of traffic destined for pods selected by a
+                      ClusterNetworkPolicy's Subject field.
+
+                      <network-policy-api:experimental:validation>
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching
+                          traffic. Currently the following actions are supported:
+
+                          - Accept: Allows the selected traffic.
+
+                          - Deny: Drops the selected traffic.
+
+                          - Pass: Skips all further ClusterNetworkPolicy rules in the
+                            current tier for the selected traffic, and passes
+                            evaluation to the next tier.
+                        enum:
+                          - Accept
+                          - Deny
+                          - Pass
+                        type: string
+                      from:
+                        description: |-
+                          From is the list of sources whose traffic this rule applies to.
+                          This field must be defined and contain at least one item.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyIngressPeer defines a peer to allow traffic
+                            from. Exactly one of the selector pointers must be set for a
+                            given peer.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              properties:
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                      name:
+                        maxLength: 100
+                        type: string
+                      ports:
+                        items:
+                          properties:
+                            endPort:
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              default: TCP
+                              type: string
+                          type: object
+                        maxItems: 100
+                        type: array
+                    required:
+                      - action
+                      - from
+                    type: object
+                  maxItems: 25
+                  type: array
+                priority:
+                  description: |-
+                    Priority is a value from 0 to 1000. Rules with lower priority values have
+                    higher precedence, and are checked before policies with higher
+                    priority values.
+                    All ClusterNetworkPolicy rules of an equal priority should be
+                    round-robin ordered (i.e. no defined ordering).
+                  format: int32
+                  maximum: 1000
+                  minimum: 0
+                  type: integer
+                subject:
+                  description: Subject defines the pods to which this ClusterNetworkPolicy applies.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    namespaces:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    pods:
+                      properties:
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - podSelector
+                      type: object
+                  type: object
+              required:
+                - priority
+                - subject
+              type: object
+            status:
+              default:
+                conditions:
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    status: Unknown
+                    type: Ready
+              description: Status is the status to be reported by the implementation.
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        default: 0
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/kubernetes/apps/kube-system/network-policy-api-crds/crds/kustomization.yaml
+++ b/kubernetes/apps/kube-system/network-policy-api-crds/crds/kustomization.yaml
@@ -3,8 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./cnp-allow.yaml
-  - ./cnp-trial-kcnp.yaml
-  - ./helmrelease.yaml
-  - ./ocirepository.yaml
-  - ./securitypolicy.yaml
+  - ./clusternetworkpolicy-crd.yaml

--- a/kubernetes/apps/kube-system/network-policy-api-crds/ks.yaml
+++ b/kubernetes/apps/kube-system/network-policy-api-crds/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname network-policy-api-crds
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  path: "./kubernetes/apps/kube-system/network-policy-api-crds/crds"
+  interval: 1h
+  timeout: 5m
+  # `wait: true` so cilium's own reconcile (which enables
+  # k8sClusterNetworkPolicy in values.yaml) can be sequenced to depend
+  # on this CRD existing first via cilium/ks.yaml's dependsOn. Mirrors
+  # the cilium -> cilium-config CRD-readiness pattern already in this
+  # repo (see kube-system/cilium/ks.yaml).
+  wait: true

--- a/kubernetes/apps/renovate/renovate-operator/app/cnp-trial-kcnp.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/cnp-trial-kcnp.yaml
@@ -1,0 +1,55 @@
+---
+# TODO: apply schema (no published JSON schema for policy.networking.k8s.io/v1alpha2 yet)
+#
+# KCNP TRIAL (home-ops#13772 §1) — scoped adoption trial of Cilium's Kubernetes
+# ClusterNetworkPolicy support, NOT a replacement for the per-namespace CNP
+# baseline. See kubernetes/apps/kube-system/cilium/app/values.yaml for the
+# k8sClusterNetworkPolicy.enabled flag and
+# kubernetes/apps/kube-system/network-policy-api-crds/ for the CRD install.
+#
+# This is a CLUSTER-SCOPED resource (spec.scope: Cluster on the CRD) living
+# inside a namespace-targeted Flux Kustomization (renovate-operator, ks.yaml
+# sets targetNamespace: renovate). Flux/kustomize does not set
+# metadata.namespace on cluster-scoped kinds, so this is safe, but it is an
+# unusual placement for this repo — the file lives here (rather than a new
+# top-level app dir) so the entire trial is a single, obviously-deletable
+# unit alongside the CRD install + the values.yaml flag.
+#
+# action: Pass is deliberate — it hands the matched flow off to the next
+# tier (Cilium's own per-namespace CiliumNetworkPolicy enforcement,
+# unaffected) rather than substituting Accept/Deny for it. This proves KCNP
+# mechanically works (subject/from selectors match, priority/tiering is
+# honored) without this trial's resource being able to weaken or override
+# the existing baseline+default-deny enforcement in the renovate namespace
+# even if the trial resource is wrong.
+#
+# Mirrors (does not replace) the existing ingress allow for Envoy ->
+# renovate-operator:8081 in ./cnp-allow.yaml.
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: kcnp-trial-renovate-operator-ingress
+spec:
+  priority: 900 # low precedence — never intended to shadow a real Tier-0 policy
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: renovate
+      podSelector:
+        matchLabels:
+          app: renovate-operator
+  ingress:
+    - name: pass-envoy-ingress-to-existing-cnp-enforcement
+      action: Pass
+      from:
+        - pods:
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: network
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: envoy
+      ports:
+        - protocol: TCP
+          port: 8081

--- a/kubernetes/apps/renovate/renovate-operator/ks.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/ks.yaml
@@ -12,6 +12,13 @@ spec:
   path: "./kubernetes/apps/renovate/renovate-operator/app"
   interval: 1h
   timeout: 5m
+  # KCNP trial (home-ops#13772 §1): this path now includes a
+  # ClusterNetworkPolicy CR (cnp-trial-kcnp.yaml), which needs the
+  # external CRD from network-policy-api-crds to exist first — same
+  # CRD-before-CR ordering as cilium -> cilium-config.
+  dependsOn:
+    - name: network-policy-api-crds
+      namespace: kube-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease


### PR DESCRIPTION
## REVIEW ONLY — do not merge

This is a design trial for review, per home-ops#13772 §1 (adoption-scout digest). It is
**not** ready to merge as-is — it needs a live soak (CRD reconcile, Hubble verification of
the trial `ClusterNetworkPolicy`, confirming cilium-agent picks up the flag cleanly) before
anyone should consider it done. Opening as a draft purely so the design is reviewable in
diff form.

## What this is

A scoped trial of Cilium's Kubernetes ClusterNetworkPolicy (KCNP) support —
`policy.networking.k8s.io`, the upstream `sigs.k8s.io/network-policy-api` tiered
cluster-scoped policy model, new in Cilium 1.20 (this cluster runs 1.20.1 already). This is
explicitly **not** a repo-wide migration off the existing per-namespace `CiliumNetworkPolicy`
baseline (`kubernetes/components/network-policy/`) — that baseline keeps enforcing,
unmodified, for the entire trial and beyond.

## What's in this PR

1. **CRD install** — `kubernetes/apps/kube-system/network-policy-api-crds/` — a new,
   dedicated Flux app installing the external `ClusterNetworkPolicy` CRD
   (`sigs.k8s.io/network-policy-api` v0.2.0, "standard" channel — matches Cilium 1.20.1's
   vendored `policyv1alpha2.ClusterNetworkPolicy` Go type). This CRD is **not** bundled in
   the cilium Helm chart, unlike Cilium's own CRDs. Renovate tracks the pin via an inline
   `# renovate: datasource=github-releases depName=kubernetes-sigs/network-policy-api`
   annotation, and the file also carries a `# workaround:` annotation (remove when the chart
   bundles the CRD itself).
2. **Feature flag** — `kubernetes/apps/kube-system/cilium/app/values.yaml` sets
   `k8sClusterNetworkPolicy.enabled: true` (chart default `false`; this flag is
   `MarkHidden` upstream in Cilium 1.20 — an undocumented/experimental surface, flagged for
   visibility, not something to treat as GA).
3. **One trial policy** — `kubernetes/apps/renovate/renovate-operator/app/cnp-trial-kcnp.yaml`
   — a single `ClusterNetworkPolicy` scoped to the `renovate-operator` pod's existing Envoy
   ingress rule (mirrors, does not replace, the existing `CiliumNetworkPolicy` allow in
   `cnp-allow.yaml`). Uses `action: Pass`, which explicitly hands the matched flow to the
   next enforcement tier (the existing per-namespace CNP baseline) rather than substituting
   `Accept`/`Deny` — this proves the mechanism (subject/from selectors, tiering) works
   without being able to weaken or override existing enforcement even if the trial rule
   itself is wrong.
4. **Flux ordering** — `dependsOn: network-policy-api-crds` added to both the `cilium`
   Kustomization and `renovate-operator`, mirroring this repo's existing
   `cilium` → `cilium-config` CRD-readiness pattern (`wait: true` + `dependsOn`), so the CRD
   is guaranteed to exist before cilium-agent's watcher for it starts, and before the trial
   CR is applied.

## Why `renovate` as the canary

- Single app (`renovate-operator`), already fully in **enforce mode**
  (baseline + default-deny + per-app CNPs already live and soaked).
- Not household-facing, not on the DNS/apiserver/ingress-gateway critical path.
- Well-understood, narrow traffic pattern (Envoy ingress on 8081, GitHub API egress via a
  separate `CiliumNetworkPolicy` unaffected by this trial) — easy to eyeball-verify via
  Hubble/`kubectl` reads.

## Risks called out for review

- KCNP is alpha in Cilium 1.20 (hidden flag) — not upstream-stable.
- If the CRD is ever removed while `k8sClusterNetworkPolicy.enabled: true` is still set,
  cilium-agent's typed-clientset watcher for it degrades to log-and-retry (standard
  client-go reflector behavior against a generically-wired Hive resource) rather than
  crash — this is inferred from the Cilium source (`pkg/policy/k8s/{cell,watcher}.go`), not
  independently verified against a live cluster.
- One-PR rollback: revert this PR. Flux prunes the CRD (a fresh CRD with at most one CR)
  and the trial `ClusterNetworkPolicy` cleanly; no other CR type references this CRD; no
  finalizer risk beyond the norm.

Do not merge until: the design is reviewed, and a live soak (CRD reconcile watched via
`kubectl_gitops_*` / `kubectl_get_crds`, Hubble confirms the trial policy's `Pass` action is
observed for matched flows, `cilium-dbg status` / cilium-agent logs show no degraded state)
has actually happened.