### PR TITLE
fix(authelia): grant renovate ns extAuth ref (fixes renovate UI 500)

### DIFF
--- a/kubernetes/apps/auth/authelia/app/referencegrant.yaml
+++ b/kubernetes/apps/auth/authelia/app/referencegrant.yaml
@@ -35,6 +35,9 @@ spec:
       namespace: observability
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
+      namespace: renovate
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
       namespace: selfhosted
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy


### PR DESCRIPTION
## What
Adds `renovate` to the `authelia-extauth-securitypolicies` ReferenceGrant `from:` list.

## Why
#13884 added an extAuth SecurityPolicy in the `renovate` namespace that references the cross-namespace `authelia` Service as its ext-authz backend. The ReferenceGrant in `auth` did not list `renovate` as a permitted source, so Envoy Gateway could not use the backend — the renovate UI returned **HTTP 500**.

Regression from #13884. Renovate **jobs** (webhook port 8082) were never affected — UI only.

## Verification
After reconcile, `renovate.<domain>` should redirect to Authelia (not 500), and pass through for an `lldap_admin` user.