### PR TITLE
feat(media): enable batocera-webdashboard-pro

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -15,8 +15,7 @@ resources:
   - ./namespace.yaml
   - ./priority-class.yaml
   # - ./av1corrector/ks.yaml # disabled 2026-08-24, memory pressure; uncomment to re-enable (NFS data on server is retained)
-  # Disabled: needs a Batocera target on the LAN (planned host: multicade)
-  # - ./batocera-webdashboard-pro/ks.yaml
+  - ./batocera-webdashboard-pro/ks.yaml
   - ./beets/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./gonic/ks.yaml


### PR DESCRIPTION
Enables the `batocera-webdashboard-pro` app (scaffolded disabled at #73ecf24c). The multicade Batocera box is now live on the LAN, giving the dashboard a `MODE: remote` target.

- Uncomments `./batocera-webdashboard-pro/ks.yaml` in `kubernetes/apps/media/kustomization.yaml`
- Removes the stale "needs a Batocera target" comment

**Prereq:** the 1Password `batocera-webdashboard-pro` item must have `BATOCERA_HOST/PORT/USER/PASS` populated (host = the multicade reservation, user `root`), or the ExternalSecret won't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kdq7MEwXEP7hqBvY3rKF4f