### PR TITLE
refactor(istio): migrate charts + images off gcr.io (ghcr.io + docker.io)

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -20,6 +20,7 @@
 # Format: one prefix per line; `#` for comments; trailing comments OK.
 
 # --- No suitable non-docker equivalent (verified 2026-05) -----------
+docker.io/istio/                        # istio pilot/proxyv2: Istio is retiring gcr.io/istio-release AND registry.istio.io/release (both late 2026); ghcr hosts only charts, not runtime images (403). docker.io/istio is upstream's permanent home. Verified 2026-08. See https://istio.io/latest/blog/2026/retirement-of-gcr.io-follow-up/
 docker.io/ollama/ollama
 docker.io/glanceapp/glance
 docker.io/library/couchdb               # ghcr/apache/couchdb is devcontainer-only

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -46,6 +46,22 @@
       },
     },
     {
+      // base + istiod MUST share a version (istiod dependsOn istio-base);
+      // a skew breaks reconciliation. The old lockstep came from Renovate's
+      // built-in "istio monorepo" preset keyed to the gcr.io path, which no
+      // longer applies after the move to ghcr.io/istio/release/charts.
+      description: "Istio Group",
+      groupName: "Istio",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "ghcr.io/istio/release/charts/base",
+        "ghcr.io/istio/release/charts/istiod",
+      ],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "Kubernetes Group",
       groupName: "Kubernetes",
       matchDatasources: ["docker"],

--- a/kubernetes/apps/istio-system/istio/app/base/ocirepository.yaml
+++ b/kubernetes/apps/istio-system/istio/app/base/ocirepository.yaml
@@ -11,4 +11,6 @@ spec:
     operation: copy
   ref:
     tag: 1.30.4
-  url: oci://gcr.io/istio-release/charts/base
+  # Istio is leaving GCP; gcr.io/istio-release is removed Dec 2026 (hard
+  # cutoff Jan 1 2027). See https://istio.io/latest/blog/2026/retirement-of-gcr.io/
+  url: oci://ghcr.io/istio/release/charts/base

--- a/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
     - name: istio-base
       namespace: istio-system
   values:
+    # istiod/pilot image + every injected sidecar pull from this hub.
+    # docker.io/istio because Istio is removing gcr.io/istio-release by
+    # Dec 2026, and 1.31+ images publish ONLY to docker.io/istio. tag is
+    # intentionally unset — it defaults to the chart version, so a chart
+    # bump drives the image. See retirement-of-gcr.io blog in the OCIRepos.
+    global:
+      hub: docker.io/istio
     # https://artifacthub.io/packages/helm/istio-official/istiod
     # https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/values.yaml
     #

--- a/kubernetes/apps/istio-system/istio/app/istiod/ocirepository.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/ocirepository.yaml
@@ -11,4 +11,6 @@ spec:
     operation: copy
   ref:
     tag: 1.30.4
-  url: oci://gcr.io/istio-release/charts/istiod
+  # Istio is leaving GCP; gcr.io/istio-release is removed Dec 2026 (hard
+  # cutoff Jan 1 2027). See https://istio.io/latest/blog/2026/retirement-of-gcr.io/
+  url: oci://ghcr.io/istio/release/charts/istiod


### PR DESCRIPTION
## Why

Istio is **leaving Google Cloud entirely** (funding-model change, GCP → AWS/GHCR/Docker Hub) and will **remove all artifacts from `gcr.io/istio-release` by Dec 2026, hard cutoff Jan 1 2027** ([announcement](https://istio.io/latest/blog/2026/retirement-of-gcr.io/)). Our two chart `OCIRepository`s and the istiod/proxy images pull from `gcr.io/istio-release` today, so they break at that cutoff.

This is **distinct** from Google's own `gcr.io` deprecation — Google keeps `gcr.io` URLs working transparently via Artifact Registry (`x-gcr-using-artifact-registry: true`). If Google were the only actor we'd do nothing; it's Istio deleting its own repos that forces the move.

Surfaced by a Renovate `Failed to look up docker package gcr.io/istio-release/charts/istiod` warning.

## Changes

| Component | From | To |
|---|---|---|
| `base` + `istiod` charts (OCIRepository) | `gcr.io/istio-release/charts/*` | `ghcr.io/istio/release/charts/*` |
| pilot Deployment + injected sidecars (`global.hub`) | `gcr.io/istio-release` | `docker.io/istio` |
| Renovate | built-in istio-monorepo grouping (gcr.io-keyed) | explicit `Istio` lockstep group on ghcr paths |

`global.hub: docker.io/istio` also unblocks a future **1.31** upgrade — 1.31+ images publish **only** to `docker.io/istio`.

## Verification

- Targets live at pinned `1.30.4`: `ghcr.io/istio/release/charts/{base,istiod}` and `docker.io/istio/{proxyv2,pilot}` all return HTTP 200.
- `helm template istiod oci://ghcr.io/istio/release/charts/istiod --version 1.30.4 --set global.hub=docker.io/istio` renders `docker.io/istio/pilot:1.30.4` and an injection ConfigMap with `hub: docker.io/istio` (confirms `global.hub` is the correct key and covers sidecars).
- All pre-commit hooks pass.

## Out of scope (verified)

- **`mirror.gcr.io`** (coredns, envoy-gateway) — Google's Docker Hub pull-through cache, a *different service*, not deprecated. Left as-is.
- zot `gcr.io` sync entry — harmless once istio stops using gcr.io; optional cleanup in a later PR.

## Blast radius

Istio is mesh infra for `mcp-system` → routine maintenance class. The `global.hub` change triggers one brief istiod rollout; running sidecars are unaffected until their pods restart. 4 files, no `sweep` label needed.