### PR TITLE
chore(zot): drop unused gcr.io pull-through sync

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/resources/config.json
+++ b/kubernetes/apps/kube-system/zot/app/resources/config.json
@@ -81,17 +81,6 @@
           "tlsVerify": true
         },
         {
-          "urls": ["https://gcr.io"],
-          "content": [
-            {
-              "prefix": "**",
-              "destination": "/gcr.io"
-            }
-          ],
-          "onDemand": true,
-          "tlsVerify": true
-        },
-        {
           "urls": ["https://ghcr.io"],
           "content": [
             {


### PR DESCRIPTION
Follow-up to the Istio gcr.io → ghcr.io/docker.io migration (#13899).

Istio was the only in-repo consumer of `gcr.io` images; now that its charts pull from `ghcr.io/istio/release/charts` and its images from `docker.io/istio`, zot's `gcr.io` on-demand sync registry is dead weight. Removed.

Untouched: the `index.docker.io`, `ghcr.io`, and `registry.k8s.io` sync entries. `mirror.gcr.io` (coredns, envoy-gateway) is Google's Docker Hub pull-through cache — a different service — and was never served by this entry.

JSON validated locally.