### PR TITLE
fix(alerts): windmill chart pin-back + batocera-webdashboard-pro probe fix

### DIFF
--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -15,10 +15,15 @@ spec:
       # 1.704.1. Re-pin when bumping; let Renovate manage the suffix.
       # 4.0.247/4.0.249 (appVersion 1.796.0) shipped with no
       # ghcr.io/windmill-labs/windmill-extra:1.796.0 image published upstream
-      # → ImagePullBackOff. Bumped to 4.0.251 (appVersion 1.799.0, image
-      # exists) rather than reverting, so Renovate has nothing older to
-      # re-propose into the break.
-      version: 4.0.251
+      # → ImagePullBackOff. Bumped to 4.0.251 (appVersion 1.799.0) to dodge
+      # that break, but 1.799.0 has the SAME problem in reverse: the base
+      # ghcr.io/windmill-labs/windmill:1.799.0 image was never published
+      # (only windmill-extra was) → rollout stuck, old pods kept serving.
+      # Pinned back to 4.0.250 (appVersion 1.798.1) — verified BOTH
+      # windmill:1.798.1 and windmill-extra:1.798.1 exist on GHCR. Upstream
+      # publishes the two images asymmetrically per release; verify both
+      # tags exist before bumping again, not just windmill-extra.
+      version: 4.0.250
   install:
     disableWait: true
   interval: 30m

--- a/kubernetes/apps/media/batocera-webdashboard-pro/app/helmrelease.yaml
+++ b/kubernetes/apps/media/batocera-webdashboard-pro/app/helmrelease.yaml
@@ -47,6 +47,14 @@ spec:
                   name: batocera-webdashboard-pro-secret
 
             probes:
+              # The app's Flask dev server is single-threaded — a blocking
+              # SSH call to the Batocera box (dashboard data fetch) can
+              # starve /health under concurrent kubelet probing, causing a
+              # probe timeout -> SIGKILL -> crash-loop (94+ restarts seen
+              # 2026-08-30) even though the app and its SSH target are both
+              # healthy. Loosened timeout/threshold as a mitigation; the
+              # real fix is a threaded/production WSGI server in the
+              # ghcr.io/rwlove/batocera-webdashboard-pro image itself.
               liveness: &probes
                 enabled: true
                 custom: true
@@ -56,8 +64,8 @@ spec:
                     port: *httpPort
                   initialDelaySeconds: 10
                   periodSeconds: 30
-                  timeoutSeconds: 10
-                  failureThreshold: 3
+                  timeoutSeconds: 30
+                  failureThreshold: 5
               readiness: *probes
               startup:
                 enabled: false


### PR DESCRIPTION
## Summary
Two independent AlertManager-firing issues fixed from the same triage pass:

**windmill** — chart 4.0.251 (appVersion 1.799.0) bumped yesterday only verified `windmill-extra:1.799.0` exists on GHCR; the base `windmill:1.799.0` image was never published upstream, stalling the rollout. Pinned back to 4.0.250 (appVersion 1.798.1) — both images confirmed present. Fixes `KubeDeploymentRolloutStuck` / `KubePodNotReady` on `windmill-app`, `windmill-workers-default`, `windmill-workers-native`. No outage — old ReplicaSets kept serving throughout.

**batocera-webdashboard-pro** — crash-looping (94+ restarts) despite the app and its SSH target (the multicade box, `192.168.1.10`) both being verified healthy and reachable. Root cause: the app's single-threaded Flask dev server blocks on an SSH call while kubelet concurrently probes `/health`, timing out the probe → SIGKILL → loop. Loosened `timeoutSeconds` 10→30 and `failureThreshold` 3→5 as a mitigation. Fixes `KubeDeploymentReplicasMismatch` / `KubePodCrashLooping` / one `KubePodNotReady`. The real fix (threaded/production WSGI server) belongs in the `ghcr.io/rwlove/batocera-webdashboard-pro` image repo, not here.

## Test plan
- [ ] Flux reconciles both HelmReleases and pods reach Ready
- [ ] `KubeDeploymentRolloutStuck` / `KubePodNotReady` (windmill) clear in AlertManager
- [ ] `KubeDeploymentReplicasMismatch` / `KubePodCrashLooping` (batocera) clear or restart rate drops sharply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNa5EdhFAfdfUspzY4E58V