### PR TITLE
fix(sabnzbd): stop mid-download restarts — widen liveness probe + move incomplete scratch to ceph-block

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/ceph-block-pvc.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/ceph-block-pvc.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-incomplete-pvc
+  labels:
+    app.kubernetes.io/name: &name sabnzbd
+    app.kubernetes.io/instance: *name
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -24,6 +24,23 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         type: statefulset
+        initContainers:
+          # ceph-block provisions fresh ext4, whose mkfs creates lost+found as
+          # root:root mode-700. fsGroup chowns it to gid 1001 but leaves mode
+          # 700, so the non-root app (uid 1106) EACCES's when it enumerates the
+          # /incomplete root for resumable jobs at startup. chmod it readable.
+          fix-lost-found:
+            image:
+              repository: docker.io/library/busybox
+              tag: "1.37.0"
+            command:
+              - /bin/sh
+              - -c
+              - "chmod 755 /incomplete/lost+found 2>/dev/null || true"
+            securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
+              readOnlyRootFilesystem: true
         containers:
           app:
             image:

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -46,6 +46,12 @@ spec:
                   name: *app
 
             probes:
+              # SABnzbd is single-threaded on its API; heavy assemble/par2/unpack
+              # bursts block /api for several seconds. A 1s timeout / 3-failure
+              # probe SIGKILLs the container mid-assembly, orphaning the queue
+              # __ADMIN__ files and causing "Error importing NzbFile" on restart.
+              # ~50s tolerance (5 × 10s) rides out an unpack burst while still
+              # catching a truly hung process.
               liveness: &probes
                 enabled: true
                 custom: true
@@ -53,10 +59,10 @@ spec:
                   httpGet:
                     path: /api?mode=version
                     port: *httpPort
-                  failureThreshold: 3
+                  failureThreshold: 5
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
               readiness: *probes
               startup:
                 enabled: false

--- a/kubernetes/apps/downloads/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./ceph-block-pvc.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/sabnzbd/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/nfs-pvc.yaml
@@ -3,41 +3,6 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: sabnzbd-incomplete-pv
-  labels:
-    type: nfs
-spec:
-  storageClassName: sabnzbd-incomplete-storage-class
-  capacity:
-    storage: 500Gi
-  accessModes:
-    - ReadWriteMany
-  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
-  nfs:
-    server: "${NFS_HOST_0}"
-    path: /mnt/downloads-nvme/sabnzbd/incomplete
-
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: sabnzbd-incomplete-pvc
-  labels:
-    type: nfs
-spec:
-  accessModes:
-    - ReadWriteMany
-  volumeMode: Filesystem
-  resources:
-    requests:
-      storage: 500Gi
-  volumeName: sabnzbd-incomplete-pv
-  storageClassName: sabnzbd-incomplete-storage-class
-
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
   name: sabnzbd-complete-pv
   labels:
     type: nfs


### PR DESCRIPTION
## Problem

SABnzbd was hard-killing its own container mid-assembly (5 restarts observed), which orphaned the queue `__ADMIN__` state and produced `Error importing NzbFile` on the next startup — and surfaced in the browser as the recurring **"Lost connection to SABnzbd"** overlay.

Root cause chain (confirmed from live logs):

1. SABnzbd is single-threaded on its API. It assembles/par2-repairs/unpacks in the `incomplete` dir, which is on **NFS** — one `.rar` part decoded every 5–8s, continuously. NFS latency intermittently pushes `/api?mode=version` past **1s**.
2. The liveness probe (`timeoutSeconds: 1`, `failureThreshold: 3`) SIGKILLs the container after ~3 slow answers.
3. The kill lands mid-assembly, so the in-flight job's `__ADMIN__` files never flush.
4. Restarted SABnzbd can't reload them → `Error importing NzbFile` per segment; the browser sees the restart as a lost connection.

One root cause, two symptoms (the overlay + the import errors).

## Changes (two commits, independently revertible)

1. **Widen the liveness probe** — `timeoutSeconds: 1→5`, `failureThreshold: 3→5` (~50s tolerance). Stops the mid-assembly kills regardless of storage. This is the acute fix.
2. **Move `incomplete` scratch NFS → ceph-block** — removes the NFS round-trip on the assemble/par2/unpack hot path (the underlying stall). `complete`/`downloads`/`config` unchanged.
   - New dynamically-provisioned `ceph-block` PVC, **150Gi**, RWO, reusing the `sabnzbd-incomplete-pvc` name so the HelmRelease binding is untouched.
   - `fix-lost-found` init container chmods the fresh-ext4 `lost+found` so the non-root app can enumerate the incomplete root at startup.

Capacity verified live: ceph-blockpool MAX AVAIL 1.65 TiB; 150Gi costs ~450 GiB raw (×3). `allowVolumeExpansion: true` if the queue habit grows.

## Cutover notes

- **In-flight `incomplete` scratch is orphaned** — active jobs re-fetch from the indexer. `complete`/`downloads` are untouched.
- RWX→RWO is safe: `incomplete` was never shared cross-namespace (the *arr apps mount the parent dir for `complete`/`downloads`, never `incomplete`); single-replica StatefulSet.
- Old NFS `incomplete` PV is `Retain` — its on-host data is orphaned, reclaimed manually later.
- Pod restarts once to bind the new PVC.

Local `kubectl kustomize` build passes; pre-commit green on both commits.