### PR TITLE
feat(pump): bump pump-voltra sidecar to v0.1.12

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.11@sha256:e2d2e48dae5226cfb55752a7a653f147a43d577f0b29234d4673fb260d728bdc
+              tag: v0.1.12@sha256:b53f9c7bfe54bd73cdf391a79e11ff44d6e4300b3b25b91c54d46d6141904509
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps the pump-voltra sidecar to **v0.1.12** (`sha256:b53f9c7b…904509`).

Ships rwlove/PUMP#141 — **self-heals a dropped ESPHome BLE-proxy connection.** A proxy TCP `EOF` previously left the sidecar reusing a dead scanner: the trainer looked permanently absent for **19h through a workout** (observed live 2026-08-30 14:17 → 08-31), and the liveness watchdog stayed green because the loop kept ticking. The supervisor now rebuilds the proxy link on disconnect (`on_stop` → `alive` flag), so it recovers in seconds.

Sidecar-only; no schema change. Third failure mode beyond wedged-loop (#133) and dead-work-task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)