### PR TITLE
fix(sabnzbd): unblock incomplete→ceph-block migration + raise memory limit (OOM root cause)

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/ceph-block-pvc.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/ceph-block-pvc.yaml
@@ -2,8 +2,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
+# Distinct name from the retired NFS PVC (sabnzbd-incomplete-pvc): a PVC's
+# storageClass/accessMode/size are immutable, so Flux patches — not replaces —
+# a same-named claim, which fails the dry-run. A new name is created fresh while
+# Flux prunes the old NFS PVC.
 metadata:
-  name: sabnzbd-incomplete-pvc
+  name: sabnzbd-incomplete
   labels:
     app.kubernetes.io/name: &name sabnzbd
     app.kubernetes.io/instance: *name

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -93,12 +93,18 @@ spec:
               - resourceName: memory
                 restartPolicy: NotRequired
 
+            # Assembly writes to the incomplete dir balloon dirty page cache
+            # against the cgroup limit faster than write-back drains it, OOM-
+            # killing the container mid-job (working_set stays ~200Mi but the
+            # hard limit counts un-flushed pages). ceph-block flushes far faster
+            # than the old NFS path, but keep 2Gi headroom for repair/unpack
+            # spikes; resizePolicy above lets this apply without a restart.
             resources:
               requests:
                 cpu: 15m
                 memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 2Gi
 
     service:
       app:
@@ -135,4 +141,4 @@ spec:
         existingClaim: sabnzbd-downloads-pvc
 
       incomplete:
-        existingClaim: sabnzbd-incomplete-pvc
+        existingClaim: sabnzbd-incomplete


### PR DESCRIPTION
Follow-up to #13902, which **failed to reconcile** and left nothing live.

## Two problems this fixes

### 1. PVC immutability blocked the whole reconcile
#13902 reused the claim name `sabnzbd-incomplete-pvc`. Flux therefore tried to **patch the existing bound NFS PVC in place** — rejected, because a PVC's `storageClass`/`accessModes`/`size` are immutable:
```
spec is immutable after creation ... RWM→RWO, ...→ceph-block, 500Gi→150Gi
```
The Kustomization stuck on the old revision, so the probe widening, init container, and storage move **all** stayed un-applied (verified: live pod still has the 1s/3-fail probe on the old NFS claim).

**Fix:** the ceph-block PVC gets a **distinct name** (`sabnzbd-incomplete`) so it's a new object; Flux prunes the retired NFS PVC/PV. `existingClaim` is repointed to match.

### 2. Corrected root cause — it's OOM, not the liveness probe
The live pod's last termination was `OOMKilled` (exit 137), restart count 6 — not a probe kill. High-res memory shows `working_set` peaking at only ~190 MB while the container still OOMs against its **1 GiB** limit. That's a **page-cache balloon**: assembling to **NFS** lets dirty pages pile against the cgroup limit faster than write-back drains them (same class as the known torrent-client-on-NFS OOM). `working_set` hides it because it subtracts reclaimable cache.

This **vindicates the ceph-block move** — RBD flushes far faster than NFS, so the balloon largely disappears. The probe widening (already in #13902) is now correctly framed as defense-in-depth, not the primary fix.

**Fix:** app memory limit **1Gi → 2Gi** for repair/unpack headroom. `resizePolicy` (already set) applies it without a restart.

## Net effect once merged
- Flux reconcile clears (valid dry-run).
- `incomplete` moves to ceph-block/150Gi; old NFS PVC+PV pruned (Retain → on-host data orphaned, reclaimed manually later).
- Pod recreates onto the new claim with 2Gi limit, widened probe, and the `lost+found` init container.

Local `kubectl kustomize` build passes; pre-commit green.