### PR TITLE
fix(renovate): first-party images never auto-merged — remove unsatisfiable soak gate

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -14,8 +14,13 @@
       // minimumReleaseAge is the real safety belt — a bad rebuild gets
       // 3 days to be caught upstream before it can land. ignoreTests
       // stays false so a red CI for any other reason still blocks.
+      // First-party ghcr.io/rwlove/* images are excluded here — renovate has
+      // no release timestamp for them, so ANY minimumReleaseAge is
+      // unsatisfiable and (internalChecksFilter=strict) the update is withheld
+      // forever. They get their own gate-free rule at the bottom.
       description: "Auto-merge container digests",
       matchDatasources: ["docker"],
+      matchPackageNames: ["!/^ghcr\\.io\\/rwlove\\//"],
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["digest"],
@@ -30,8 +35,10 @@
       // minimumReleaseAge gives a bad release 3 days to get yanked
       // upstream before it can land. Digests stay on the trusted-org
       // allowlist above — CI can't meaningfully validate a re-tag.
+      // First-party ghcr.io/rwlove/* excluded — see the digest rule above.
       description: "Auto-merge all non-major container + helm updates once CI passes",
       matchDatasources: ["docker", "helm"],
+      matchPackageNames: ["!/^ghcr\\.io\\/rwlove\\//"],
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["minor", "patch"],
@@ -77,12 +84,20 @@
       ignoreTests: false,
     },
     {
-      // First-party images: Rob builds and pushes these himself, so
-      // there is no upstream release to be yanked and the 3-day soak
-      // the docker rules above stamp on every bump protects against
-      // nothing here — it only delays a known-good rebuild. This rule
-      // is last, so its minimumReleaseAge override wins the merge and
-      // drops these off the dashboard's "Pending Status Checks" wait.
+      // First-party images: Rob builds and pushes these himself, so there is
+      // no upstream release to be yanked and a soak protects against nothing —
+      // it only delays a known-good rebuild.
+      //
+      // NO minimumReleaseAge on purpose, and the two soak rules above now
+      // exclude these packages so their 3-day gate can't leak in via
+      // rule-merge. This is load-bearing: renovate has no release timestamp
+      // for ghcr.io/rwlove/* images, so ANY age gate is unsatisfiable and
+      // (internalChecksFilter=strict) renovate WITHHOLDS the update entirely —
+      // no branch, no PR, stuck pendingChecks forever. That is exactly what a
+      // "1 minute" gate here did (home-ops #13775, whose title said "drop soak"
+      // but which added the gate): pump image bumps never auto-opened and were
+      // rolled by hand every release. With no gate, the PR opens the instant a
+      // new tag is seen and automerge+ignoreTests lands it on green.
       description: "Auto-merge rwlove personal container images (no soak — first-party)",
       matchDatasources: ["docker"],
       automerge: true,
@@ -90,7 +105,6 @@
       matchPackageNames: [
         "/^ghcr\\.io\\/rwlove\\//",
       ],
-      minimumReleaseAge: "1 minute",
       ignoreTests: true,
     },
   ],


### PR DESCRIPTION
## Problem

Pump image bumps (and every other `ghcr.io/rwlove/*` image) **never auto-merge** — they're rolled by hand every release. Rob asked for these to "merge green immediately."

## Root cause

The `Auto-merge rwlove personal container images` rule carries `minimumReleaseAge: "1 minute"`, added by #13775 (whose title said "drop soak" but whose diff *added* the gate, on the theory that a 1-min override beats the inherited 3-day and reads as immediate).

Renovate has **no release timestamp** for `ghcr.io/rwlove/*` images (it does for third-party — alpine shows `currentVersionTimestamp`). So *any* `minimumReleaseAge` is unsatisfiable, and with renovate's default `internalChecksFilter: strict` the update is **withheld entirely** — no branch, no PR, stuck `pendingChecks: true` forever.

Confirmed live: the 2026-08-31 15:44Z `rwlove-pump` run detected `pump-voltra v0.1.11 → v0.1.12` but left it `prNo: null, result: pending`. Zero renovate pump PRs have ever opened.

## Fix

- Exclude `ghcr.io/rwlove/**` from the two soak-bearing docker rules (digest + non-major) so their 3-day gate can't leak into first-party via rule-merge.
- Drop `minimumReleaseAge` from the first-party rule entirely — **no** age gate.

No gate → renovate opens the bump PR the instant it sees a new tag → the existing `automerge: true, ignoreTests: true` merges it on green → Flux deploys. Hands-free.

**Third-party soaks are untouched** — they have real timestamps and keep their deliberate 3-day yank window.

Validated with `renovate-config-validator` (`Config validated successfully`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)