### PR TITLE
harden(pump): add startup + liveness probes to the Go server

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -93,6 +93,38 @@ spec:
               - secretRef:
                   name: pump-secret
 
+            # The Go server shipped with NO probes — a wedged server (a
+            # deadlock, a goroutine parked on a dead DB connection, pool
+            # starvation) stayed Running and served nothing, with nothing to
+            # restart it. `/api/ping` is a static 200 that only answers once the
+            # HTTP listener is up, which is AFTER MigratePostgres runs at boot —
+            # so a startup probe on it doubles as "migrations finished", and its
+            # generous failureThreshold keeps a slow migration from being killed
+            # mid-run (the migration runner has no context deadline). Liveness
+            # then takes over. Readiness is left to app-template's TCP default;
+            # a DB-aware /readyz is a follow-up.
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/ping
+                    port: 8080
+                  # 40 × 5s = up to ~200s for boot + migrations before the
+                  # pod is declared failed.
+                  periodSeconds: 5
+                  failureThreshold: 40
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/ping
+                    port: 8080
+                  periodSeconds: 30
+                  failureThreshold: 3
+
             resources:
               requests:
                 cpu: 15m


### PR DESCRIPTION
## Problem

The pump Go server — the highest-stakes PUMP component (holds the DB pool, all ingest, SSE) — shipped with **no liveness, readiness, or startup probe** (`kubectl`-confirmed: all three empty). A wedged server (deadlock, goroutine parked on a dead DB connection after a Postgres failover, pool starvation) stays `Running` and serves nothing, with nothing to restart it. Every sidecar has a liveness probe; the server had none.

Found in the cross-component adversarial hardening review — the "green but dead" failure class.

## Fix

Startup + liveness probe on `/api/ping` (a static 200). The HTTP listener only comes up **after** `MigratePostgres` runs at boot, so `/api/ping` answering doubles as "migrations finished." The startup probe's generous `failureThreshold` (40 × 5s ≈ 200s) keeps a slow boot-time migration from being killed mid-run (the migration runner has no context deadline — a separate Go follow-up). Liveness (30s / 3 failures) restarts a server that stops serving.

Readiness stays on app-template's TCP default for now; a DB-aware `/readyz` is a follow-up in the Go code batch. Pre-commit hooks (yamllint, flate schema, etc.) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)