### PR TITLE
harden(pump-cv): bound RTSP socket reads with FFmpeg stimeout

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -140,8 +140,16 @@ spec:
               # Force RTSP over TCP — UDP transport on the security VLAN
               # drops occasional packets and noisy h264 decode warnings
               # spam the log. OpenCV's FFmpeg backend reads this env var
-              # at VideoCapture time; semicolon-separated key;value.
-              OPENCV_FFMPEG_CAPTURE_OPTIONS: "rtsp_transport;tcp"
+              # at VideoCapture time; semicolon-separated key;value,
+              # pipe-separated options.
+              #
+              # stimeout (microseconds) bounds a socket read so a half-open
+              # Reolink stream returns an error instead of parking cap.read()
+              # in its worker thread forever. The sidecar's own read-stale
+              # watchdog (pump-cv v0.6.4) is the primary guard; this is the
+              # lower-level backstop since FFmpeg's stimeout coverage is more
+              # reliable than OpenCV's per-capture timeout props.
+              OPENCV_FFMPEG_CAPTURE_OPTIONS: "rtsp_transport;tcp|stimeout;5000000"
 
             envFrom:
               - secretRef:


### PR DESCRIPTION
Adds `stimeout;5000000` (5s) to `OPENCV_FFMPEG_CAPTURE_OPTIONS` so a half-open Reolink stream errors out of `cap.read()` instead of parking the worker thread forever. Pairs with the sidecar's own read-stale watchdog (pump-cv v0.6.4, PUMP #144) as the lower-level backstop — FFmpeg's stimeout is more reliably honored than OpenCV's per-capture timeout props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)