### PR TITLE
harden(pump): give the Go server memory burst headroom (128M→320M limit)

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -128,9 +128,16 @@ spec:
             resources:
               requests:
                 cpu: 15m
+                # Request stays at the idle footprint; the limit is raised to
+                # give burst headroom. request==limit==128M left ZERO room for a
+                # spike (a large health-ingest batch, many concurrent SSE
+                # clients, image/QR generation) — the next spike OOMKills the
+                # server and drops every SSE connection. Burstable QoS with a
+                # 320M ceiling absorbs the spike while keeping the scheduler
+                # footprint small.
                 memory: 128M
               limits:
-                memory: 128M
+                memory: 320M
             securityContext: *hardened
 
     service:


### PR DESCRIPTION
`request==limit==128M` left zero headroom for a spike (a large health-ingest batch, many concurrent SSE clients, image/QR generation) — the next spike OOMKills the server and drops every SSE connection. Request stays at the idle footprint; the limit rises to 320M (Burstable QoS) so a spike is absorbed. From the cross-component hardening review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)