### PR TITLE
fix(windmill): pin chart 4.0.253 to clear stuck rollout

### DIFF
--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -19,11 +19,17 @@ spec:
       # that break, but 1.799.0 has the SAME problem in reverse: the base
       # ghcr.io/windmill-labs/windmill:1.799.0 image was never published
       # (only windmill-extra was) → rollout stuck, old pods kept serving.
-      # Pinned back to 4.0.250 (appVersion 1.798.1) — verified BOTH
-      # windmill:1.798.1 and windmill-extra:1.798.1 exist on GHCR. Upstream
-      # publishes the two images asymmetrically per release; verify both
-      # tags exist before bumping again, not just windmill-extra.
-      version: 4.0.251
+      # 2026-08-30 (#13901): pinned back to 4.0.250 (appVersion 1.798.1) —
+      # verified BOTH windmill:1.798.1 and windmill-extra:1.798.1 on GHCR.
+      # 2026-08-31 (#13905): Renovate re-bumped to 4.0.251 (appVersion
+      # 1.799.0) — the SAME broken pin — because it compares only chart
+      # semver, not whether the appVersion's base image exists. Rollout
+      # stuck again (windmill:1.799.0 = 404), old pods kept serving.
+      # 2026-09-01: pinned 4.0.253 (appVersion 1.800.1) — verified BOTH
+      # windmill:1.800.1 AND windmill-extra:1.800.1 return 200 on GHCR.
+      # Upstream publishes the two images asymmetrically per release;
+      # verify BOTH tags exist before bumping again, not just one.
+      version: 4.0.253
   install:
     disableWait: true
   interval: 30m


### PR DESCRIPTION
## What

Bump the windmill HelmRelease chart pin `4.0.251` → `4.0.253`.

## Why

Chart `4.0.251` resolves to appVersion `1.799.0`, whose **base** image `ghcr.io/windmill-labs/windmill:1.799.0` was never published upstream (only `windmill-extra:1.799.0` was) → `ImagePullBackOff` on the new ReplicaSets. The old `1.798.1` pods kept serving so there was **no outage**, but the rollout stalled ~21h and lit up `KubeDeploymentRolloutStuck` ×3, `KubePodNotReady` ×3, and `KubeJobFailed` ×3 (the watchdog CronJob) for the `home` namespace.

This is a **repeat**: fixed in #13901 (pinned to `4.0.250`), then re-broken by Renovate in #13905 (bumped back to `4.0.251`) — Renovate compares chart semver only, not whether the appVersion's base image exists.

## Verification

Chart `4.0.253` → appVersion `1.800.1`, with **both** images confirmed present on GHCR (HTTP 200):
- `ghcr.io/windmill-labs/windmill:1.800.1`
- `ghcr.io/windmill-labs/windmill-extra:1.800.1`

Post-merge: new `1.800.1` ReplicaSets should reach `1/1 Ready` for all three deployments, old ones scale to 0, and the `home`-namespace rollout/watchdog alerts clear.

## Follow-up (not in this PR)

Second time Renovate has broken windmill this way. Worth a `renovate.json` rule gating windmill chart bumps on manual base-image verification — flagging, not fixing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)