### PR TITLE
fix(ollama): bound llama.cpp prompt cache to stop host-RAM OOMKills

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -53,6 +53,37 @@ spec:
               # https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-set-the-quantization-type-for-the-kv-cache
               OLLAMA_KV_CACHE_TYPE: q8_0
               OLLAMA_FLASH_ATTENTION: 1
+              # ROOT CAUSE of the 2026-09-01 OOMKills (exit 137, ~every 1.5d):
+              # ollama has NO ollama-level cache cap, but each per-model
+              # llama-server runner is a llama.cpp binary that reads
+              # standard llama.cpp env vars from the inherited process env
+              # (llm/llama_server.go sets cmd.Env = os.Environ(), confirmed
+              # against ollama 0.33.2 source; the binary's own --help
+              # confirms `env: LLAMA_ARG_CACHE_RAM` is registered on this
+              # exact image). Undocumented by ollama itself — this is a
+              # llama.cpp flag (https://github.com/ggml-org/llama.cpp/pull/16391)
+              # ollama silently inherits.
+              #
+              # Unset, the compiled default is 8192 MiB PER RUNNER. With
+              # OLLAMA_MAX_LOADED_MODELS=3 that's up to 3 independent
+              # 8 GiB caches (24 GiB worst case) against a 6Gi container
+              # limit — nowhere near bounded at container scale. Confirmed
+              # via the crashed container's log: 19,779 live prompt-cache
+              # entries (~21 MiB each, `checkpoints: 0` — zero prefix
+              # reuse) for qwen2.5vl:3b with no "cache size limit reached"
+              # eviction message ever printed before the kill.
+              #
+              # The traffic is Frigate's GenAI VLM: one-shot ~1.1-1.2k
+              # token detection-description prompts, near-zero cross-
+              # request prefix overlap (see OLLAMA_KEEP_ALIVE comment
+              # below for the same workload). Prompt-cache reuse buys
+              # this workload almost nothing, so cap tight rather than
+              # disable outright (0 would also drop legitimate same-
+              # session reuse for qwen2.5-coder/bge-m3 traffic).
+              # 512 MiB/runner x up to 3 runners = 1.5 GiB worst-case
+              # aggregate, leaving the bulk of the (now 10Gi) limit for
+              # actual model weights + KV cache.
+              LLAMA_ARG_CACHE_RAM: 512
               # Raised from ollama's 5m default on 2026-07-26. Frigate's
               # GenAI VLM was aging out between detections, so real
               # descriptions paid ~38s of cold load (vision projector
@@ -126,7 +157,16 @@ spec:
                 cpu: 500m
                 nvidia.com/gpu: 1
               limits:
-                memory: 6G
+                # Headroom above the 6G request, added alongside the
+                # LLAMA_ARG_CACHE_RAM fix above (2026-09-01 OOMKill
+                # root-cause: unbounded per-runner llama.cpp prompt
+                # cache, see that comment). This is belt-and-suspenders,
+                # not the fix itself — worker8 has ~31 GiB available at
+                # time of writing, request stays flat so scheduling is
+                # unaffected, this only widens the cgroup ceiling so a
+                # transient spike doesn't get SIGKILLed while the cache
+                # fix soaks.
+                memory: 10G
                 nvidia.com/gpu: 1
 
             # GPU access is via the device plugin (nvidia.com/gpu: 1),


### PR DESCRIPTION
## What

Two changes to `kubernetes/apps/ai/ollama/app/helmrelease.yaml`:
1. **Real fix:** `LLAMA_ARG_CACHE_RAM: 512` (MiB per runner)
2. **Belt-and-suspenders:** `limits.memory` `6G` → `10G` (request stays flat at `6G`)

## Why

`ollama-0` was being **OOMKilled** (exit 137, `reason: OOMKilled`) roughly **every 1.5 days** — a true host-RAM cgroup kill, not VRAM, not a liveness probe.

**Root cause:** ollama has no cache cap of its own, but each `OLLAMA_MAX_LOADED_MODELS` slot runs an independent `llama-server` (vendored llama.cpp) subprocess that inherits the parent env (`llm/llama_server.go`: `cmd.Env = os.Environ()`) and honors llama.cpp's `LLAMA_ARG_CACHE_RAM` flag — undocumented by ollama itself. Unset, the compiled default is **8192 MiB per runner**; with `MAX_LOADED_MODELS=3` that's up to **24 GiB** worst-case against a 6Gi container limit. The crashed container logged **19,779 live prompt-cache entries** (`checkpoints: 0` — zero prefix reuse) for `qwen2.5vl:3b` with no eviction before the SIGKILL.

The dominant traffic is Frigate's GenAI VLM: one-shot ~1.1–1.2k-token detection prompts with near-zero cross-request prefix overlap ([ollama#17351](https://github.com/ollama/ollama/issues/17351)), so the prompt cache buys this workload almost nothing.

## Verification

`LLAMA_ARG_CACHE_RAM` confirmed present four ways: upstream issue thread, llama.cpp source ([PR #16391](https://github.com/ggml-org/llama.cpp/pull/16391)), ollama's `os.Environ()` passthrough, and — decisively — `--help` from the **actual binary running in the pod** (`-cram, --cache-ram N ... (env: LLAMA_ARG_CACHE_RAM)`). The pinned llama.cpp build `b10630` postdates the flag's merge.

**Sizing:** `512 MiB × 3 runners = 1.5 GiB` worst-case aggregate cache — tight (VLM gets nothing from a big cache) but not `0` (preserves same-session reuse for coder/embedding traffic). The `10G` limit is padding while the fix soaks; `worker8` has ~31 GiB available and the flat request keeps scheduling unaffected. **VRAM untouched** — `MAX_LOADED_MODELS` unchanged, so the P40 budget is unaffected.

## Soak / follow-up

Not closed until validated: watch `container_memory_usage_bytes` for `ollama-0` over the next few days, confirm no further `OOMKilled`. If clean, consider right-sizing the `10G` limit back down. `512 MiB` is a judgment call — tunable up if single-session reuse turns out to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)