### PR TITLE
fix(omada-exporter): slow scrape 1m→5m to rate-limit controller CLOSE-WAIT leak

### DIFF
--- a/kubernetes/apps/observability/exporters/omada-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/omada-exporter/app/helmrelease.yaml
@@ -95,5 +95,16 @@ spec:
           - port: http
             scheme: http
             path: /metrics
-            interval: 1m
+            # 5m, not 1m: rcooler/omada_exporter re-queries the Omada
+            # controller's HTTPS API (brain:8043) on EVERY scrape, and this
+            # controller (v6.2.14.11) leaks the server side of each closed
+            # connection into CLOSE-WAIT. Those accumulate until Tomcat's
+            # 8043 connector hits maxConnections and stops accepting →
+            # OmadaControllerUnreachable + TargetDown (2026-08-01, 2026-09-01
+            # ~1:13 PM ET). 1m churn saturated it in ~1 month; 5m cuts the
+            # leak rate ~5x. This is a RATE-LIMITER, not the fix — the leak
+            # is server-side and unfixable from here; the durable bound is a
+            # scheduled omada.service restart on brain. See
+            # rwlove/lovenet-network-configuration#51.
+            interval: 5m
             scrapeTimeout: 30s


### PR DESCRIPTION
## What

`omada-exporter` ServiceMonitor `interval` `1m` → `5m`.

## Why

The Omada controller on `brain` (v6.2.14.11) wedged its HTTPS connector twice — 2026-08-01 and 2026-09-01 ~1:13 PM ET — firing `OmadaControllerUnreachable` + `TargetDown`.

**Root cause (found by direct inspection on brain):** 112 sockets stuck in `CLOSE-WAIT` on `:8043` — the controller never `close()`s the server side of connections the client has closed. They accumulate until Tomcat's connector hits maxConnections and stops accepting (`Recv-Q 101`, 0 established). Confirmed it is **not** OOM (the only heap dump is from the Aug 1 event), **not** a JVM deadlock (internal scheduler pools, MongoDB, and AP management on `:8843` were all healthy — APs stayed adopted, so the network itself was never affected), and **not** the exporter pod (healthy, 0 restarts).

`rcooler/omada_exporter` re-queries `:8043` on **every** scrape, so the 1m cadence was the dominant source of new-and-closed connections feeding the leak. `5m` cuts the leak rate ~5×.

## This is a rate-limiter, not the fix

The leak is **server-side and unfixable from here**. This PR buys time (recurrence should stretch from ~monthly toward ~quarterly). The durable bound is a **scheduled `omada.service` restart on `brain`** (human-touch per HOMELAB-SPEC L2.9) — proposed separately, likely belongs in `rwlove/lovenet-network-configuration` (runbook #51).

## Alert timing unaffected

`OmadaControllerUnreachable` = `up{job="omada-exporter"} == 0` `for: 10m` → still 2 samples at a 5m interval. Metric resolution for Omada (client counts, AP status) drops to 5m, which is fine for a home network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)