### PR TITLE
fix(home-assistant): bump 2026.8.3 → 2026.9.0 (drop CARTO basemap watermark)

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
           venv-reset:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: &hassImage 2026.8.3@sha256:16ca445e58fa71d4f7ff287d4e9793ea690ccae932a5e200852371425cd7abb0
+              tag: &hassImage 2026.9.0@sha256:f795a47fa14a5b109cc524b7f7e8b3d9ab95665d0482d9a11b794b6ad8425baa
 
             args:
               - |


### PR DESCRIPTION
## What

Bump Home Assistant `2026.8.3` → `2026.9.0`.

## Why

The built-in **Map** renders `API KEY REQUIRED` watermarks across every tile. CARTO — the raster basemap provider HA's map has always used — began requiring an API key in Aug 2026 and now watermarks unauthenticated tile requests. `2026.8.3` still points the map at CARTO, so the watermark is served by CARTO's servers and can't be cleared locally.

`2026.9` ([frontend #53816](https://github.com/home-assistant/frontend/pull/53816)) drops CARTO entirely for **self-hosted OpenStreetMap vector tiles via MapLibre GL** — no key, no external tile provider, plus real dark-mode cartography. Bumping clears the watermark at the source.

Upstream refs: [core #180277](https://github.com/home-assistant/core/issues/180277), [frontend #53800](https://github.com/home-assistant/frontend/issues/53800).

## Risk / timing

- **Household-facing.** Merge triggers a Flux reconcile → HA restart (~1–2 min unavailable). Per repo maintenance windows, land in the **Tuesday 02:00–04:00** window unless Rob accepts the blip now.
- Monthly HA release — carries the usual breaking-change surface (integration deprecations etc.). The map fix is the driver; a release-notes skim before merge is advisable.
- Image digest pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)