### PR TITLE
feat(emqx): sandbox deck-light client to its own topics via acl.conf

### DIFF
--- a/kubernetes/apps/home/emqx/app/configmap.yaml
+++ b/kubernetes/apps/home/emqx/app/configmap.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: emqx-acl
+data:
+  # Mounted over EMQX's default authz file source (/opt/emqx/etc/acl.conf).
+  # Only ADDS a sandbox for the deck-light controller (clientid ESP32_c747D4,
+  # an untrusted closed-firmware ESP32 on the IoT VLAN) — everything below the
+  # divider is EMQX 5's stock acl.conf, preserved verbatim. With
+  # authorization.no_match = allow, any client matching no rule (i.e. every
+  # other client) is unaffected. Protocol/rationale: home-assistant-config
+  # packages/deck_lights.yaml.
+  #
+  # NOTE: EMQX reads this at boot; a later edit needs a pod roll to take effect.
+  acl.conf: |
+    %% --- Deck-light sandbox (clientid ESP32_c747D4) ---
+    {allow, {clientid, "ESP32_c747D4"}, publish, ["state/62c747d47605"]}.
+    {allow, {clientid, "ESP32_c747D4"}, subscribe, ["device/62c747d47605"]}.
+    {deny, {clientid, "ESP32_c747D4"}, all, ["#"]}.
+
+    %% --- EMQX 5 stock defaults (verbatim) ---
+    {allow, {username, {re, "^dashboard$"}}, subscribe, ["$SYS/#"]}.
+    {allow, {ipaddr, "127.0.0.1"}, all, ["$SYS/#", "#"]}.
+    {deny, all, subscribe, ["$SYS/#", {eq, "#"}, {eq, "+/#"}]}.
+    {allow, all}.

--- a/kubernetes/apps/home/emqx/app/helmrelease.yaml
+++ b/kubernetes/apps/home/emqx/app/helmrelease.yaml
@@ -36,6 +36,18 @@ spec:
       EMQX_AUTH__MNESIA__PASSWORD_HASH: plain
       EMQX_DASHBOARD__DEFAULT_USERNAME: admin
 
+    # Mount a custom acl.conf over EMQX's default authz file source
+    # (/opt/emqx/etc/acl.conf). Adds a sandbox rule for the deck-light
+    # controller; the rest is EMQX stock. See the emqx-acl ConfigMap.
+    extraVolumes:
+      - name: acl
+        configMap:
+          name: emqx-acl
+    extraVolumeMounts:
+      - name: acl
+        mountPath: /opt/emqx/etc/acl.conf
+        subPath: acl.conf
+
     image:
       repository: public.ecr.aws/emqx/emqx
 

--- a/kubernetes/apps/home/emqx/app/kustomization.yaml
+++ b/kubernetes/apps/home/emqx/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Sandbox an untrusted IoT client on EMQX

Mounts a custom `acl.conf` over EMQX's default authorization file source
(`/opt/emqx/etc/acl.conf`, via the chart's `extraVolumes`), scoping one
untrusted closed-firmware IoT device (clientid `ESP32_c747D4`) to only its own
MQTT topics:

- allow publish `state/62c747d47605`
- allow subscribe `device/62c747d47605`
- deny everything else for that client

### Why
Until now the broker enforced **no authorization** — the HelmRelease's
`emqxConfig` uses EMQX-4.x auth keys that 5.x silently ignores — so this device
had unrestricted broker access. Defense-in-depth: constrain it to its own topic
tree.

### Safety
- Everything below the divider in `acl.conf` is EMQX 5's stock file, verbatim.
- `authorization.no_match` stays `allow` (confirmed on the live broker), so any
  client matching no rule — i.e. every other client — is completely unaffected.
- 3 replicas + rolling update: a malformed `acl.conf` would stall the rollout
  (new pod not Ready), not take the broker down.
- Verified post-deploy: broker healthy, existing clients unaffected, target
  client reaches its own topics but is denied others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
