### PR TITLE
feat(observability): vllm-driver-spark synthetic-decode wedge detector

### DIFF
--- a/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
@@ -37,6 +37,15 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus
+        # Synthetic-decode wedge probe (vllm-driver-spark-completion Probe,
+        # blackbox-exporter/app/probes.yaml). WITHOUT this hole the probe is
+        # a silent default-deny drop (exit 28) and probe_success never
+        # populates — the exact blackbox-exporter label trap from #13264
+        # (reference_cnp_blackbox_exporter_label_trap). The chart label is
+        # `prometheus-blackbox-exporter`, NOT `blackbox-exporter`.
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus-blackbox-exporter
       toPorts:
         - ports:
             - port: "8000"

--- a/kubernetes/apps/ai/vllm-driver-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/prometheusrule.yaml
@@ -38,3 +38,67 @@ spec:
           for: 5m
           labels:
             severity: critical
+        # Synthetic-probe wedge detector — the sister of SparkTeiEmbedWedged
+        # / SparkOllamaWedged, and the load-bearing signal for this endpoint.
+        # /health returns 200 and the pod stays Ready while the EngineCore
+        # spin-loops (observed live 2026-09-05: GPU pinned 96%,
+        # num_requests_running stuck at 2, zero completions for 12 days) —
+        # so SparkVllmDriverPodDown above CANNOT catch a wedge. The
+        # vllm-driver-spark-completion Probe (blackbox-exporter/app/
+        # probes.yaml, 2-min cadence) POSTs a real 1-token /v1/chat/
+        # completions decode and asserts the OpenAI shape; probe_success
+        # goes 0 the moment decode freezes.
+        #
+        # Companion: the generic BlackboxProbeFailed does NOT cover this
+        # probe (its matcher is scoped to nfs|ollama-embed), so this rule is
+        # the only page for a driver wedge.
+        - alert: SparkVllmDriverWedged
+          annotations:
+            summary: vllm-driver-spark synthetic decode probe failing (reasoning/driver LLM wedged)
+            description: |
+              The vllm-driver-spark-completion Probe (POST /v1/chat/
+              completions, max_tokens:1) has been failing for ≥5 minutes.
+              The pod reports Ready and /health=200 while the EngineCore is
+              not actually serving — a GB10 CUDA-graph decode hang (#40969).
+              Impact: Open WebUI chat, LightRAG, and any driver-LLM consumer
+              stall. Checks:
+              (1) `kubectl -n ai logs statefulset/vllm-driver-spark --tail=200`;
+              (2) confirm the wedge signature —
+                  `vllm:num_requests_running > 0` with zero increase in
+                  `vllm:request_success_total` (SparkVllmDriverWedgedInternal);
+              (3) recovery is a restart —
+                  `kubectl -n ai rollout restart statefulset/vllm-driver-spark`
+                  (weights are cached on the PVC; ~10-40 min to reload +
+                  recompile graphs — do NOT thrash the pod);
+              (4) silence SparkVllmDriverPodDown for the restart window only,
+                  never this alert.
+          expr: |-
+            probe_success{instance=~"https?://vllm-driver-spark.*"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # Secondary/corroborating internal-counter view of the same wedge,
+        # verified live to fire against the current incident (2026-09-05):
+        # requests in flight (num_requests_running > 0) but zero successful
+        # completions over 10m. This catches the wedge from the engine's own
+        # metrics even if the synthetic probe request can't get scheduled.
+        # NB the aggregation: request_success_total is split into multiple
+        # series by `finished_reason`, so a bare `and` to num_requests_running
+        # (which has no such label) returns EMPTY and never fires — sum()/max()
+        # collapse the labels so the join works. Warning, not critical, to
+        # avoid double-paging with the probe alert above.
+        - alert: SparkVllmDriverWedgedInternal
+          annotations:
+            summary: vllm-driver-spark serving requests but completing none (engine-counter wedge signal)
+            description: |
+              vllm:num_requests_running > 0 with zero increase in
+              vllm:request_success_total over 10m — the engine is holding
+              requests without completing them. Corroborates
+              SparkVllmDriverWedged; same recovery (rollout restart).
+          expr: |-
+            max(vllm:num_requests_running{job="vllm-driver-spark"}) > 0
+            and
+            sum(increase(vllm:request_success_total{job="vllm-driver-spark"}[10m])) == 0
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -113,6 +113,37 @@ spec:
             valid_status_codes: [200]
           prober: http
           timeout: 45s
+        # Synthetic-decode prober for vllm-driver-spark, the Qwen3.6-35B-A3B
+        # reasoning/driver LLM on the Spark. POSTs a 1-token chat completion
+        # and asserts the OpenAI response shape ("choices"). This is the
+        # wedge detector the endpoint lacked: vLLM returns /health=200 while
+        # the EngineCore spin-loops (GPU pinned 96%, decode frozen,
+        # num_requests_running stuck) — /health cannot see it, a real decode
+        # can. Sister of ollama_generate (also a 1-token generation), but
+        # against the OpenAI /v1/chat/completions surface, so the success
+        # assertion is the OpenAI shape ("choices") rather than ollama's
+        # ("response"). The model id is the served-model-name invariant
+        # (qwen3.6-35b-a3b), stable across image/model bumps.
+        #
+        # 40s timeout absorbs a cold CUDA-graph warm-up after a restart
+        # (weights load from the cache PVC, then graphs compile); a warm
+        # decode returns in well under a second. The Probe CR (probes.yaml)
+        # pairs scrapeTimeout 45s > this 40s so a cold load surfaces as a
+        # slow success, not a scrape error (same rule as ollama-vlm-warm).
+        vllm_completion:
+          http:
+            body: |-
+              {"model":"qwen3.6-35b-a3b","messages":[{"role":"user","content":"ping"}],"max_tokens":1,"stream":false}
+            fail_if_body_not_matches_regexp:
+              - "\"choices\""
+            headers:
+              Content-Type: application/json
+            method: POST
+            preferred_ip_protocol: "ip4"
+            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+            valid_status_codes: [200]
+          prober: http
+          timeout: 40s
         tcp_connect:
           prober: tcp
           tcp:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -231,3 +231,32 @@ spec:
     staticConfig:
       static:
         - http://tei-embed-spark.ai.svc.cluster.local:3000/v1/embeddings
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: vllm-driver-spark-completion
+spec:
+  # Wedge detector for vllm-driver-spark (Qwen3.6-35B-A3B reasoning/driver
+  # LLM). The endpoint returns /health=200 while the EngineCore spin-loops
+  # (observed live 2026-09-05: GPU pinned 96%, num_requests_running stuck
+  # at 2, zero completions for 12 days) — so pod-Ready and /health cannot
+  # catch a wedge; only a real decode can. POSTs a 1-token completion and
+  # asserts the OpenAI shape. Sister of tei-embed-spark-embed / ollama-*.
+  #
+  # 2m cadence: the SparkVllmDriverWedged alert is for:5m, so finer
+  # granularity buys nothing and a decode is more expensive than an embed.
+  # scrapeTimeout 45s > the module's 40s timeout so a cold CUDA-graph
+  # warm-up after a restart surfaces as a slow success, not a scrape error
+  # (same pairing rule as ollama-vlm-warm's 50s>45s).
+  interval: 2m
+  scrapeTimeout: 45s
+  module: vllm_completion
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://vllm-driver-spark.ai.svc.cluster.local:8000/v1/chat/completions


### PR DESCRIPTION
## What

Adds the wedge safety net for `vllm-driver-spark` (the Qwen3.6-35B-A3B reasoning/driver LLM on the Spark) — **PR-1 of the Hermes buildout**. The endpoint returns `/health=200` and stays pod-Ready while the EngineCore spin-loops on a GB10 CUDA-graph decode hang (#40969). Verified live 2026-09-05: `num_requests_running` stuck at 2, **zero completions for 12 days**. Pod-Ready alone cannot detect this.

## Changes

- **`vllm_completion` blackbox module** — POST `/v1/chat/completions`, `max_tokens:1`, asserts the OpenAI `"choices"` shape; 40s timeout for cold CUDA-graph warm-up. Mirrors `ollama_generate` / `tei_embed`.
- **`vllm-driver-spark-completion` Probe** — 2m cadence, `scrapeTimeout: 45s` > the module's 40s so a cold reload surfaces as a slow success, not a scrape error.
- **CNP ingress fix** — adds the blackbox-exporter (`app.kubernetes.io/name: prometheus-blackbox-exporter`) to the `:8000` allowlist. Without it the probe is a silent default-deny drop (exit 28) and `probe_success` never populates — the #13264 label trap.
- **`SparkVllmDriverWedged`** (critical, `probe_success==0` for 5m) — the primary detector, matching the `SparkTeiEmbedWedged` / `SparkOllamaWedged` pattern.
- **`SparkVllmDriverWedgedInternal`** (warning) — corroborates from engine counters. Its expr uses `sum()`/`max()` to collapse the `finished_reason` split on `request_success_total`; a bare `and` returns empty and never fires (verified live before/after).

## Note on merge

The endpoint is **wedged right now**, so `SparkVllmDriverWedged` will fire on merge — that's the detector proving itself. Recovery is a manual `kubectl -n ai rollout restart statefulset/vllm-driver-spark` (propose-then-execute; weights are PVC-cached, ~10–40 min reload). Silence `SparkVllmDriverPodDown` for the restart window only — never the wedge alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4rLwjfTe1eGMwrHs1capz