### PR TITLE
fix(jdownloader2): raise mem limit for NFS page-cache balloon OOM

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -56,9 +56,16 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 768Mi
+              # limit is sized for the NFS write-back page-cache balloon,
+              # not the app RSS (~619Mi working set). The /output volume is
+              # direct NFS; its dirty page cache is unreclaimable under the
+              # cgroup limit and counts toward usage_bytes (peaked 997Mi at
+              # the old 1G ceiling → OOM exit 137), while working_set hides
+              # it. Same failure mode as the nzb downloader — give it +2Gi
+              # headroom. See reference_nzb_downloader_incomplete_nfs_pagecache_oom.
               limits:
-                memory: 1G
+                memory: 3G
 
     service:
       app:


### PR DESCRIPTION
usage_bytes peaked at 997Mi against the 1G limit (OOM exit 137) while
working_set stayed at ~619Mi and hid it — the /output volume is direct
NFS and its dirty write-back page cache is unreclaimable under the
cgroup limit. Same failure mode as the nzb downloader. Bump limit
1G→3G for page-cache headroom; lift request 512Mi→768Mi to cover the
real ~619Mi working set.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T55HRAHDm7U7umHxvPQNFb
