### PR TITLE
feat(ai): deploy Hermes Agent as the local-first routing front door

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -23,6 +23,7 @@
 docker.io/istio/                        # istio pilot/proxyv2: Istio is retiring gcr.io/istio-release AND registry.istio.io/release (both late 2026); ghcr hosts only charts, not runtime images (403). docker.io/istio is upstream's permanent home. Verified 2026-08. See https://istio.io/latest/blog/2026/retirement-of-gcr.io-follow-up/
 docker.io/ollama/ollama
 docker.io/glanceapp/glance
+docker.io/nousresearch/hermes-agent     # Nous Research publishes hermes-agent only to Docker Hub (repo's own docker.yml pushes IMAGE_NAME=nousresearch/hermes-agent, no registry prefix). No ghcr/quay publication: ghcr.io/nousresearch/hermes-agent = permission_denied, ghcr.io/home-operations/hermes-agent = name unknown. Verified 2026-09.
 docker.io/library/couchdb               # ghcr/apache/couchdb is devcontainer-only
 docker.io/library/monica                # Monica CRM canonical image; monica-next is ghcr but the moving :main dev tag
 docker.io/longhornio/                    # Longhorn canonical, no ghcr publication

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-162-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-163-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-173-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-94-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-95-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hermes-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes
+  # Additive — the ai namespace default-deny triggers the lockdown; these
+  # rules punch holes. DNS egress is provided cluster-wide by the baseline
+  # network-policy component, so it is not repeated here.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Primary model: the vLLM reasoning/driver LLM on the Spark. Hermes runs
+    # the local execution loop against this endpoint — zero Anthropic quota.
+    # The driver's own cnp-allow adds the matching ingress entry for hermes.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: vllm-driver-spark
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  # No ingress holes: the OpenAI-compatible API server (:8642) is in-cluster
+  # only with no consumer yet (reach it via `kubectl port-forward` for
+  # testing). Kubelet health probes (host → pod) are allowed by Cilium's host
+  # policy and need no rule. Consumer ingress + the claude -p → Anthropic
+  # egress land with the escalation bridge in PR-4.

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-secret
+    creationPolicy: Owner
+  data:
+    # Claude MAX subscription OAuth (output of `claude setup-token`, ~1yr).
+    # Subscription only — never an API key (Rob's hard constraint). Consumed
+    # by the claude-code escalation skill (wired in PR-4). Its OWN 1P item
+    # (`hermes`), deliberately NOT the shared `claude-runner` item, so the
+    # claude-runner teardown can't break Hermes.
+    - secretKey: CLAUDE_CODE_OAUTH_TOKEN
+      remoteRef:
+        key: hermes
+        property: claude_code_oauth_token
+    # Auth key for Hermes' in-cluster OpenAI-compatible API server (:8642).
+    # Mandatory whenever the API server binds beyond loopback — an
+    # unauthenticated Hermes API server was an entry point for the June-2026
+    # agent-backdoor campaign, so this is never optional.
+    - secretKey: API_SERVER_KEY
+      remoteRef:
+        key: hermes
+        property: api_server_key

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -1,0 +1,154 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    # First boot: s6 remaps the hermes user, chowns /opt/data, then starts the
+    # gateway. Don't let Flux block on readiness (mirrors vllm/ollama-spark).
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      hermes:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # StatefulSet + single writer: "never run two gateway containers
+        # against the same data directory" (session/memory stores are not
+        # concurrency-safe). RWO Longhorn volume enforces it.
+        type: statefulset
+        pod:
+          securityContext:
+            # s6-overlay image: /init starts as root to remap the internal
+            # `hermes` user to HERMES_UID/GID and chown /opt/data, then drops
+            # each supervised service to that user via s6-setuidgid. So it MUST
+            # start as root and keep the default cap set — runAsNonRoot or
+            # capabilities.drop:[ALL] breaks the supervised drop. Documented
+            # escape hatch per helmrelease.security.md (same root-required
+            # rationale as ollama-spark / vllm-driver-spark).
+            runAsUser: 0
+            runAsGroup: 0
+            fsGroup: 10000
+            fsGroupChangePolicy: OnRootMismatch
+        initContainers:
+          config-seed:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.8.31
+            # Seed config.yaml onto the data volume ONCE (cp -n = no-clobber),
+            # so Hermes owns it after first boot ("hand-placed once, curates
+            # after"). Personal identity (SOUL/USER/MEMORY) is placed by hand
+            # on the PVC, never committed to this public repo.
+            command:
+              - sh
+              - -c
+              - cp -n /seed/config.yaml /opt/data/config.yaml || true
+        containers:
+          app:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.8.31
+            # The image ENTRYPOINT (/init → main-wrapper.sh) MUST stay PID 1
+            # for s6-overlay; only override CMD.
+            args: ["gateway", "run"]
+            env:
+              HERMES_HOME: /opt/data
+              HERMES_UID: "10000"
+              HERMES_GID: "10000"
+              # In-cluster OpenAI-compatible API server (health + reachability
+              # for later consumers). Binds 0.0.0.0 but pod-network only — no
+              # public HTTPRoute. API_SERVER_KEY (from the secret) is mandatory:
+              # an unauthenticated Hermes API server was an entry point for the
+              # June-2026 agent-backdoor campaign.
+              API_SERVER_ENABLED: "true"
+              API_SERVER_HOST: 0.0.0.0
+              # The driver has no --api-key, so any non-empty value satisfies
+              # the OpenAI client. Real secrets come via envFrom below.
+              OPENAI_API_KEY: sk-noauth-local-vllm
+            envFrom:
+              - secretRef:
+                  name: hermes-secret
+            probes:
+              # TCP on the API server port — the API server binds :8642 once
+              # the gateway is up. Generous startup budget for the s6 init +
+              # chown + gateway warmup on a fresh volume.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8642
+                  initialDelaySeconds: 90
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8642
+                  initialDelaySeconds: 45
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8642
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            securityContext:
+              # See the pod comment: root-required s6 image. s6-setuidgid needs
+              # SETUID/SETGID/CHOWN from the default cap set, so do NOT drop
+              # ALL; rootfs stays writable for s6 /run state. This is the
+              # documented deviation, not the baseline.
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: false
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                memory: 4Gi
+    service:
+      app:
+        controller: hermes
+        ports:
+          http:
+            port: 8642
+    persistence:
+      # The single source of truth for all Hermes state (SQLite, config, .env,
+      # profiles, skills, memories, sessions) — mounted into both the seed init
+      # container and the app.
+      data:
+        existingClaim: hermes-data-pvc
+        advancedMounts:
+          hermes:
+            config-seed:
+              - path: /opt/data
+            app:
+              - path: /opt/data
+      # The operator-managed config.yaml, mounted read-only into the seed init
+      # container only (it copies it onto the data volume if absent).
+      config-seed:
+        type: configMap
+        name: hermes-config
+        advancedMounts:
+          hermes:
+            config-seed:
+              - path: /seed
+                readOnly: true

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./longhorn-pvc.yaml
+configMapGenerator:
+  - name: hermes-config
+    files:
+      - config.yaml=./resources/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ai/hermes/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/ai/hermes/app/longhorn-pvc.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-data-pvc
+  labels:
+    type: longhorn
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 20Gi
+  volumeName: hermes-data-pv
+  storageClassName: hermes-data-storage-class
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: hermes-data-pv
+  labels:
+    type: longhorn
+spec:
+  # Irreplaceable, continuously-authored state (SQLite/FTS5 sessions,
+  # memory, self-authored skills, identity) → Longhorn per the storage-class
+  # decision tree rule 3. numberOfReplicas 2 (not media-grade 1). The volume
+  # carries no recurring-job-group labels, so Longhorn auto-applies the
+  # `default` group (daily snapshot + weekly + monthly backup) — the intended
+  # coverage per storage-class.instructions.md; do NOT add named labels here
+  # or it drops out of `default`. xfs (block, WAL-crash-safe) is the right FS
+  # for SQLite — NFS/SMB would force Hermes to fall back to journal=DELETE.
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: hermes-data-storage-class
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeAttributes:
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "2880"
+    volumeHandle: hermes-data-xfs

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -1,0 +1,43 @@
+# Hermes Agent config — seeded ONCE onto the /opt/data PVC by the init
+# container (cp -n: seed-if-absent, matching Hermes' "hand-placed once,
+# curates after" model). This is application config, NOT a k8s manifest,
+# so it carries no schema (resources/ dir rule). Secrets — OPENAI_API_KEY
+# (dummy; the driver has no --api-key), CLAUDE_CODE_OAUTH_TOKEN,
+# API_SERVER_KEY — arrive via env from the hermes ExternalSecret, never here.
+# Personal identity (SOUL.md / USER.md / MEMORY.md) is hand-placed on the
+# PVC separately and is never committed to this public repo.
+model:
+  # The vLLM reasoning/driver model on the Spark. provider "vllm" is an
+  # alias for "custom" (any OpenAI-compatible endpoint); base_url is what
+  # actually selects it.
+  default: qwen3.6-35b-a3b
+  provider: vllm
+  base_url: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+  # Local server — /v1/models auto-detect is unreliable, so pin the window
+  # to the driver's --max-model-len.
+  context_length: 131072
+  # REQUIRED, not optional: the driver runs --tool-call-parser qwen3_xml +
+  # --reasoning-parser qwen3, which leaks tool calls into plain text under
+  # streaming (Hermes #72901). Non-streaming is the documented escape hatch,
+  # and the entire local execution loop depends on real tool_calls.
+  streaming: false
+auxiliary:
+  # Context compression on the same local model — zero Anthropic quota.
+  compression:
+    provider: vllm
+    base_url: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+    model: qwen3.6-35b-a3b
+  # vision aux deferred to a later PR — the driver is text-only, and wiring
+  # the P40 VLM (qwen2.5vl) would add a cross-app CNP dependency this PR
+  # doesn't need. Image tasks are out of scope for the initial bring-up.
+agent:
+  # Hermes' native control is a fail-OPEN denylist (disabled_toolsets); the
+  # fail-CLOSED allowlist lands as a pre_tool_call hook in PR-4. Until then,
+  # disable the highest-risk toolset — arbitrary web (egress + exfil surface).
+  disabled_toolsets:
+    - web
+# Interactive front door only for now. The unattended/cron lanes (deny by
+# default) land with the hardened hooks + escalation bridge in PR-4.
+cron_mode: false
+unattended_mode: false
+single_query_mode: false

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/hermes/app"
+  interval: 30m
+  timeout: 5m
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: longhorn
+      namespace: longhorn-system

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./claude-runner/ks.yaml
   - ./comfyui/ks.yaml
   - ./comfyui-spark/ks.yaml
+  - ./hermes/ks.yaml
   - ./lightrag/ks.yaml
   - ./local-cron/ks.yaml
   - ./ollama/ks.yaml

--- a/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
@@ -46,6 +46,12 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus-blackbox-exporter
+        # Hermes runs its local execution loop against the driver — the
+        # cheapest routing tier (zero Anthropic quota). Same-namespace, but
+        # default-deny still requires the explicit hole.
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: hermes
       toPorts:
         - ports:
             - port: "8000"


### PR DESCRIPTION
## What

**PR-3 of the Hermes buildout** — the core app. Hermes (`nousresearch/hermes-agent`, s6-overlay) as a single-writer StatefulSet in `ai`, pointed at the Spark vLLM driver. Cheapest routing tier: ambient work + the local execution loop run here at **zero Anthropic quota**, replacing the current all-Opus baseline. The `claude -p` escalation bridge + redaction gate + fail-closed `pre_tool_call` allowlist + unattended/cron lanes are **PR-4**.

## Contents

- **HelmRelease** — app-template StatefulSet, image `v2026.8.31`, `gateway run`, API server `:8642` in-cluster only (no public route; `API_SERVER_KEY` mandatory — June-2026 unauthenticated-dashboard attack surface). Root-required s6 image (remaps uid 10000 + chowns `/opt/data`, drops via s6-setuidgid) → documented securityContext escape hatch.
- **Longhorn PVC** — 20Gi xfs, 2 replicas, auto `default` backup group, `/opt/data`. Block+xfs keeps SQLite on WAL.
- **config.yaml** — seeded once (`cp -n`) via init container. **`streaming: false`** because the driver's `qwen3_xml` + reasoning parser leaks tool calls to plain text under streaming (Hermes #72901). Identity (SOUL/USER/MEMORY) hand-placed on the PVC, never in git.
- **ExternalSecret** → its own 1P `hermes` item (not the shared `claude-runner` one).
- **CNP** — egress to driver:8000; driver ingress allows hermes; `web` toolset disabled until the PR-4 hook.

## Runtime note

OAuth token is a placeholder until `claude setup-token` runs and the driver endpoint is restored separately — so the escalation bridge + live model calls activate once those land. The app deploys/persists independently; I'll verify the pod post-merge and fix-forward if `gateway run` bring-up needs adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4rLwjfTe1eGMwrHs1capz