### PR TITLE
fix(ai): auto-consent hermes shell hooks so the gate fires

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -76,6 +76,14 @@ spec:
               HERMES_HOME: /opt/data
               HERMES_UID: "10000"
               HERMES_GID: "10000"
+              # Auto-consent the operator-owned shell hooks at startup. Without
+              # this, the pre_tool_call gate registers but is "not allowlisted"
+              # and SKIPPED (fail-open on consent) — the first-use prompt can't
+              # be answered in a headless pod. This env var (vs a writable
+              # allowlist file on the PVC) is agent-un-removable, and config.yaml
+              # is operator-owned (cp -f each start) so no rogue hook can be
+              # auto-trusted. See hermes hooks docs — HERMES_ACCEPT_HOOKS.
+              HERMES_ACCEPT_HOOKS: "1"
               # In-cluster OpenAI-compatible API server (health + reachability
               # for later consumers). Binds 0.0.0.0 but pod-network only — no
               # public HTTPRoute. API_SERVER_KEY (from the secret) is mandatory:


### PR DESCRIPTION
`hermes hooks list` on the running pod showed the `pre_tool_call` gate registered but **`✗ not allowlisted`** — Hermes requires first-use consent per `(event, command)`, and an unconsented hook is **skipped** (fail-open on consent), so the `terminal` tool would run **ungated**. The first-use prompt can't be answered in a headless pod.

Fix: `HERMES_ACCEPT_HOOKS=1` auto-consents the operator-owned config hooks at startup. Chosen over a writable allowlist file on the PVC because the env var is **agent-un-removable**, and `config.yaml` is `cp -f` each start so no rogue hook can be auto-trusted. Verified live — the gate flips to **`✓ allowed`** once consented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)