### PR TITLE
feat(observability): tool-call parser regression canary

### DIFF
--- a/kubernetes/apps/ai/vllm-driver-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/prometheusrule.yaml
@@ -73,7 +73,7 @@ spec:
               (4) silence SparkVllmDriverPodDown for the restart window only,
                   never this alert.
           expr: |-
-            probe_success{instance=~"https?://vllm-driver-spark.*"} == 0
+            probe_success{job=~"probe/observability/vllm-driver-spark-completion"} == 0
           for: 5m
           labels:
             severity: critical
@@ -100,5 +100,31 @@ spec:
             and
             sum(increase(vllm:request_success_total{job="vllm-driver-spark"}[10m])) == 0
           for: 10m
+          labels:
+            severity: warning
+        # Tool-call parser regression canary. The driver can serve chat fine
+        # (wedge probe green) while --tool-call-parser leaks tool calls into
+        # plain text — which silently breaks Hermes' agentic execution loop.
+        # The vllm-driver-spark-toolcall Probe (30-min cadence) POSTs a
+        # tools request and asserts a "tool_calls" field. for:31m spans just
+        # over one probe interval, so it needs two consecutive misses to fire
+        # (no flap on a single slow/transient scrape). Warning: this degrades
+        # tool-calling, not chat, and outages are covered by the alerts above.
+        - alert: SparkVllmDriverToolCallBroken
+          annotations:
+            summary: vllm-driver-spark tool-call parser regression (Hermes execution loop degraded)
+            description: |
+              The vllm-driver-spark-toolcall Probe has failed for >31m — the
+              driver is not returning well-formed tool_calls for a tools
+              request, even though chat may still work. Most likely cause: an
+              image/model bump changed the default --tool-call-parser away from
+              qwen3_xml, or --enable-auto-tool-choice was dropped. Impact: any
+              Hermes/agentic tool-calling through the driver breaks. Check
+              `kubectl -n ai get statefulset vllm-driver-spark -o yaml` for the
+              --tool-call-parser / --reasoning-parser / --enable-auto-tool-choice
+              args, and confirm with a live tools request against :8000.
+          expr: |-
+            probe_success{instance=~"https?://vllm-driver-spark.*/v1/chat/completions",job=~"probe/observability/vllm-driver-spark-toolcall"} == 0
+          for: 31m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -144,6 +144,34 @@ spec:
             valid_status_codes: [200]
           prober: http
           timeout: 40s
+        # Tool-call prober for vllm-driver-spark. The wedge probe above uses
+        # max_tokens:1 and so never exercises the --tool-call-parser qwen3_xml
+        # path — but a silent parser regression (leaking tool calls into plain
+        # text instead of returning tool_calls, e.g. after an image/model bump
+        # to a build that defaults to a wrong parser) is the failure mode most
+        # likely to break Hermes' agentic execution loop. This POSTs a request
+        # with a tools array and asserts the response carries a "tool_calls"
+        # field. tool_choice auto + a clear prompt reliably elicits the call.
+        #
+        # 30s timeout: this is a reasoning model, so it spends ~200 tokens
+        # thinking before emitting the call (~238 completion tokens total,
+        # ~8-12s warm). Runs at a low 30-min cadence (Probe CR) — the parser
+        # only breaks on a config/image change, not intermittently, so this is
+        # a regression canary, not a hot-path detector.
+        vllm_toolcall:
+          http:
+            body: |-
+              {"model":"qwen3.6-35b-a3b","messages":[{"role":"user","content":"Get the current weather for Paris using the available tool."}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"auto","max_tokens":1024}
+            fail_if_body_not_matches_regexp:
+              - "\"tool_calls\""
+            headers:
+              Content-Type: application/json
+            method: POST
+            preferred_ip_protocol: "ip4"
+            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+            valid_status_codes: [200]
+          prober: http
+          timeout: 30s
         tcp_connect:
           prober: tcp
           tcp:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -260,3 +260,27 @@ spec:
     staticConfig:
       static:
         - http://vllm-driver-spark.ai.svc.cluster.local:8000/v1/chat/completions
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: vllm-driver-spark-toolcall
+spec:
+  # Regression canary for the --tool-call-parser qwen3_xml path — the one
+  # thing the max_tokens:1 wedge probe can't exercise. A silent parser break
+  # (tool calls leaking to plain text) is the failure most likely to break
+  # Hermes' agentic execution loop, and it only happens on a config/image
+  # change, so 30-min cadence is ample. module vllm_toolcall asserts a
+  # "tool_calls" field in the response. scrapeTimeout 35s > the module's 30s
+  # so a slow reasoning pass surfaces as a slow success, not a scrape error.
+  interval: 30m
+  scrapeTimeout: 35s
+  module: vllm_toolcall
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://vllm-driver-spark.ai.svc.cluster.local:8000/v1/chat/completions


### PR DESCRIPTION
The `max_tokens:1` wedge probe can't exercise `--tool-call-parser qwen3_xml`, so a silent parser regression (tool calls leaking to plain text after an image/model bump) would break Hermes' agentic execution while chat still looks fine. Adds a `vllm_toolcall` blackbox module + a 30-min-cadence Probe + `SparkVllmDriverToolCallBroken` alert (warning, for:31m). Also scopes the existing `SparkVllmDriverWedged` alert to the completion probe's job label so the new probe (same instance URL) can't pollute the critical wedge alert. Tool-calls + job labels verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)