### PR TITLE
feat(observability): monitor hermes health (probe + alerts)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
@@ -39,8 +39,16 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
-  # No ingress holes: the OpenAI-compatible API server (:8642) is in-cluster
-  # only with no consumer yet (reach it via `kubectl port-forward` for
-  # testing). Kubelet health probes (host → pod) are allowed by Cilium's host
-  # policy and need no rule. Consumer ingress + the claude -p → Anthropic
-  # egress land with the escalation bridge in PR-4.
+  ingress:
+    # Blackbox-exporter health probe → /health on :8642 (unauthenticated).
+    # Without this the hermes-health probe is a silent default-deny drop and
+    # probe_success never populates — the #13264 label trap. The label is
+    # `prometheus-blackbox-exporter`, NOT `blackbox-exporter`.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus-blackbox-exporter
+      toPorts:
+        - ports:
+            - port: "8642"
+              protocol: TCP

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
+  - ./prometheusrule.yaml
 configMapGenerator:
   - name: hermes-config
     files:

--- a/kubernetes/apps/ai/hermes/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/hermes/app/prometheusrule.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hermes-rules
+spec:
+  groups:
+    - name: hermes.availability
+      rules:
+        # Pod-level failure — image-pull, OOM, crashloop, node loss, or a
+        # bad init container (config-seed / claude-cli-install).
+        - alert: HermesPodDown
+          annotations:
+            summary: hermes Pod not Ready (local-first agent front door unavailable)
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has been not-Ready
+              for >10 minutes. Inspect with `kubectl -n ai describe pod
+              {{ $labels.pod }}` and `kubectl -n ai logs {{ $labels.pod }}
+              --previous`. Init containers seed config + install the claude
+              CLI; a failure there blocks startup.
+          expr: |-
+            kube_pod_status_ready{namespace="ai",pod=~"hermes-.*",condition="true"} == 0
+          for: 10m
+          labels:
+            severity: warning
+        # Synthetic /health probe — catches an up-but-not-serving gateway that
+        # pod-Ready cannot (same rationale as the vllm/tei/ollama wedge probes).
+        # The hermes-health Probe (blackbox-exporter, 1-min cadence) GETs
+        # :8642/health. Warning, not critical: Hermes is Rob's tooling surface,
+        # not a household-facing service, and the local 35B + escalation both
+        # keep working directly even if the Hermes gateway is down.
+        - alert: HermesDown
+          annotations:
+            summary: hermes /health probe failing (agent gateway not serving)
+            description: |
+              The hermes-health Probe (GET :8642/health) has failed for >5m.
+              The gateway may be up (pod-Ready) but not serving — check
+              `kubectl -n ai logs statefulset/hermes --tail=100`. Recovery:
+              `kubectl -n ai rollout restart statefulset/hermes`.
+          expr: |-
+            probe_success{job=~"probe/observability/hermes-health"} == 0
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -266,6 +266,27 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
+  name: hermes-health
+spec:
+  # Liveness for the Hermes agent gateway (the local-first routing front
+  # door). /health is unauthenticated and returns 200 once the gateway is up
+  # — a plain http_2xx check is enough; the OpenAI API (:8642/v1/*) itself is
+  # key-gated. This is the only external health signal for Hermes beyond
+  # pod-Ready. Alert HermesDown lives in hermes/app/prometheusrule.yaml.
+  interval: 1m
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://hermes.ai.svc.cluster.local:8642/health
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
   name: vllm-driver-spark-toolcall
 spec:
   # Regression canary for the --tool-call-parser qwen3_xml path — the one


### PR DESCRIPTION
Hermes is now a production service with no external health signal beyond pod-Ready. Adds a `hermes-health` blackbox Probe (GET `:8642/health`, unauthenticated, 1-min), the CNP ingress hole for the blackbox-exporter (without it the probe is a silent default-deny drop — #13264 trap), and `HermesPodDown`/`HermesDown` alerts (warning — Hermes is tooling, and the 35B + escalation keep working if it's down). `/health` unauth + API key-gating verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)