### PR TITLE
chore(immich): revert transcode policy to disabled (frame-album video done)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -30,7 +30,7 @@ spec:
             "ffmpeg": {
               "targetResolution": "1080",
               "maxBitrate": "8000k",
-              "transcode": "bitrate",
+              "transcode": "disabled",
               "realtime": {
                 "enabled": true,
                 "videoCodecs": ["h264", "hevc"],


### PR DESCRIPTION
Automated flip-scope-revert step — see tools/immich-frame-video-transcode.sh.