### PR TITLE
feat(paperless): enable native AI (P40 bge-m3 embeddings + Spark 35B generation)

### DIFF
--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -59,6 +59,12 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: frigate
+        # collab/paperless — native paperless-ngx AI embeddings (bge-m3) via
+        # PAPERLESS_AI_LLM_EMBEDDING_BACKEND=ollama. Generation goes to the
+        # Spark (see ai/vllm-driver-spark cnp-allow.yaml), not here.
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: paperless
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
@@ -52,6 +52,12 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
             app.kubernetes.io/name: hermes
+        # collab/paperless — native paperless-ngx AI generation
+        # (qwen3.6-35b-a3b) via PAPERLESS_AI_LLM_BACKEND=openai-like.
+        # Embeddings go to the P40 (see ai/ollama cnp-allow.yaml), not here.
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: paperless
       toPorts:
         - ports:
             - port: "8000"

--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -99,3 +99,26 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+    # Native paperless-ngx AI (PAPERLESS_AI_*). Hybrid GPU routing:
+    #   embeddings -> ai/ollama            (bge-m3)          on 11434
+    #   generation -> ai/vllm-driver-spark (qwen3.6-35b-a3b) on 8000
+    # Both are in-cluster local models — no remote-API egress. Without these
+    # holes the connection is a silent default-deny drop that reads as a wrong
+    # model/endpoint (cf. the blackbox-exporter label trap, #13264). Ingress
+    # counterparts live in ai/ollama and ai/vllm-driver-spark cnp-allow.yaml.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: vllm-driver-spark
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -87,6 +87,32 @@ spec:
               # Configure redis integration (celery broker). Own db index
               # (db7) so it no longer shares db0 with other tenants.
               PAPERLESS_REDIS: redis://dragonfly.databases.svc.cluster.local:6379/7
+              # Native paperless-ngx AI (v3.1.x). Hybrid GPU routing keeps the
+              # steady embedding load on the cheap, already-warm P40 path and
+              # sends only occasional generation to the Spark 35B:
+              #   embeddings -> P40 ollama bge-m3        (native ollama API)
+              #   generation -> Spark vLLM qwen3.6-35b-a3b (OpenAI /v1)
+              # Both endpoints are in-cluster ONLY — paperless documents are
+              # internal-tier and must never reach a remote API (key below is a
+              # placeholder, not a secret). CNP holes: this app's egress in
+              # cnp-allow.yaml + ingress in ai/ollama and ai/vllm-driver-spark.
+              PAPERLESS_AI_ENABLED: "true"
+              # Generation -> Spark vLLM (OpenAI-compatible; api_base needs /v1).
+              # Model is the driver's --served-model-name, stable across image
+              # bumps.
+              PAPERLESS_AI_LLM_BACKEND: openai-like
+              PAPERLESS_AI_LLM_MODEL: qwen3.6-35b-a3b
+              PAPERLESS_AI_LLM_ENDPOINT: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+              # vLLM enforces no key; a non-empty placeholder stops the
+              # OpenAI-compatible client refusing to send with an empty key.
+              # NOT a secret — never leaves the cluster.
+              PAPERLESS_AI_LLM_API_KEY: not-needed
+              # Embeddings -> P40 ollama bge-m3 (native ollama API, bare root,
+              # NO /v1). Reuses the embedder already resident + validated for
+              # this corpus.
+              PAPERLESS_AI_LLM_EMBEDDING_BACKEND: ollama
+              PAPERLESS_AI_LLM_EMBEDDING_MODEL: bge-m3
+              PAPERLESS_AI_LLM_EMBEDDING_ENDPOINT: http://ollama.ai.svc.cluster.local:11434
 
             envFrom: *envFrom
 


### PR DESCRIPTION
Enables paperless-ngx v3.1.x **native AI** (the `PAPERLESS_AI_*` config, previously all blank/disabled) declaratively via HelmRelease env, plus the CiliumNetworkPolicy holes it needs. No hand-entry in the admin UI — the UI Application-Configuration fields stay null, so env values apply.

## Hybrid GPU routing (reuse-first, no new load)

| Function | Backend | Model | Endpoint |
|---|---|---|---|
| Embeddings (frequent) | `ollama` | `bge-m3` | `http://ollama.ai.svc.cluster.local:11434` (P40) |
| Generation (infrequent) | `openai-like` | `qwen3.6-35b-a3b` | `http://vllm-driver-spark.ai.svc.cluster.local:8000/v1` (Spark) |

Embeddings run on every ingest + the nightly reindex, so they stay on the cheap, already-warm P40 `bge-m3` path (the embedder already validated for this corpus). Generation is infrequent and quality-sensitive, so it goes to the Spark 35B. **Both are new *callers* of already-resident models** — no new model load, no eviction, no change to either GPU's VRAM budget.

## CNP holes (default-deny cluster)

- paperless **egress** → `ai/ollama:11434` and `ai/vllm-driver-spark:8000`
- symmetric **ingress** on `ai/ollama` and `ai/vllm-driver-spark` ← `collab/paperless`

Without both sides the connection is a silent default-deny drop (reads as a wrong model/endpoint). Additive rules only — no inference workload restarts.

## Notes

- Documents are internal-tier: both endpoints are in-cluster only; the LLM API key is a non-secret placeholder (`not-needed`) so the OpenAI-compatible client won't refuse an empty key.
- Chunk size / context size / request timeout left at paperless defaults (1024 / 8192 / 120s).
- Applying rolls the paperless StatefulSet pod once (single replica, brief blip; not household-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)