### PR TITLE
feat(hermes): enable Kanban dashboard + Authelia-gated board route

### DIFF
--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -30,3 +30,15 @@ spec:
       remoteRef:
         key: hermes
         property: api_server_key
+    # Basic-auth for the bundled dashboard's own gate (:9119). A non-loopback
+    # dashboard bind requires a provider or the s6 service SystemExits; the
+    # board HTTPRoute is additionally Authelia-gated. Injected as env via
+    # envFrom → the dashboard reads HERMES_DASHBOARD_BASIC_AUTH_{USERNAME,PASSWORD}.
+    - secretKey: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+      remoteRef:
+        key: hermes
+        property: dashboard_basic_auth_username
+    - secretKey: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+      remoteRef:
+        key: hermes
+        property: dashboard_basic_auth_password

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -93,6 +93,16 @@ spec:
               # The driver has no --api-key, so any non-empty value satisfies
               # the OpenAI client. Real secrets come via envFrom below.
               OPENAI_API_KEY: sk-noauth-local-vllm
+              # Kanban dashboard — the bundled s6 service (UI + /api/plugins/
+              # kanban/* + /events WS) on :9119. It is already supervised by
+              # /init; this flag brings it up. A non-loopback bind REQUIRES an
+              # auth provider (a June-2026 hardening SystemExits otherwise), so
+              # HERMES_DASHBOARD_BASIC_AUTH_{USERNAME,PASSWORD} arrive via envFrom
+              # from hermes-secret; the board HTTPRoute is additionally fronted by
+              # Authelia (defense in depth, admin-tier group:lldap_admin).
+              HERMES_DASHBOARD: "true"
+              HERMES_DASHBOARD_HOST: 0.0.0.0
+              HERMES_DASHBOARD_PORT: "9119"
             envFrom:
               - secretRef:
                   name: hermes-secret
@@ -151,6 +161,9 @@ spec:
         ports:
           http:
             port: 8642
+          # Bundled Kanban dashboard s6 service (board.${SECRET_DOMAIN} route).
+          dashboard:
+            port: 9119
     persistence:
       # The single source of truth for all Hermes state (SQLite, config, .env,
       # profiles, skills, memories, sessions) — mounted into both the seed init

--- a/kubernetes/apps/ai/hermes/app/httproute.yaml
+++ b/kubernetes/apps/ai/hermes/app/httproute.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+#
+# Kanban dashboard UI (the bundled s6 service on :9119). Fronted by Authelia
+# via securitypolicy.yaml (admin-tier, group:lldap_admin) — the same extAuth
+# pattern as ai/khoj. The dashboard ALSO enforces its own basic-auth, so this
+# is defense in depth.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes-board
+  annotations:
+    glance/name: "Hermes Board"
+    glance/show: "true"
+    glance/id: "AI"
+spec:
+  hostnames:
+    - board.${SECRET_DOMAIN}
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: hermes
+          port: 9119

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -8,8 +8,10 @@ resources:
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./longhorn-pvc.yaml
   - ./prometheusrule.yaml
+  - ./securitypolicy.yaml
 configMapGenerator:
   - name: hermes-config
     files:

--- a/kubernetes/apps/ai/hermes/app/securitypolicy.yaml
+++ b/kubernetes/apps/ai/hermes/app/securitypolicy.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# extAuth via Authelia — same pattern as ai/khoj (#12767). failOpen:false so
+# Authelia down means deny, not an open board. board.${SECRET_DOMAIN} is
+# admin-tier (group:lldap_admin) in the authelia access_control block. The
+# dashboard additionally enforces its own basic-auth (defense in depth).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: hermes-board-extauth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hermes-board
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - name: authelia
+          namespace: auth
+          port: 9091
+      path: /api/authz/ext-authz/
+      headersToBackend:
+        - Remote-User
+        - Remote-Groups
+        - Remote-Name
+        - Remote-Email

--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -86,6 +86,7 @@ data:
             - 'konflate.${SECRET_DOMAIN}'
             - 'monica.${SECRET_DOMAIN}'
             - 'renovate.${SECRET_DOMAIN}'
+            - 'board.${SECRET_DOMAIN}'
           policy: 'one_factor'
           subject: 'group:lldap_admin'
         # Household-tier (was authorization_policy: one_factor)


### PR DESCRIPTION
First PR in the Hermes board/fleet sequence (plan: floating-riding-manatee). Standalone and reverts clean.

## What
- Activate the bundled dashboard s6 service on **:9119** via `HERMES_DASHBOARD=true` (the image already supervises it under `/init`; this only turns it on — no new container, no entrypoint change).
- Expose it as a service port and route `board.${SECRET_DOMAIN}` → :9119 with an Authelia extAuth `SecurityPolicy` (admin-tier `group:lldap_admin`), mirroring `ai/khoj`.
- Dashboard basic-auth (mandatory for a non-loopback bind) sourced from the `hermes` 1P item via `envFrom`; Authelia fronts the route as defense in depth.
- Glance tile via annotations.

## Runtime prereq (batched, one-time)
Needs two new fields on the `hermes` 1P item: `dashboard_basic_auth_username`, `dashboard_basic_auth_password`. Until they exist, ExternalSecret keeps its last-good values (gateway unaffected) and only the dashboard service waits; `reloader` restarts the pod automatically once the fields land.

## Validation
`kubectl kustomize` builds clean (hermes + authelia); yamllint + readme-drift + all pre-commit hooks pass.