### PR TITLE
feat(hermes): seed board profiles (orchestrator + worker fleet)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -58,7 +58,27 @@ spec:
               # HERMES_ACCEPT_HOOKS does not consent `gateway run` (verified via
               # `hermes hooks doctor`). Seeding it each start also restores it if
               # the agent deletes it, since consent is checked at registration.
-              - cp -f /seed/config.yaml /opt/data/config.yaml && cp -f /seed/shell-hooks-allowlist.json /opt/data/shell-hooks-allowlist.json
+              #
+              # Profiles (the board's "different agents"): each profile's
+              # config.yaml is operator-owned (cp -f = authoritative — pins the
+              # LOCAL provider + the orchestrator's kanban toolset, so an agent
+              # cannot disable its own gate or switch to a remote model). SOUL.md
+              # is a one-time identity seed (cp -n) the agent then evolves — never
+              # clobbered on restart.
+              - |
+                set -e
+                cp -f /seed/config.yaml /opt/data/config.yaml
+                cp -f /seed/shell-hooks-allowlist.json /opt/data/shell-hooks-allowlist.json
+                for p in orchestrator generalist ml network observability smart-home storage; do
+                  mkdir -p "/opt/data/profiles/$${p}"
+                done
+                cp -f /seed-profiles/orchestrator-config.yaml /opt/data/profiles/orchestrator/config.yaml
+                for p in generalist ml network observability smart-home storage; do
+                  cp -f /seed-profiles/worker-config.yaml "/opt/data/profiles/$${p}/config.yaml"
+                done
+                for p in orchestrator generalist ml network observability smart-home storage; do
+                  cp -n "/seed-profiles/$${p}.SOUL.md" "/opt/data/profiles/$${p}/SOUL.md" || true
+                done
           # One-time install of the `claude` CLI onto the PVC for the escalation
           # skill. Lands in /opt/data/.local/bin (already on $PATH) so no PATH
           # override is needed. Idempotent: skips if already present, so only
@@ -187,6 +207,17 @@ spec:
           hermes:
             config-seed:
               - path: /seed
+                readOnly: true
+      # Per-profile seed files (operator-owned config.yaml + one-time SOUL.md),
+      # mounted read-only into the seed init container only. It places them under
+      # /opt/data/profiles/<name>/ (config cp -f, identity cp -n).
+      profiles-seed:
+        type: configMap
+        name: hermes-profiles
+        advancedMounts:
+          hermes:
+            config-seed:
+              - path: /seed-profiles
                 readOnly: true
       # The fail-closed pre_tool_call gate, mounted READ-ONLY at /opt/hooks —
       # physically outside the writable /opt/data PVC, so the agent cannot

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -20,5 +20,18 @@ configMapGenerator:
   - name: hermes-hooks
     files:
       - gate.py=./resources/gate.py
+  # Board profiles — flat keys (ConfigMap keys can't contain "/"); the seed
+  # init container fans them into /opt/data/profiles/<name>/{config.yaml,SOUL.md}.
+  - name: hermes-profiles
+    files:
+      - orchestrator-config.yaml=./resources/profiles/orchestrator-config.yaml
+      - worker-config.yaml=./resources/profiles/worker-config.yaml
+      - orchestrator.SOUL.md=./resources/profiles/orchestrator.SOUL.md
+      - generalist.SOUL.md=./resources/profiles/generalist.SOUL.md
+      - ml.SOUL.md=./resources/profiles/ml.SOUL.md
+      - network.SOUL.md=./resources/profiles/network.SOUL.md
+      - observability.SOUL.md=./resources/profiles/observability.SOUL.md
+      - smart-home.SOUL.md=./resources/profiles/smart-home.SOUL.md
+      - storage.SOUL.md=./resources/profiles/storage.SOUL.md
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/generalist.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/generalist.SOUL.md
@@ -1,0 +1,6 @@
+# Generalist
+
+You are the **Generalist worker** — the default assignee for cards that don't fit a domain specialist.
+You execute locally on the 35B and escalate a genuinely hard reasoning step via the gated `claude -p`
+path. Work only within your task's `agent/` workspace. `kanban_block` anything destructive, ambiguous, or
+needing Rob.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/ml.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/ml.SOUL.md
@@ -1,0 +1,6 @@
+# ML Operator
+
+You are the **ML worker** for Rob's cluster: Ollama lifecycle, vLLM, GPU placement, Open WebUI, Immich
+CLIP, Frigate model tuning. You execute locally on the 35B and escalate a hard reasoning step via the
+gated `claude -p` path. **Prime directive: never crash the inference path** — when in doubt, `kanban_block`
+for Rob. Work only within your task's `agent/` workspace.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/network.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/network.SOUL.md
@@ -1,0 +1,6 @@
+# Network Operator
+
+You are the **Network worker** for Rob's home network (Lovenet): VLANs, ACLs, Omada, Cilium BGP, DNS,
+firewall, VPN egress. You execute locally on the 35B and escalate a hard reasoning step via the gated
+`claude -p` path. **Prime directive: never break the network** — brain/beast core infra is touched by
+humans, not you; `kanban_block` anything touching it. Work only within your task's `agent/` workspace.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/observability.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/observability.SOUL.md
@@ -1,0 +1,7 @@
+# Observability Operator
+
+You are the **Observability worker** for Rob's cluster: Prometheus rules, AlertManager routing, Grafana
+dashboards, Loki, ServiceMonitors/Probes, silences. You execute locally on the 35B and escalate a hard
+reasoning step via the gated `claude -p` path. **Prime directive: never bury a real alert under flap** —
+prefer a tight rule over a noisy one; `kanban_block` if a change could either flood or silence the
+notification surface. Work only within your task's `agent/` workspace.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/orchestrator-config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/orchestrator-config.yaml
@@ -1,0 +1,32 @@
+# Orchestrator profile config (operator-owned; seeded cp -f = authoritative).
+# Same LOCAL-provider + fail-closed-gate floor as the workers, PLUS the kanban
+# toolset override below. Self-contained (loaded with HERMES_HOME=<profile dir>).
+model:
+  default: qwen3.6-35b-a3b
+  provider: vllm
+  base_url: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+  context_length: 131072
+  streaming: false
+auxiliary:
+  free_only: true
+  compression:
+    provider: vllm
+    base_url: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+    model: qwen3.6-35b-a3b
+agent:
+  disabled_toolsets:
+    - web
+# CRITICAL (adversarial review, delegation break #1): a peer-received turn
+# (`peer run in-cluster/orchestrator "…"`) runs on the `api_server` platform,
+# whose default toolset (`hermes-api-server`) STRIPS every kanban_* tool. Without
+# this override the orchestrator produces text and creates NO card — the whole
+# beast→board path silently no-ops. `hermes-cli` is the full toolset incl kanban.
+platform_toolsets:
+  api_server:
+    - hermes-cli
+hooks:
+  pre_tool_call:
+    - matcher: "terminal"
+      command: "python3 /opt/hooks/gate.py"
+      timeout: 10
+      fail_closed: true

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/orchestrator.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/orchestrator.SOUL.md
@@ -1,0 +1,15 @@
+# Orchestrator
+
+You are the **Orchestrator** for Rob's home-ops Hermes board. You receive a goal, decompose it into a
+dependency graph of concrete cards, assign each to the right worker, then step back and let the dispatcher
+run them. You do not do the work yourself.
+
+Assign by domain: inference/GPU/model tasks → `ml`; network/DNS/VLAN/Cilium/firewall → `network`;
+alerts/metrics/dashboards/logs → `observability`; Home Assistant/ESPHome/Z-Wave/Zigbee/Matter →
+`smart-home`; Longhorn/Ceph/PVC/backups/durability → `storage`; anything else → `generalist`.
+
+Reasoning stays local. When a step genuinely needs frontier reasoning, the assigned worker escalates via
+the gated `claude -p` path — you never call a remote model directly.
+
+`kanban_block` any card that is destructive, ambiguous, or needs Rob; he clears it from the dashboard.
+Propose-then-execute is the rule.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/smart-home.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/smart-home.SOUL.md
@@ -1,0 +1,7 @@
+# Smart-Home Operator
+
+You are the **Smart-Home worker** for Rob's Home Assistant stack: HA core, Z-Wave/Zigbee/Matter, ESPHome,
+Wyoming voice, Frigate↔HA, Music Assistant, the checked-in HA YAML. You execute locally on the 35B and
+escalate a hard reasoning step via the gated `claude -p` path. **Prime directive: never break Home
+Assistant** (Renee-facing) — back up before destructive edits; `kanban_block` anything risky for Rob.
+Work only within your task's `agent/` workspace.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/storage.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/storage.SOUL.md
@@ -1,0 +1,6 @@
+# Storage Operator
+
+You are the **Storage worker** for Rob's cluster: Ceph (rook), Longhorn + backup targets, Garage S3, CNPG
+clusters + Barman, direct-NFS workloads. You execute locally on the 35B and escalate a hard reasoning step
+via the gated `claude -p` path. **Prime directive: never lose data** — PVC/volume/backup changes are
+destructive; `kanban_block` and let Rob approve. Work only within your task's `agent/` workspace.

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/worker-config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/worker-config.yaml
@@ -1,0 +1,28 @@
+# Worker profile config (operator-owned; seeded cp -f = authoritative, so a
+# worker can never be pinned to a remote provider or lose its gate). Loaded
+# with HERMES_HOME=<profile dir>, so this is SELF-CONTAINED on purpose: every
+# safety block (LOCAL provider, web disabled, fail-closed gate) is repeated here
+# rather than assumed-inherited from the base config. Shared by all worker
+# profiles (generalist + the domain specialists). Workers spawn on the `cli`
+# platform (full toolset incl kanban_*), so no platform_toolsets override.
+model:
+  default: qwen3.6-35b-a3b
+  provider: vllm
+  base_url: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+  context_length: 131072
+  streaming: false
+auxiliary:
+  free_only: true
+  compression:
+    provider: vllm
+    base_url: http://vllm-driver-spark.ai.svc.cluster.local:8000/v1
+    model: qwen3.6-35b-a3b
+agent:
+  disabled_toolsets:
+    - web
+hooks:
+  pre_tool_call:
+    - matcher: "terminal"
+      command: "python3 /opt/hooks/gate.py"
+      timeout: 10
+      fail_closed: true


### PR DESCRIPTION
PR-2 of the Hermes board sequence (after #14063). Lands profiles BEFORE the orchestration config (PR-3) that references them.

## What
- Seeds `orchestrator` + 6 workers (`generalist`, `ml`, `network`, `observability`, `smart-home`, `storage`) under `/opt/data/profiles/<name>/` via the config-seed init container.
- **config.yaml** — operator-owned (`cp -f`), self-contained: LOCAL vLLM provider pin + fail-closed gate. No profile can be switched to a remote model or lose its gate (adversarial security fix).
- **orchestrator** adds `platform_toolsets.api_server: [hermes-cli]` — without it a `peer run in-cluster/orchestrator` turn runs on the `api_server` platform toolset that **strips every `kanban_*` tool**, so card creation silently no-ops (adversarial delegation fix).
- **SOUL.md** — one-time identity seed (`cp -n`); the agent evolves it, never clobbered on restart.

## Notes
- Loop vars escaped `$${p}` per repo envsubst convention (Flux substitutes at apply-time).
- Profiles land before PR-3's `orchestrator_profile`/`default_assignee` config to avoid dispatching against non-existent profiles.

## Validation
`kubectl kustomize` builds clean (11 objects); yamllint clean; profiles render into the `hermes-profiles` ConfigMap.