### PR TITLE
feat(hermes): add bearer-auth api_server route for beast peering

### DIFF
--- a/kubernetes/apps/ai/hermes/app/httproute.yaml
+++ b/kubernetes/apps/ai/hermes/app/httproute.yaml
@@ -24,3 +24,27 @@ spec:
     - backendRefs:
         - name: hermes
           port: 9119
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+#
+# Hermes OpenAI-compatible API server / peer endpoint (:8642). This route is
+# how the off-cluster beast gateway peers in (`hermes peer add in-cluster
+# https://hermes-api.${SECRET_DOMAIN}`). Deliberately NOT Authelia-gated — a bot
+# can't do interactive auth; the api_server enforces its own bearer API_SERVER_KEY
+# (mandatory, from the hermes ExternalSecret). Internal gateway = LAN-only via
+# split-horizon DNS; no public exposure.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hermes-api
+spec:
+  hostnames:
+    - hermes-api.${SECRET_DOMAIN}
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: hermes
+          port: 8642


### PR DESCRIPTION
PR-5 of the Hermes board sequence. Small, standalone. Lets the off-cluster beast gateway peer into the in-cluster orchestrator.

## What
- Adds the `hermes-api.${SECRET_DOMAIN}` HTTPRoute → the in-cluster api_server (:8642).
- **Not** Authelia-gated (a bot can't do interactive auth) — the api_server enforces its own mandatory bearer `API_SERVER_KEY`. Internal gateway, LAN-only via split-horizon DNS.
- Enables: `hermes peer add in-cluster https://hermes-api.${SECRET_DOMAIN} --key <API_SERVER_KEY>` from beast, then `peer run in-cluster/orchestrator "..."`.

## Validation
`kubectl kustomize` builds clean (12 objects); yamllint clean.