### PR TITLE
fix(hermes): allow Envoy gateway ingress to board + api ports

### DIFF
--- a/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
@@ -52,3 +52,19 @@ spec:
         - ports:
             - port: "8642"
               protocol: TCP
+    # Internal gateway (envoy) → the board dashboard (:9119, Authelia-fronted)
+    # and the api_server / peer endpoint (:8642, bearer-key). Without this the
+    # board + hermes-api HTTPRoutes resolve but Cilium default-denies the
+    # gateway→backend hop, so Envoy returns "503 upstream connection timeout".
+    # Same pattern as ai/khoj. Auth is enforced at the gateway (Authelia) and by
+    # the api_server's own bearer key — the CNP only opens the network path.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9119"
+              protocol: TCP
+            - port: "8642"
+              protocol: TCP


### PR DESCRIPTION
Fix for a gap in #14063 / #14066 caught by live testing: both HTTPRoutes resolve but Envoy returns **503 upstream connection timeout** because the hermes CNP ingress only allowed the blackbox-exporter — Cilium default-denied the gateway→backend hop.

Adds `network/envoy` ingress for :9119 (dashboard) and :8642 (api/peer), mirroring `ai/khoj`. Auth is unchanged (Authelia at the gateway + api_server bearer key); this only opens the network path.

Verified: direct in-cluster to :8642 already returns 401 (api_server healthy); the 503 was purely the gateway→pod Cilium drop.