### PR TITLE
fix(hermes): expose kanban tools to the api_server peer agent

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -46,6 +46,20 @@ agent:
   # surface) — escalation to Claude goes through the gated `terminal` path.
   disabled_toolsets:
     - web
+# Expose the Kanban board tools to the api_server (peer) agent so beast can
+# create and route cards over the peer path. BOTH keys are required — verified
+# end-to-end live (beast peer → card created on the in-cluster board):
+#   • platform_toolsets registers the `kanban` toolset on the api_server platform
+#     (its default `hermes-api-server` set excludes every kanban_* tool);
+#   • the top-level `toolsets` list satisfies the kanban tools' own check_fn
+#     (_profile_has_kanban_toolset → "kanban" in config.toolsets), which gates
+#     kanban_* for non-worker agents. platform_toolsets ALONE is not enough.
+platform_toolsets:
+  api_server:
+    - hermes-cli
+    - kanban
+toolsets:
+  - kanban
 # The security floor: a fail-closed pre_tool_call gate scoped to the `terminal`
 # tool (the coding-agent shell-out to `claude -p` and any shell command).
 # gate.py is mounted READ-ONLY at /opt/hooks (outside the writable PVC), so the


### PR DESCRIPTION
The load-bearing fix that makes beast→board delegation actually work — found by **live end-to-end testing** (not predictable from the manifests).

Symptom: `hermes peer dm in-cluster "...create a card..."` produced text but **no card** — the peer-reachable api_server agent had no `kanban_*` tools.

Root cause: two separate gates, both must be satisfied:
1. `platform_toolsets.api_server: [hermes-cli, kanban]` — the api_server platform's default toolset (`hermes-api-server`) *excludes* kanban_*, so they must be registered explicitly.
2. top-level `toolsets: [kanban]` — the kanban tools' own `check_fn` (`_profile_has_kanban_toolset` → `"kanban" in config.toolsets`) gates them for non-worker agents.

The adversarial review predicted only #1; #2 was invisible without running it.

**Verified:** from beast, `peer dm in-cluster` → `kanban_create` → card `t_2358910c` (`ready`, assignee `generalist`) landed on the in-cluster board (confirmed in kanban.db).

## Validation
`kubectl kustomize` builds clean; yamllint clean.