### PR TITLE
feat(hermes): LightRAG knowledge-graph — query/ingest skill + auto-RAG

### DIFF
--- a/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
@@ -26,6 +26,16 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
+    # LightRAG knowledge-graph API (:9621) — the query/ingest skill and the
+    # pre_llm_call auto-RAG hook. Same-namespace endpoint; auth is the X-API-Key.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: lightrag
+      toPorts:
+        - ports:
+            - port: "9621"
+              protocol: TCP
     # External HTTPS for (a) the claude-code escalation skill → api.anthropic.com
     # (draws Rob's Max subscription) and (b) the one-time npm install of the
     # `claude` CLI onto the PVC. toEntities:[world]:443 is the cluster's reliable

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -22,6 +22,13 @@ spec:
       remoteRef:
         key: hermes
         property: claude_code_oauth_token
+    # LightRAG knowledge-graph API key (sent as X-API-Key by the query/ingest
+    # skill and the pre_llm_call auto-RAG hook). From the shared `lightrag` 1P
+    # item, same key the lightrag app itself uses.
+    - secretKey: LIGHTRAG_API_KEY
+      remoteRef:
+        key: lightrag
+        property: api_key
     # Auth key for Hermes' in-cluster OpenAI-compatible API server (:8642).
     # Mandatory whenever the API server binds beyond loopback — an
     # unauthenticated Hermes API server was an entry point for the June-2026

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -79,6 +79,12 @@ spec:
                 for p in orchestrator generalist ml network observability smart-home storage; do
                   cp -n "/seed-profiles/$${p}.SOUL.md" "/opt/data/profiles/$${p}/SOUL.md" || true
                 done
+                # LightRAG skill (operator-owned, cp -f authoritative).
+                mkdir -p /opt/data/skills/lightrag/scripts
+                cp -f /seed-skills/SKILL.md /opt/data/skills/lightrag/SKILL.md
+                cp -f /seed-skills/query.py /opt/data/skills/lightrag/scripts/query.py
+                cp -f /seed-skills/ingest.py /opt/data/skills/lightrag/scripts/ingest.py
+                chmod +x /opt/data/skills/lightrag/scripts/query.py /opt/data/skills/lightrag/scripts/ingest.py
           # One-time install of the `claude` CLI onto the PVC for the escalation
           # skill. Lands in /opt/data/.local/bin (already on $PATH) so no PATH
           # override is needed. Idempotent: skips if already present, so only
@@ -123,6 +129,9 @@ spec:
               HERMES_DASHBOARD: "true"
               HERMES_DASHBOARD_HOST: 0.0.0.0
               HERMES_DASHBOARD_PORT: "9119"
+              # LightRAG knowledge-graph endpoint for the query/ingest skill and
+              # the pre_llm_call auto-RAG hook. LIGHTRAG_API_KEY comes via envFrom.
+              LIGHTRAG_URL: http://lightrag.ai.svc.cluster.local:9621
             envFrom:
               - secretRef:
                   name: hermes-secret
@@ -218,6 +227,16 @@ spec:
           hermes:
             config-seed:
               - path: /seed-profiles
+                readOnly: true
+      # LightRAG skill seed files (SKILL.md + query.py + ingest.py), placed onto
+      # /opt/data/skills/lightrag/ by the seed init container.
+      skills-seed:
+        type: configMap
+        name: hermes-skills-lightrag
+        advancedMounts:
+          hermes:
+            config-seed:
+              - path: /seed-skills
                 readOnly: true
       # The fail-closed pre_tool_call gate, mounted READ-ONLY at /opt/hooks —
       # physically outside the writable /opt/data PVC, so the agent cannot

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -20,6 +20,14 @@ configMapGenerator:
   - name: hermes-hooks
     files:
       - gate.py=./resources/gate.py
+      - lightrag-rag.py=./resources/lightrag-rag.py
+  # LightRAG skill — flat keys; the seed init fans them into
+  # /opt/data/skills/lightrag/{SKILL.md,scripts/{query.py,ingest.py}}.
+  - name: hermes-skills-lightrag
+    files:
+      - SKILL.md=./resources/skills/lightrag/SKILL.md
+      - query.py=./resources/skills/lightrag/scripts/query.py
+      - ingest.py=./resources/skills/lightrag/scripts/ingest.py
   # Board profiles — flat keys (ConfigMap keys can't contain "/"); the seed
   # init container fans them into /opt/data/profiles/<name>/{config.yaml,SOUL.md}.
   - name: hermes-profiles

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -73,6 +73,14 @@ hooks:
       command: "python3 /opt/hooks/gate.py"
       timeout: 10
       fail_closed: true
+  # Auto-RAG: inject relevant LightRAG knowledge-graph context into LOCAL turns.
+  # Fail-safe (any error/slow → no-op, never breaks a turn) and bounded (~3k
+  # tokens). Runs only on Hermes turns, NOT on `claude -p` (a separate CLI), so
+  # the KG content stays local; gate.py additionally refuses the LIGHTRAG-KG
+  # sentinel in any claude -p command (L2 #1: local yes, Claude no).
+  pre_llm_call:
+    - command: "python3 /opt/hooks/lightrag-rag.py"
+      timeout: 12
 # Interactive front door. Unattended/cron lanes (deny by default) come later.
 cron_mode: false
 unattended_mode: false

--- a/kubernetes/apps/ai/hermes/app/resources/gate.py
+++ b/kubernetes/apps/ai/hermes/app/resources/gate.py
@@ -63,6 +63,12 @@ if is_escalation:
         r"\bExternalSecret\b",
         r"op://",  # 1Password refs
         r"(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}",  # MAC address
+        # LightRAG knowledge-graph content is LOCAL-only (Rob's personal
+        # finance/property/tax docs). The pre_llm_call auto-RAG hook wraps every
+        # injected block in this sentinel; refusing it here keeps that content
+        # from being copy-forwarded into a claude -p prompt (L2 #1: local yes,
+        # Claude no). Verbatim-forward is blocked; paraphrase can't be caught.
+        r"LIGHTRAG-KG",
     ]
     for pat in RESTRICTED:
         if re.search(pat, blob):

--- a/kubernetes/apps/ai/hermes/app/resources/lightrag-rag.py
+++ b/kubernetes/apps/ai/hermes/app/resources/lightrag-rag.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Hermes pre_llm_call hook — auto-RAG. Injects relevant LightRAG knowledge-graph
+# context into Hermes' LOCAL-model turns. Wired in config.yaml as a
+# `hooks.pre_llm_call` entry and consented in shell-hooks-allowlist.json.
+#
+# Contract (Hermes hooks): payload JSON on stdin (includes `user_message`). Emit
+# {"context": "..."} on stdout to inject that text into the user message; emit
+# nothing to inject nothing. This hook is FAIL-SAFE: any error/timeout prints
+# nothing and exits 0, so a slow or down LightRAG never blocks or breaks a turn.
+#
+# Data boundary (HOMELAB-SPEC L2 #1): this runs ONLY on Hermes' local-model
+# turns — `claude -p` is a separate CLI invocation, not a Hermes turn, so injected
+# KG context never reaches Claude. The injected block is wrapped in the
+# LIGHTRAG-KG sentinel that gate.py refuses to let into a `claude -p` command.
+import json
+import os
+import sys
+import urllib.request
+
+SENTINEL = "LIGHTRAG-KG"  # gate.py blocks this marker from claude -p escalations
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return
+    msg = payload.get("user_message") or ""
+    if isinstance(msg, dict):
+        msg = msg.get("content") or msg.get("text") or ""
+    msg = str(msg).strip()
+    if len(msg) < 12:  # skip trivial turns
+        return
+    key = os.environ.get("LIGHTRAG_API_KEY", "")
+    if not key:
+        return
+    url = os.environ.get("LIGHTRAG_URL", "http://lightrag.ai.svc.cluster.local:9621").rstrip("/")
+    body = json.dumps({
+        "query": msg, "mode": "local", "top_k": 6,
+        "max_total_tokens": 3000, "only_need_context": True,
+    }).encode()
+    req = urllib.request.Request(
+        url + "/query", data=body, method="POST",
+        headers={"Content-Type": "application/json", "X-API-Key": key},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=8) as resp:  # short: fail-safe no-op if slow
+            data = json.loads(resp.read().decode())
+    except Exception:
+        return
+    ctx = data.get("response") if isinstance(data, dict) else None
+    if not ctx or not str(ctx).strip():
+        return
+    ctx = str(ctx).strip()
+    if len(ctx) > 12000:  # bound the injection so it can't blow the context window
+        ctx = ctx[:12000] + "\n...[truncated]"
+    block = (
+        "<%s note: relevant context from Rob's private LightRAG knowledge graph. "
+        "LOCAL use only - do NOT forward this block to claude -p or any remote model.>\n"
+        "%s\n</%s>" % (SENTINEL, ctx, SENTINEL)
+    )
+    sys.stdout.write(json.dumps({"context": block}))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass  # fail-safe: never break a turn

--- a/kubernetes/apps/ai/hermes/app/resources/shell-hooks-allowlist.json
+++ b/kubernetes/apps/ai/hermes/app/resources/shell-hooks-allowlist.json
@@ -1,1 +1,1 @@
-{"approvals":[{"event":"pre_tool_call","command":"python3 /opt/hooks/gate.py"}]}
+{"approvals":[{"event":"pre_tool_call","command":"python3 /opt/hooks/gate.py"},{"event":"pre_llm_call","command":"python3 /opt/hooks/lightrag-rag.py"}]}

--- a/kubernetes/apps/ai/hermes/app/resources/skills/lightrag/SKILL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/skills/lightrag/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: lightrag
+description: "Query and add to Rob's LightRAG knowledge graph (personal docs: finances, property, tax, contracts). LOCAL Hermes only — never forward its content to claude -p."
+version: 1.0.0
+author: Hermes Agent (home-ops)
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [RAG, KnowledgeGraph, LightRAG, Search, Memory, Ingest]
+---
+
+# LightRAG Knowledge Graph
+
+Query and extend Rob's private LightRAG knowledge graph — the entity/relationship graph built from his
+personal documents (finances, property + contractor estimates, tax forms, contracts, etc.).
+
+**Data boundary (hard rule):** this content is internal + **personal**. LOCAL Hermes (the 35B) may use it
+freely. **Never** paste LightRAG results into a `claude -p` escalation or any remote-model prompt — it
+must not leave the network (HOMELAB-SPEC L2 #1). The gate blocks LightRAG-marked context from `claude -p`;
+do not route around it.
+
+The endpoint URL and API key come from the environment (`LIGHTRAG_URL`, `LIGHTRAG_API_KEY`), already
+injected — the helper scripts read them, so you never handle the key directly.
+
+## When to use
+
+- "What do we know about <topic> from my documents", "look up <account / estimate / form>", grounding an
+  answer in Rob's records, or "add this finding to the knowledge graph".
+
+## Query (retrieve grounded knowledge)
+
+```
+python3 scripts/query.py "your natural-language question" [mode]
+```
+
+- `mode` (optional): `local` (entity-centric, fastest — the default), `global` (relationship-centric),
+  `mix`/`hybrid` (both, richest but slower), `naive` (plain vector).
+- Add `--context-only` to get the raw retrieved KG (entities/relations/chunks) without LLM synthesis, to
+  reason over the sources yourself.
+
+## Ingest (add knowledge to the graph)
+
+```
+python3 scripts/ingest.py "the durable finding/text to add"
+# or pipe:  echo "..." | python3 scripts/ingest.py
+```
+
+Ingest durable, factual findings (not transient chatter). Ingestion is async — LightRAG extracts
+entities/relations on its own pipeline; nothing to wait on.

--- a/kubernetes/apps/ai/hermes/app/resources/skills/lightrag/scripts/ingest.py
+++ b/kubernetes/apps/ai/hermes/app/resources/skills/lightrag/scripts/ingest.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""LightRAG ingest — add a durable finding to Rob's knowledge graph.
+
+Usage: ingest.py "text to add"   (or pipe the text via stdin)
+Ingestion is async: LightRAG extracts entities/relations on its own pipeline.
+"""
+import json
+import os
+import sys
+import urllib.request
+
+
+def main() -> None:
+    text = sys.argv[1] if len(sys.argv) > 1 else sys.stdin.read()
+    text = (text or "").strip()
+    if not text:
+        print("no text to ingest", file=sys.stderr)
+        sys.exit(2)
+    url = os.environ.get("LIGHTRAG_URL", "http://lightrag.ai.svc.cluster.local:9621").rstrip("/")
+    key = os.environ.get("LIGHTRAG_API_KEY", "")
+    body = json.dumps({"text": text}).encode()
+    req = urllib.request.Request(
+        url + "/documents/text", data=body, method="POST",
+        headers={"Content-Type": "application/json", "X-API-Key": key},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=45) as resp:
+            print(resp.read().decode())
+    except Exception as exc:  # noqa: BLE001
+        print("lightrag ingest failed: %s" % exc, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/apps/ai/hermes/app/resources/skills/lightrag/scripts/query.py
+++ b/kubernetes/apps/ai/hermes/app/resources/skills/lightrag/scripts/query.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""LightRAG query — grounded retrieval from Rob's knowledge graph.
+
+LOCAL Hermes use only; never forward results into a claude -p prompt.
+Usage: query.py "question" [mode] [--context-only]
+  mode: local (default) | global | mix | hybrid | naive
+"""
+import json
+import os
+import sys
+import urllib.request
+
+
+def main() -> None:
+    flags = [a for a in sys.argv[1:] if a.startswith("-")]
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    if not args:
+        print('usage: query.py "question" [mode] [--context-only]', file=sys.stderr)
+        sys.exit(2)
+    query = args[0]
+    mode = args[1] if len(args) > 1 else "local"
+    context_only = "--context-only" in flags
+
+    url = os.environ.get("LIGHTRAG_URL", "http://lightrag.ai.svc.cluster.local:9621").rstrip("/")
+    key = os.environ.get("LIGHTRAG_API_KEY", "")
+    body = json.dumps({
+        "query": query, "mode": mode, "top_k": 8,
+        "max_total_tokens": 6000, "only_need_context": context_only,
+    }).encode()
+    req = urllib.request.Request(
+        url + "/query", data=body, method="POST",
+        headers={"Content-Type": "application/json", "X-API-Key": key},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=45) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:  # noqa: BLE001
+        print("lightrag query failed: %s" % exc, file=sys.stderr)
+        sys.exit(1)
+    print(data.get("response", data) if isinstance(data, dict) else data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wires Rob's LightRAG knowledge graph into **local** Hermes agents (full read+write), while keeping its personal content off remote models.

## Data boundary (Rob's call: "local Hermes full access, claude none")
- Auto-RAG runs via a **`pre_llm_call`** hook — it fires on Hermes' **local-model turns only**. `claude -p` is a separate CLI invocation, not a Hermes turn, so injected KG context **never reaches Claude by construction**.
- `gate.py` additionally refuses the `LIGHTRAG-KG` sentinel in any `claude -p` command (blocks a verbatim copy-forward; paraphrase can't be caught).

## What
- **Skill `lightrag`** — `SKILL.md` + `query.py` + `ingest.py`, seeded to `/opt/data/skills/lightrag/`. Agents query the graph for grounded knowledge and ingest durable findings.
- **Auto-RAG hook** (`lightrag-rag.py`) — bounded (~3k tokens, 8s timeout) and **fail-safe** (any error/slow → no-op, never breaks a turn). Injects relevant KG context into each substantive local turn.
- `LIGHTRAG_API_KEY` from the shared `lightrag` 1P item; `LIGHTRAG_URL` env; CNP egress hermes→`lightrag:9621`.

Scripts/hook are Python (`os.environ`, no `$VARS`) so Flux envsubst leaves them intact.

## Notes
- In-cluster only. Beast can get the skill (LAN LightRAG route) as a follow-up.
- Latency: the auto-RAG hook adds up to ~8s per local turn when LightRAG is slow (then no-ops); tunable.

## Validation
Python/JSON/YAML valid; `kubectl kustomize` builds (13 objects). Live end-to-end verify after merge/deploy.