### PR TITLE
fix(hermes): board dashboard auth + isolate LightRAG key (unbreak ES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-90-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-91-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -22,13 +22,6 @@ spec:
       remoteRef:
         key: hermes
         property: claude_code_oauth_token
-    # LightRAG knowledge-graph API key (sent as X-API-Key by the query/ingest
-    # skill and the pre_llm_call auto-RAG hook). From the shared `lightrag` 1P
-    # item, same key the lightrag app itself uses.
-    - secretKey: LIGHTRAG_API_KEY
-      remoteRef:
-        key: lightrag
-        property: api_key
     # Auth key for Hermes' in-cluster OpenAI-compatible API server (:8642).
     # Mandatory whenever the API server binds beyond loopback — an
     # unauthenticated Hermes API server was an entry point for the June-2026
@@ -37,15 +30,32 @@ spec:
       remoteRef:
         key: hermes
         property: api_server_key
-    # Basic-auth for the bundled dashboard's own gate (:9119). A non-loopback
-    # dashboard bind requires a provider or the s6 service SystemExits; the
-    # board HTTPRoute is additionally Authelia-gated. Injected as env via
-    # envFrom → the dashboard reads HERMES_DASHBOARD_BASIC_AUTH_{USERNAME,PASSWORD}.
-    - secretKey: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
-      remoteRef:
-        key: hermes
-        property: dashboard_basic_auth_username
-    - secretKey: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
-      remoteRef:
-        key: hermes
-        property: dashboard_basic_auth_password
+    # NOTE: LIGHTRAG_API_KEY is a SEPARATE ExternalSecret below (own target
+    # secret) — the `lightrag` 1P item exposes its key only via
+    # `extract`/`{{ .api_key }}` (a direct `property: api_key` lookup errors and
+    # would fail this whole ES). Dashboard basic-auth is NOT a secret here — it's
+    # a hashed value in config.yaml (dashboard.basic_auth, behind Authelia).
+---
+# LightRAG API key, ISOLATED in its own Secret so a provider hiccup on the
+# `lightrag` 1P item can never fail the main hermes-secret. Same `extract` +
+# `{{ .api_key }}` mechanism the lightrag app's own ExternalSecret uses (a direct
+# `property: api_key` remoteRef errors — the field is only reachable via extract).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-lightrag
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-lightrag-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        LIGHTRAG_API_KEY: "{{ .api_key }}"
+  dataFrom:
+    - extract:
+        key: lightrag

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -135,6 +135,9 @@ spec:
             envFrom:
               - secretRef:
                   name: hermes-secret
+              # LightRAG API key (isolated ExternalSecret) — LIGHTRAG_API_KEY.
+              - secretRef:
+                  name: hermes-lightrag-secret
             probes:
               # TCP on the API server port — the API server binds :8642 once
               # the gateway is up. Generous startup budget for the s6 init +

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -113,3 +113,14 @@ kanban:
   max_in_progress_per_profile: 1
   review_dispatch: true
   auto_subscribe_on_create: true
+# Dashboard (the bundled board UI on :9119). This Hermes version reads basic-auth
+# from HERE (not the HERMES_DASHBOARD_BASIC_AUTH_* env PR-1 tried, which this
+# build ignores → the service SystemExit'd and nothing listened on :9119). The
+# board HTTPRoute is ALSO Authelia-gated (admin group), so this basic-auth is a
+# second factor, not the primary gate. password_hash is a scrypt hash (one-way);
+# every `$` is escaped `$$` so Flux envsubst passes it through intact.
+dashboard:
+  public_url: https://board.${SECRET_DOMAIN}
+  basic_auth:
+    username: rob
+    password_hash: "scrypt$$16384$$8$$1$$d3VnR54RVLvjyd6M2RFG+w==$$dUa0TH3Q14pNobwL9KWvt13N5KKe2Gs33vxydWhsj+Q="


### PR DESCRIPTION
Fixes two live-found breakages after the LightRAG merge (#14069).

## 1. Board UI = "upstream connect error" (dashboard never bound)
This Hermes build reads dashboard basic-auth from **config** (`dashboard.basic_auth.username` + `password_hash`), not the `HERMES_DASHBOARD_BASIC_AUTH_*` env PR-1 set — so the s6 dashboard service `SystemExit`'d on its non-loopback bind and nothing listened on :9119. Adds `dashboard.basic_auth` (scrypt hash) + `public_url`. The board route is **also** Authelia-gated, so this is a second factor. Password handed to Rob out-of-band.

## 2. hermes ExternalSecret → SecretSyncedError (LightRAG 401)
A direct `property: api_key` lookup on the `lightrag` 1P item **errors** (its key is only reachable via `extract`), which failed the *entire* hermes ES — so `LIGHTRAG_API_KEY` never synced. Moves it to its **own** ExternalSecret (`hermes-lightrag-secret`) via the proven `extract`+`template` mechanism (isolated so a lightrag hiccup can't break the main secret), reverts the main ES to its two working keys, and drops the never-valid `dashboard_basic_auth` 1P entries.

## Validation
`kubectl kustomize` builds (14 objects); all pre-commit hooks pass. Live-verify board + LightRAG query after merge.