### PR TITLE
feat(hermes): full lovenet-gateway MCP broker for all agents

### DIFF
--- a/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
@@ -36,6 +36,17 @@ spec:
         - ports:
             - port: "9621"
               protocol: TCP
+    # Full lovenet-gateway MCP broker (all tools) for every agent — the
+    # mcp-gateway in mcp-system on :8080. The mcp-gateway pod's own CNP only
+    # admits the istio gateway, which fronts the broker and admits
+    # `fromEntities:[cluster]` on :8080; this egress is what lets hermes reach it.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     # External HTTPS for (a) the claude-code escalation skill → api.anthropic.com
     # (draws Rob's Max subscription) and (b) the one-time npm install of the
     # `claude` CLI onto the PVC. toEntities:[world]:443 is the cluster's reliable

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -124,3 +124,23 @@ dashboard:
   basic_auth:
     username: rob
     password_hash: "scrypt$$16384$$8$$1$$d3VnR54RVLvjyd6M2RFG+w==$$dUa0TH3Q14pNobwL9KWvt13N5KKe2Gs33vxydWhsj+Q="
+# Full lovenet-gateway MCP broker — ALL its tools (kubectl_*, ha_*, omada_*,
+# netbox_*, immich_*, arr_*, prom_*, grafana_*, esphome_*, music_assistant_*,
+# comfyui_*, paperless_*, chrome_*, …) available to EVERY agent (Rob: full access
+# to all agents, interactive + unattended). The internal endpoint needs no auth
+# (auth is only at the external Authelia gateway); tools.include: [] = all.
+#
+# SECURITY NOTE (accepted): MCP tool calls are NOT covered by the pre_tool_call
+# gate (it matches `terminal` only), so this is an UNGATED mutating surface
+# (kubectl_delete, omada/network, ha control…). The behavioral guardrail is the
+# kanban human-in-the-loop (a worker `kanban_block`s a destructive step → Rob
+# clears it) plus each profile's SOUL prime directive.
+mcp_servers:
+  lovenet-gateway:
+    url: "http://mcp-gateway.mcp-system.svc.cluster.local:8080/mcp"
+    enabled: true
+    connect_timeout: 30
+    timeout: 120
+    tools:
+      include: []
+      exclude: []


### PR DESCRIPTION
Gives every in-cluster Hermes agent (orchestrator + all workers) **full** access to the lovenet-gateway MCP broker — all tools (`kubectl_*`, `ha_*`, `omada_*`, `netbox_*`, `immich_*`, `arr_*`, `prom_*`, `grafana_*`, `esphome_*`, `music_assistant_*`, `comfyui_*`, `paperless_*`, `chrome_*`, …). Rob's explicit call: full access to all agents, interactive + unattended.

## What
- `mcp_servers.lovenet-gateway` → `http://mcp-gateway.mcp-system:8080/mcp` (internal endpoint, no auth — auth is only at the external Authelia gateway). `tools.include: []` = all.
- CNP egress `ai/hermes` → `mcp-system:8080` (the istio gateway fronts the broker, admits `fromEntities:[cluster]`).

## Accepted risk (Rob signed off)
MCP tool calls are **not** covered by the `pre_tool_call` gate (it matches `terminal` only) → this is an **ungated mutating surface** (`kubectl_delete`, network, HA…). The behavioral guardrail is the kanban human-in-the-loop (worker `kanban_block` → Rob unblocks) + each profile's SOUL prime directive.

beast (interactive) gets MCP via the external OIDC route as a separate `hermes mcp add` step.

## Validation
`kubectl kustomize` builds; connectivity verified live after merge (`hermes mcp test lovenet-gateway`).