### PR TITLE
fix(hermes): MCP url via istio gateway + drop orchestrator port-binding

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -137,7 +137,10 @@ dashboard:
 # clears it) plus each profile's SOUL prime directive.
 mcp_servers:
   lovenet-gateway:
-    url: "http://mcp-gateway.mcp-system.svc.cluster.local:8080/mcp"
+    # The `mcp-gateway` service selects the app pod (its CNP admits only the
+    # istio gateway → hermes drops). Use `mcp-gateway-istio` — the istio gateway
+    # that fronts the broker and admits fromEntities:[cluster] on :8080.
+    url: "http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp"
     enabled: true
     connect_timeout: 30
     timeout: 120

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/orchestrator-config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/orchestrator-config.yaml
@@ -16,14 +16,13 @@ auxiliary:
 agent:
   disabled_toolsets:
     - web
-# CRITICAL (adversarial review, delegation break #1): a peer-received turn
-# (`peer run in-cluster/orchestrator "…"`) runs on the `api_server` platform,
-# whose default toolset (`hermes-api-server`) STRIPS every kanban_* tool. Without
-# this override the orchestrator produces text and creates NO card — the whole
-# beast→board path silently no-ops. `hermes-cli` is the full toolset incl kanban.
-platform_toolsets:
-  api_server:
-    - hermes-cli
+# NOTE: no per-profile `platform_toolsets.api_server` here. A profile that
+# enables the api_server platform conflicts with `multiplex_profiles` (the
+# DEFAULT profile owns the single shared :8642 listener) and gets skipped with a
+# port-binding warning. The kanban toolset for the peer/board path is provided
+# GLOBALLY in the default config.yaml (platform_toolsets.api_server + toolsets:
+# [kanban]); the orchestrator profile only needs to exist for the dispatcher to
+# spawn it (`hermes -p orchestrator`, which runs on the full `cli` toolset).
 hooks:
   pre_tool_call:
     - matcher: "terminal"


### PR DESCRIPTION
Two live-found fixes after #14071:

1. **MCP couldn't connect** — the url pointed at the `mcp-gateway` service (selects the app pod, whose CNP admits only the istio gateway → hermes dropped, "Failed to connect: CancelledError"). Point at **`mcp-gateway-istio`** (the istio gateway fronting the broker; admits `fromEntities:[cluster]` on :8080). Verified **200** from the hermes pod.
2. **Orchestrator profile skip-warning** — drop its vestigial `platform_toolsets.api_server` (conflicts with `multiplex_profiles`; kanban toolset is provided globally). The profile still exists for the dispatcher to spawn.

Verified live after merge (`GET /mcp` 200 from hermes; MCP tools discovered).