### PR TITLE
fix(paperless-mcp): rebase fork onto v2.2.0 — 3 workaround patches down to 1

### DIFF
--- a/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
@@ -25,34 +25,32 @@ spec:
         containers:
           app:
             image:
-              # workaround: https://github.com/Kuadrant/mcp-gateway/issues/1436 — return to ghcr.io/baruchiro/paperless-mcp `latest` when this + Kuadrant/mcp-gateway#1419 + baruchiro/paperless-mcp#140 all close (umbrella: home-ops #13804)
-              # Fork build of baruchiro/paperless-mcp v2.0.1 carrying THREE fixes the
-              # Kuadrant broker needs to federate paperless (each necessary, none
-              # sufficient alone). Each maps to an upstream gap:
-              #   1. protocol version — the SDK negotiated "2025-03-26"; the broker
-              #      only serves upstreams that negotiate its pinned "2025-11-25", so
-              #      paperless was dropped from every served set (the actual
-              #      federation blocker). Fork advertises "2025-11-25" so the SDK
-              #      echoes it. Upstream: Kuadrant/mcp-gateway#1436.
-              #   2. stateful transport — v2.x ran stateless (empty Mcp-Session-Id,
-              #      GET /mcp -> 405); a 2025-11-25 (stateful) upstream needs a real
-              #      session + notification stream. Related upstream:
-              #      Kuadrant/mcp-gateway#1419 (see caveat below).
-              #   3. #138 schema — collapse `type: ["T","null"]` unions (from
-              #      `.nullable()`) to scalar so the broker doesn't reject tools.
-              #      Upstream: baruchiro/paperless-mcp#140.
+              # workaround: https://github.com/Kuadrant/mcp-gateway/issues/1419 — return to ghcr.io/baruchiro/paperless-mcp `latest` when this closes (umbrella: home-ops #13804)
+              # Fork build of baruchiro/paperless-mcp v2.2.0 carrying ONE fix the
+              # Kuadrant broker needs to federate paperless. v2.2.0 closed the other
+              # two gaps the earlier v2.0.1-based fork carried:
+              #   - #138 schema (array-form nullable `type`) — fixed upstream via
+              #     Zod v4 -> anyOf (baruchiro/paperless-mcp#140/#146/#148).
+              #   - protocol version — SDK >=1.30 negotiates "2025-11-25" natively,
+              #     so the old advertise-"2025-11-25" shim is unnecessary
+              #     (Kuadrant/mcp-gateway#1436).
+              # Remaining fork patch:
+              #   - stateful transport — v2.2.0 still runs the Streamable HTTP server
+              #     stateless (sessionIdGenerator: undefined, GET /mcp -> 405); a
+              #     2025-11-25 (stateful) broker needs a real session + notification
+              #     stream. Upstream: Kuadrant/mcp-gateway#1419 (see caveat below).
               # CAVEAT (Kuadrant/mcp-gateway#1419, stale-session recovery): the
               # broker does NOT re-federate this upstream on its own after the
               # paperless pod restarts (Renovate bump, reconcile, node drain) — it
               # holds a stale session and serves 0 paperless tools until the broker
               # is restarted: `kubectl -n mcp-system rollout restart deploy/mcp-gateway`.
-              # Built from rwlove/paperless-mcp `fix/stateful-transport`; tracked in #13804.
+              # Built from rwlove/paperless-mcp `rebase/v2.2.0-stateful`; tracked in #13804.
               repository: ghcr.io/rwlove/paperless-mcp
-              tag: fix-138-stateful-proto-20260825@sha256:1cdcb6de15b9af8ff3e2f271664706b93f4409b07c8f721f9d840615072d22be
+              tag: v2.2.0-stateful-20260907@sha256:a13e250c930449aab27738c732a46954d2a1fbb7fa64f991ab8507c4959948d4
             # v2.0.x makes a per-request `Authorization: Bearer` mandatory and drops
             # the env-token fallback, so every broker request 401s (the mcp-gateway
             # route strips Authorization so backends use their own env cred). The
-            # fork is v2.0.1-based, so this is still required: --no-auth restores the
+            # fork is v2.2.0-based, so this is still required: --no-auth restores the
             # env-token fallback (PAPERLESS_API_KEY, set by the ExternalSecret).
             # Safe here: CNP-gated to broker-only access behind Authelia — the
             # "trusted network" the flag documents. Appends to the image


### PR DESCRIPTION
## What

Rebase the `paperless-mcp` fork image onto upstream **v2.2.0**, dropping two of the three patches the old v2.0.1-based fork carried. Pins `ghcr.io/rwlove/paperless-mcp:v2.2.0-stateful-20260907@sha256:a13e250c…` (built from `rwlove/paperless-mcp` `rebase/v2.2.0-stateful`).

## Why now

Upstream v2.2.0 (2026-09-07) closed two of the three federation gaps:

| Fork patch | v2.2.0 | Detail |
|---|---|---|
| #138 schema (array-form nullable `type`) | **fixed upstream** | Zod v4 → `anyOf` (baruchiro/paperless-mcp#140/#146/#148) |
| protocol-version shim | **unneeded** | SDK ≥1.30 negotiates `2025-11-25` natively (Kuadrant/mcp-gateway#1436) |
| stateful transport | **kept** | v2.2.0 still stateless; broker needs a real session + notification stream (Kuadrant/mcp-gateway#1419) |

v2.2.0 also fixed the `tsc` OOM that originally blocked the SDK-1.30 upgrade (clean build now peaks ~280 MB).

## Verification (local)

Built the image (node 24) and ran a full MCP handshake against it:
- `initialize` → 200, session id issued, **`protocolVersion: 2025-11-25`** negotiated with no shim
- `GET /mcp` → 200 `text/event-stream` (notification stream, was 405)
- `DELETE /mcp` → 200 (teardown)
- `tools/list` → **44 tools**, **0 array-form `type` schemas**, `query_documents` clean

## Post-merge

Per the standing caveat (Kuadrant/mcp-gateway#1419), the broker holds a stale session across the paperless pod restart, so after Flux reconciles: `kubectl -n mcp-system rollout restart deploy/mcp-gateway`, then confirm the `paperless_` tools re-federate.

Refs #13804

🤖 Generated with [Claude Code](https://claude.com/claude-code)