### PR TITLE
feat(mcp-system): run searxng-mcp stateful — drop #1419 workaround

### DIFF
--- a/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
@@ -26,10 +26,8 @@ spec:
           app:
             image:
               repository: docker.io/isokoliuk/mcp-searxng
-              # 2.0.0 needs MCP_HTTP_STATELESS=true to federate through the
-              # Kuadrant mcp-gateway broker (workaround annotation is on that
-              # env below). Renovate <2.0.0 pin removed 2026-08-22 — 2.0.0
-              # verified working with stateless mode (mcp-searxng#256).
+              # Renovate <2.0.0 pin removed 2026-08-22. Federates through the
+              # Kuadrant mcp-gateway broker in full stateful mode (see env).
               tag: "2.1.0@sha256:b4cf227a6459a5071a9b455c060bdd6912ee4fd4d2275abfdb30bc4f9e539136"
             env:
               SEARXNG_URL: http://searxng.collab.svc.cluster.local:8080
@@ -44,8 +42,12 @@ spec:
               # CIDR) — not spoofable from outside the mesh. Parallels
               # github-mcp-server's --trust-proxy-headers.
               MCP_HTTP_TRUST_PROXY: "10.42.0.0/16"
-              # workaround: https://github.com/Kuadrant/mcp-gateway/issues/1419 — remove when the mcp-gateway broker carries the session-ID/protocol-version for the stateful 2026-07-28 handshake instead of sending a session-less request. Until then 2.0.0's strict streamable-HTTP layer rejects the broker POST as `hasInitializeRequest=false, sessionId=undefined`; POST-only stateless mode accepts it. Dropping this env restores legacy GET/DELETE /mcp + subscriptions + server->client notifications, none of which a request/response search tool needs. Verified working 2026-08-22 (mcp-searxng#256). Tracking issue #13682.
-              MCP_HTTP_STATELESS: "true"
+              # Runs stateful (full streamable-HTTP: GET/DELETE /mcp +
+              # subscriptions + notifications). The MCP_HTTP_STATELESS=true
+              # workaround for Kuadrant/mcp-gateway#1419 was dropped once the
+              # 0.9.0 broker was verified to carry a valid session to a strict
+              # stateful upstream and re-federate across upstream restarts
+              # (retested 2026-09-07, broker 0.9.0 + searxng 2.1.0, in-mesh).
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## What

Removes the `MCP_HTTP_STATELESS=true` env from `searxng-mcp` so it federates through the Kuadrant mcp-gateway broker in **full stateful mode** (streamable-HTTP with GET/DELETE `/mcp`, subscriptions, server→client notifications). Refreshes the now-stale image/env comments.

## Why

`MCP_HTTP_STATELESS=true` was a workaround for [Kuadrant/mcp-gateway#1419](https://github.com/Kuadrant/mcp-gateway/issues/1419): the broker was reported (searxng 2.0.0) to send session-less requests that a strict streamable-HTTP upstream rejects, de-federating it. Stateless POST-only mode sidestepped that by not requiring a session — at the cost of the full transport.

Retested **2026-09-07** on the current setup (broker `mcp-gateway:v0.9.0`, `searxng:2.1.0`, in our Istio mesh):

- Directly probed searxng with the env removed → genuinely **strict/stateful**: session-less `tools/list` → `400 No valid session ID`; `initialize` → `200` + real `Mcp-Session-Id`.
- Broker produced **zero** session-less `POST request rejected` against it — it completes the `initialize` handshake and carries the session.
- Forced **two** upstream pod restarts → broker recovered on its own each time (only transient `connection refused` while the new pod wasn't listening; consecutive failures stopped at 2, never hit `threshold=3`, no `removing tools`). No broker restart needed.

The original bug no longer reproduces, and the stale-session-on-restart risk did not materialize for this upstream, so the workaround is safe to drop.

## Test plan

- [ ] Flux reconciles `searxng-mcp`; pod comes up without `MCP_HTTP_STATELESS`.
- [ ] searxng tools remain federated through the broker (`searxng_*` callable).
- [ ] Soak: survives an upstream pod restart without de-federation.

Closes #13682

🤖 Generated with [Claude Code](https://claude.com/claude-code)