### PR TITLE
fix(hermes): raise mcp_discovery_timeout so broker tools register

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -147,3 +147,13 @@ mcp_servers:
     tools:
       include: []
       exclude: []
+# The lovenet-gateway broker federates ~1,500 tools; that discovery takes many
+# seconds. The default `mcp_discovery_timeout` (1.5s) is the bound the FIRST
+# agent build waits before snapshotting its tool list — our broker misses it, so
+# a peer/worker turn (a short session with no between-turns refresh) sees only
+# the instant resource/prompt meta-tools and NONE of the kubectl_*/ha_*/omada_*
+# tools. `hermes mcp test` (longer bound) proves the full set is discoverable.
+# Raise the bound so the snapshot waits for the big discovery to complete (it
+# returns as soon as discovery finishes, so this is a max, not a fixed delay).
+mcp_discovery_timeout: 60
+mcp_single_query_discovery_timeout: 60


### PR DESCRIPTION
The last MCP fix (#14072) connected but the agent only saw 4 tools. Root cause found by live debugging: the broker federates **~1,500 tools**, and the default `mcp_discovery_timeout` (**1.5s**) is the bound the first agent build waits before snapshotting — our broker misses it, so a peer/worker turn (short session, no between-turns refresh) registered only the instant resource/prompt meta-tools, none of the `kubectl_*`/`ha_*`/`omada_*` tools.

`hermes mcp test lovenet-gateway` proved the full set IS discoverable given time. Raise the bound to 60s (returns as soon as discovery completes → a max, not a fixed delay).

Verified live after merge (peer dm → agent calls a real kubectl/prom tool).