### PR TITLE
fix(hermes): raise MCP connect_timeout 30->180 (broker tools finally register)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -142,7 +142,14 @@ mcp_servers:
     # that fronts the broker and admits fromEntities:[cluster] on :8080.
     url: "http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp"
     enabled: true
-    connect_timeout: 30
+    # 180s (was 30, below the 60 default — my mistake). At BUSY gateway startup
+    # (concurrent profile reconcile + dashboard + …) the connect+list of the
+    # broker's ~1,200 tools exceeds 30s → asyncio.wait_for times out inside
+    # _discover_and_register_server → the server PARKS and is skipped by every
+    # later register pass (it's now in _servers/cooldown), so agents get 0 tools.
+    # `hermes mcp test` connects idle in ~6s, which is why the tools were always
+    # discoverable there. Give the startup connect ample room.
+    connect_timeout: 180
     timeout: 120
     tools:
       include: []


### PR DESCRIPTION
Root cause of the empty MCP tool set, found by calling the deployed register path directly and reading the **deployed** source (upstream 29112bef — the cloned repo was a different build, which sent the earlier timeout/auth guesses astray).

`_discover_and_register_server` wraps the connect in `asyncio.wait_for(connect_timeout)`. I had set **`connect_timeout: 30`** (below the 60 default). At **busy gateway startup** the connect+list of the broker's ~1,200 tools exceeds 30s → times out → the server **parks** → every later register pass skips it (now in `_servers`/cooldown) → agents get **0** broker tools. `hermes mcp test` connects idle in ~6s, which is exactly why the tools were always discoverable there but never in a real agent build (the `registered N tool(s)` log never fired). Raise to **180s**.

Verified live after merge: peer dm → agent calls a real `kubectl_*`/`prom_*` tool.