### PR TITLE
chore(immich): temporarily cap frame-album video (720p/5Mbps)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -32,7 +32,7 @@ spec:
             "ffmpeg": {
               "targetResolution": "720",
               "maxBitrate": "5000k",
-              "transcode": "disabled",
+              "transcode": "bitrate",
               "realtime": {
                 "enabled": true,
                 "videoCodecs": ["h264", "hevc"],


### PR DESCRIPTION
Automated flip-scope-revert step — see tools/immich-frame-video-transcode.sh.