### PR TITLE
fix(hermes): drop MCP include:[] filter (allow-nothing) — 1205 tools register

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -151,9 +151,13 @@ mcp_servers:
     # discoverable there. Give the startup connect ample room.
     connect_timeout: 180
     timeout: 120
-    tools:
-      include: []
-      exclude: []
+    # NO tools filter. THE fix (proven live: with the block, discovery registers
+    # only the 4 resource/prompt utility tools and logs "skipping tool 'X'
+    # (filtered by config)" for all ~1,200 real tools; without it, 1205 register).
+    # In THIS deployed build (upstream 29112bef) an empty `include: []` is an
+    # explicit allow-NOTHING allowlist — NOT "no filter" as an older build treated
+    # it. Omitting `tools` entirely = all tools. (This version mismatch is why the
+    # earlier discovery-timeout / connect-timeout / cache fixes all missed.)
 # The lovenet-gateway broker federates ~1,500 tools; that discovery takes many
 # seconds. The default `mcp_discovery_timeout` (1.5s) is the bound the FIRST
 # agent build waits before snapshotting its tool list — our broker misses it, so


### PR DESCRIPTION
**The fix.** Live debug trace of the deployed register path showed discovery *received* all ~1,200 broker tools but logged `skipping tool 'X' (filtered by config)` for each — registering only 4 utility tools. Removing `tools: {include: [], exclude: []}` → **1205** register. Version trap: the deployed build treats empty `include: []` as **allow-nothing**; the cloned source I was reading treats it as *no filter* — which is why the earlier timeout/cache fixes missed. Verified live: with the block → 4; without → 1205.