### PR TITLE
feat(hermes): vault-bridge — materialise the Obsidian claude vault for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-91-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-92-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hermes/app/cnp-allow.yaml
@@ -47,6 +47,18 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # Obsidian vault sync — the vault-bridge LiveSync sidecar → obsidian-couchdb
+    # (collab ns) :5984. The couchdb side re-adds the matching ingress for hermes
+    # (its rule was removed when claude-runner was retired). Label is
+    # `obsidian-couchdb` (not `couchdb`).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: obsidian-couchdb
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP
     # External HTTPS for (a) the claude-code escalation skill → api.anthropic.com
     # (draws Rob's Max subscription) and (b) the one-time npm install of the
     # `claude` CLI onto the PVC. toEntities:[world]:443 is the cluster's reliable

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -59,3 +59,40 @@ spec:
   dataFrom:
     - extract:
         key: lightrag
+---
+# LiveSync vault-bridge settings.json (couchDB creds templated in). Mirrors the
+# retired claude-runner's proven vault-bridge. encrypt:false — the `claude` DB is
+# not E2EE (its doc IDs are plaintext paths), so no passphrase. CouchDB is the
+# source of truth; the laptop stays the canonical editor.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-vault-bridge
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-vault-bridge-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        settings.json: |-
+          {
+            "couchDB_URI": "http://obsidian-couchdb.collab.svc.cluster.local:5984",
+            "couchDB_USER": "{{ .couchdb_username }}",
+            "couchDB_PASSWORD": "{{ .couchdb_password }}",
+            "couchDB_DBNAME": "claude",
+            "encrypt": false,
+            "passphrase": "",
+            "liveSync": true,
+            "syncOnSave": true,
+            "syncOnStart": true,
+            "usePluginSync": false,
+            "isConfigured": true
+          }
+  dataFrom:
+    - extract:
+        key: obsidian

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -132,6 +132,10 @@ spec:
               # LightRAG knowledge-graph endpoint for the query/ingest skill and
               # the pre_llm_call auto-RAG hook. LIGHTRAG_API_KEY comes via envFrom.
               LIGHTRAG_URL: http://lightrag.ai.svc.cluster.local:9621
+              # The materialised Obsidian vault (the `claude` DB), synced by the
+              # vault-bridge sidecar. Hermes' note-taking/obsidian skill reads &
+              # writes markdown here (also the substrate for the LLM-Wiki flow).
+              OBSIDIAN_VAULT_PATH: /vault
             envFrom:
               - secretRef:
                   name: hermes-secret
@@ -187,6 +191,33 @@ spec:
                 memory: 2Gi
               limits:
                 memory: 4Gi
+          # vault-bridge — the official Self-hosted LiveSync CLI (same author +
+          # core as the Obsidian plugin) in `daemon` mode: continuously
+          # replicates the `claude` CouchDB DB <-> the local filesystem via the
+          # _changes feed, materialising the vault as files the agent reads/writes.
+          # CouchDB stays the source of truth; the laptop is the canonical editor.
+          # Single pod → the RWO vault PVC is shared with the app container.
+          vault-bridge:
+            image:
+              repository: ghcr.io/vrtmrz/livesync-cli
+              tag: 1.0.24-cli
+            # Entrypoint prepends LIVESYNC_DB_PATH as argv[1], so args become:
+            #   /db --settings /config/settings.json --vault /vault daemon
+            args:
+              - --settings
+              - /config/settings.json
+              - --vault
+              - /vault
+              - daemon
+            env:
+              LIVESYNC_DB_PATH: /db
+              TZ: America/New_York
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
     service:
       app:
         controller: hermes
@@ -197,6 +228,30 @@ spec:
           dashboard:
             port: 9119
     persistence:
+      # The materialised Obsidian vault (the `claude` DB) — ceph-block, shared
+      # RWO between the app (reads/writes markdown at /vault) and vault-bridge
+      # (LiveSync materialises files at /vault, PouchDB local db at /db).
+      vault:
+        existingClaim: hermes-vault-data
+        advancedMounts:
+          hermes:
+            app:
+              - path: /vault
+                subPath: vault
+            vault-bridge:
+              - path: /vault
+                subPath: vault
+              - path: /db
+                subPath: db
+      # LiveSync settings.json (couchDB creds templated) → vault-bridge only.
+      vault-bridge-config:
+        type: secret
+        name: hermes-vault-bridge-secret
+        advancedMounts:
+          hermes:
+            vault-bridge:
+              - path: /config
+                readOnly: true
       # The single source of truth for all Hermes state (SQLite, config, .env,
       # profiles, skills, memories, sessions) — mounted into both the seed init
       # container and the app.

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./httproute.yaml
   - ./longhorn-pvc.yaml
   - ./prometheusrule.yaml
+  - ./pvc-vault.yaml
   - ./securitypolicy.yaml
 configMapGenerator:
   - name: hermes-config

--- a/kubernetes/apps/ai/hermes/app/pvc-vault.yaml
+++ b/kubernetes/apps/ai/hermes/app/pvc-vault.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/v1/persistentvolumeclaim.json
+#
+# The materialised Obsidian vault (the `claude` CouchDB DB) for Hermes' agents.
+# ceph-block, NOT backed-up Longhorn: CouchDB (obsidian-couchdb) is the source of
+# truth and the laptop is the canonical editor, so this in-cluster copy is
+# regenerable — a full re-pull from CouchDB rebuilds it. RWO, single pod (the
+# app container reads it; the vault-bridge sidecar writes it via LiveSync).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-vault-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
@@ -26,5 +26,16 @@ spec:
         - ports:
             - port: "5984"
               protocol: TCP
+    # Hermes vault-bridge (ai/hermes) LiveSync ↔ the `claude` DB. Re-adds the
+    # ingress the retired claude-runner had (removed in #14043); Hermes is the
+    # successor in-cluster vault client.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: hermes
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP
   # No egress holes needed — CouchDB is self-contained for this
   # single-node setup. No remote replication peers configured.


### PR DESCRIPTION
PR-4 of the Hermes plan. Gives agents a live copy of the `claude` Obsidian vault via the official Self-hosted LiveSync CLI (mirrors the retired claude-runner's proven vault-bridge). Substrate for the Karpathy 'LLM Wiki' workflow.

## What
- **vault-bridge** sidecar (`ghcr.io/vrtmrz/livesync-cli:1.0.24-cli`, daemon) syncs the `claude` DB ↔ `/vault`; app reads/writes markdown there (`OBSIDIAN_VAULT_PATH=/vault`).
- **ceph-block** vault PVC (regenerable — CouchDB is source of truth, laptop is canonical editor).
- settings.json templated from the `obsidian` 1P item; `encrypt:false` (the `claude` DB isn't E2EE — verified: plaintext doc paths).
- CNP: hermes egress → `obsidian-couchdb.collab:5984` **and** re-add the couchdb ingress for `ai/hermes` (claude-runner's rule was removed in #14043).

## Notes
- Full-vault sync for **local** agents (your stance, same as LightRAG); gate.py still blocks vault content from `claude -p`. CouchDB records conflict revisions if agent + laptop edit the same note.

## Validation
Both apps `kubectl kustomize` clean; verified live after merge (vault materialises, agent reads a note).