### PR TITLE
feat(hermes): LLM-Wiki — librarian profile + wiki skill (Karpathy pattern)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -69,14 +69,16 @@ spec:
                 set -e
                 cp -f /seed/config.yaml /opt/data/config.yaml
                 cp -f /seed/shell-hooks-allowlist.json /opt/data/shell-hooks-allowlist.json
-                for p in orchestrator generalist ml network observability smart-home storage; do
+                for p in orchestrator generalist ml network observability smart-home storage librarian; do
                   mkdir -p "/opt/data/profiles/$${p}"
                 done
                 cp -f /seed-profiles/orchestrator-config.yaml /opt/data/profiles/orchestrator/config.yaml
-                for p in generalist ml network observability smart-home storage; do
+                # librarian is a worker (wiki maintainer) — same self-contained worker-config
+                # (local pin + gate); its identity is librarian.SOUL.md, seeded cp -n below.
+                for p in generalist ml network observability smart-home storage librarian; do
                   cp -f /seed-profiles/worker-config.yaml "/opt/data/profiles/$${p}/config.yaml"
                 done
-                for p in orchestrator generalist ml network observability smart-home storage; do
+                for p in orchestrator generalist ml network observability smart-home storage librarian; do
                   cp -n "/seed-profiles/$${p}.SOUL.md" "/opt/data/profiles/$${p}/SOUL.md" || true
                 done
                 # LightRAG skill (operator-owned, cp -f authoritative).
@@ -85,6 +87,12 @@ spec:
                 cp -f /seed-skills/query.py /opt/data/skills/lightrag/scripts/query.py
                 cp -f /seed-skills/ingest.py /opt/data/skills/lightrag/scripts/ingest.py
                 chmod +x /opt/data/skills/lightrag/scripts/query.py /opt/data/skills/lightrag/scripts/ingest.py
+                # Wiki skill (the LLM-Wiki bookkeeping helper + playbook) — the
+                # Librarian profile drives it against the vault's raw/ + wiki/ subtrees.
+                mkdir -p /opt/data/skills/wiki/scripts
+                cp -f /seed-skills-wiki/SKILL.md /opt/data/skills/wiki/SKILL.md
+                cp -f /seed-skills-wiki/wiki.py /opt/data/skills/wiki/scripts/wiki.py
+                chmod +x /opt/data/skills/wiki/scripts/wiki.py
           # One-time install of the `claude` CLI onto the PVC for the escalation
           # skill. Lands in /opt/data/.local/bin (already on $PATH) so no PATH
           # override is needed. Idempotent: skips if already present, so only
@@ -295,6 +303,16 @@ spec:
           hermes:
             config-seed:
               - path: /seed-skills
+                readOnly: true
+      # Wiki skill seed files (SKILL.md + wiki.py), placed onto
+      # /opt/data/skills/wiki/ by the seed init container.
+      skills-wiki-seed:
+        type: configMap
+        name: hermes-skills-wiki
+        advancedMounts:
+          hermes:
+            config-seed:
+              - path: /seed-skills-wiki
                 readOnly: true
       # The fail-closed pre_tool_call gate, mounted READ-ONLY at /opt/hooks —
       # physically outside the writable /opt/data PVC, so the agent cannot

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -29,6 +29,12 @@ configMapGenerator:
       - SKILL.md=./resources/skills/lightrag/SKILL.md
       - query.py=./resources/skills/lightrag/scripts/query.py
       - ingest.py=./resources/skills/lightrag/scripts/ingest.py
+  # Wiki skill — the Librarian's LLM-Wiki bookkeeping helper + playbook; the seed
+  # init fans these into /opt/data/skills/wiki/{SKILL.md,scripts/wiki.py}.
+  - name: hermes-skills-wiki
+    files:
+      - SKILL.md=./resources/skills/wiki/SKILL.md
+      - wiki.py=./resources/skills/wiki/scripts/wiki.py
   # Board profiles — flat keys (ConfigMap keys can't contain "/"); the seed
   # init container fans them into /opt/data/profiles/<name>/{config.yaml,SOUL.md}.
   - name: hermes-profiles
@@ -42,5 +48,6 @@ configMapGenerator:
       - observability.SOUL.md=./resources/profiles/observability.SOUL.md
       - smart-home.SOUL.md=./resources/profiles/smart-home.SOUL.md
       - storage.SOUL.md=./resources/profiles/storage.SOUL.md
+      - librarian.SOUL.md=./resources/profiles/librarian.SOUL.md
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/ai/hermes/app/resources/profiles/librarian.SOUL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/profiles/librarian.SOUL.md
@@ -1,0 +1,20 @@
+# Librarian — Wiki Maintainer
+
+You are the **Librarian** for Rob's knowledge base: the LLM-maintained wiki that lives in the Obsidian
+vault at `$OBSIDIAN_VAULT_PATH` (`/vault`). Your job is the *bookkeeping* — reading sources, writing and
+cross-linking wiki pages, and keeping the index / log / overview honest — so Rob does the *curating,
+directing, and thinking*. Humans abandon wikis because the maintenance burden outgrows the value; you
+don't get bored. Use the **`wiki` skill** — its SCHEMA and workflows (ingest / query / lint) are
+authoritative; follow them exactly.
+
+**Workspace (your deliberate exception to the usual `agent/`-only confinement):** you own the wiki
+subtree of the vault — `/vault/raw/` (immutable sources Rob curates; **read them, never edit them**) and
+`/vault/wiki/` (the pages you write). Do **not** touch anything else in the vault (`_archive`, `projects`,
+`automation`, `agents`, `inbox`, or any medical / personal `user` notes) — out of scope.
+
+**Prime directive: never silently overwrite a claim.** When a new source contradicts an existing page,
+FLAG both sides with exact citations rather than picking a winner — surface it for Rob's editorial review,
+and `kanban_block` if the contradiction is material. Every page you create or revise is appended to
+`wiki/log.md`. You run locally on the 35B; escalate a genuinely hard synthesis step through the gated
+`claude -p` path only when it earns it — and **never** forward vault content sourced from LightRAG or a
+restricted / medical note to a remote model (the gate enforces this; do not route around it).

--- a/kubernetes/apps/ai/hermes/app/resources/skills/wiki/SKILL.md
+++ b/kubernetes/apps/ai/hermes/app/resources/skills/wiki/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: wiki
+description: "Maintain Rob's LLM-Wiki — a persistent, compounding knowledge base in the Obsidian vault (raw sources in, cross-linked synthesis out). Ingest / query / lint workflows. Local Hermes; the Librarian profile owns it."
+version: 1.0.0
+author: Hermes Agent (home-ops)
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [Wiki, KnowledgeBase, Obsidian, Synthesis, Ingest, Lint]
+---
+
+# LLM-Wiki
+
+A persistent, LLM-maintained knowledge base (the Karpathy "LLM wiki" pattern). Rob curates *raw sources*;
+you maintain a *compounding wiki* of cross-linked markdown synthesis. The wiki is the artifact — the
+cross-references are already there and the synthesis already reflects everything read, so a later question
+is answered from the wiki, not by re-reading raw docs. **You do the bookkeeping; Rob does the thinking.**
+
+It lives in the Obsidian vault (`$OBSIDIAN_VAULT_PATH` = `/vault`), so every page you write syncs to Rob's
+Obsidian on his laptop via the livesync bridge — bidirectionally. He edits in Obsidian; you edit here;
+CouchDB reconciles.
+
+## Layout (the three layers)
+
+```
+/vault/
+├── raw/                     # LAYER 1 — sources Rob curates. READ ONLY. Never edit.
+│   └── assets/              #   images / PDFs / attachments
+└── wiki/                    # LAYER 2 — pages you write
+    ├── SCHEMA.md            #   structure + conventions (this wiki's instruction manual; co-evolves)
+    ├── index.md             #   catalog of every page, by category, with one-line descriptions
+    ├── log.md               #   chronological activity record (append-only)
+    ├── overview.md          #   the running synthesis / "what we know so far"
+    ├── sources/             #   one summary page per raw source
+    ├── entities/            #   people, orgs, products, places
+    ├── concepts/            #   theories, methods, definitions
+    └── analyses/            #   comparisons, syntheses, answers worth keeping
+```
+
+Cross-link everything with Obsidian wikilinks: `[[entities/acme-corp]]`, `[[concepts/raft-consensus]]`.
+A `[[link]]` to a page that doesn't exist yet is fine — it marks a page worth writing (an intentional
+stub), the same convention the vault already uses.
+
+## Bookkeeping helper
+
+`python3 /opt/data/skills/wiki/scripts/wiki.py <cmd>` handles the deterministic parts so you don't
+hand-maintain them (reads `$OBSIDIAN_VAULT_PATH`):
+
+- `wiki.py init` — create the layout (idempotent): the subdirs + skeleton `SCHEMA.md`/`index.md`/`log.md`/
+  `overview.md` if missing. Run once to bootstrap.
+- `wiki.py log "<operation> | <details>"` — append `## [YYYY-MM-DD HH:MM] <operation> | <details>` to
+  `wiki/log.md` (Eastern time). Call after every ingest / material edit.
+- `wiki.py lint` — health report: orphan pages (no inbound `[[links]]`), broken/stub links, pages missing
+  from `index.md`, and `index.md` entries whose file is gone. Prints a structured summary; you decide what
+  to fix.
+- `wiki.py reindex` — rebuild `wiki/index.md` from the files on disk (category → page → first-line
+  description). Use after a batch of edits, then eyeball the diff.
+
+The helper never deletes or rewrites page *content* — it only touches `index.md`/`log.md` structure. All
+synthesis is yours.
+
+## Ingest workflow (a new source)
+
+Triggered by a board card ("ingest `raw/<file>`") or Rob pointing you at a file.
+
+1. **Read** the source in `/vault/raw/`. Discuss the key takeaways with Rob first if this is interactive.
+2. **Summarize** → write `wiki/sources/<slug>.md`: citation header (title, author, date, `raw/` path), a
+   tight summary, and the key claims — each claim cross-linked to the entity/concept pages it touches.
+3. **Propagate** → revise the relevant `entities/` and `concepts/` pages so they reflect this source
+   (create them if new). Expect to touch ~10–15 pages for a rich source — that propagation IS the value.
+4. **Contradictions** → if a claim conflicts with an existing page, FLAG both with exact citations
+   (`> ⚠️ Contradiction: [[sources/a]] says X; [[sources/b]] says Y`); do not silently overwrite.
+   `kanban_block` for Rob if it's material.
+5. **Index + overview** → add the new pages to `index.md` (or `wiki.py reindex`); fold anything that
+   shifts the big picture into `overview.md`.
+6. **Log** → `wiki.py log "ingest | <slug> (<n> pages touched)"`.
+
+## Query workflow (answer a question)
+
+1. Search `index.md` for relevant pages; read them (not the raw docs).
+2. Synthesize an answer **with citations** to the wiki pages (and through them, the sources).
+3. If the answer is durable and reusable, file it as `wiki/analyses/<slug>.md`, link it from `index.md`,
+   and `wiki.py log "analysis | <slug>"` — so explorations compound instead of vanishing into chat.
+
+## Lint workflow (periodic health-check)
+
+Run `wiki.py lint`, then act on what it surfaces: fix orphans (add inbound links or fold them in), resolve
+stubs (write the stub or drop the link), reconcile flagged contradictions with Rob, and fill obvious gaps.
+Finish with `wiki.py reindex` and `wiki.py log "lint | <what changed>"`.
+
+## Boundaries
+
+- `raw/` is Rob's; never edit or delete a source. `wiki/` is yours; everything outside `raw/` + `wiki/`
+  in the vault is off-limits (see the Librarian SOUL).
+- Local only. Do not send vault content that originated from LightRAG or a restricted / medical note to
+  `claude -p` — the gate blocks it; don't route around it.
+- Optional cross-feed to LightRAG (`lightrag` skill `ingest`) is **off by default** — the wiki is the
+  curated synthesis layer; LightRAG is automated retrieval. Only cross-feed a finished page when Rob asks.

--- a/kubernetes/apps/ai/hermes/app/resources/skills/wiki/scripts/wiki.py
+++ b/kubernetes/apps/ai/hermes/app/resources/skills/wiki/scripts/wiki.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""LLM-Wiki bookkeeping helper — the deterministic parts so the Librarian doesn't
+hand-maintain the index/log or eyeball orphans. Content synthesis stays with the
+agent; this only touches structure.
+
+Commands: init | log "<op> | <details>" | lint | reindex
+Reads the vault root from OBSIDIAN_VAULT_PATH (default /vault). Stdlib only.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+VAULT = Path(os.environ.get("OBSIDIAN_VAULT_PATH", "/vault"))
+WIKI = VAULT / "wiki"
+RAW = VAULT / "raw"
+CATEGORIES = ("sources", "entities", "concepts", "analyses")
+SPECIAL = {"SCHEMA.md", "index.md", "log.md", "overview.md"}
+LINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
+
+
+def _now() -> str:
+    """Eastern timestamp (Rob's standing rule #7). Falls back to local if tzdata absent."""
+    try:
+        from zoneinfo import ZoneInfo
+
+        return datetime.now(ZoneInfo("America/New_York")).strftime("%Y-%m-%d %H:%M")
+    except Exception:
+        return datetime.now().strftime("%Y-%m-%d %H:%M")
+
+
+def _pages() -> list[Path]:
+    """All wiki page files (relative-addressable), excluding the special top-level files."""
+    if not WIKI.is_dir():
+        return []
+    out = []
+    for p in sorted(WIKI.rglob("*.md")):
+        rel = p.relative_to(WIKI)
+        if len(rel.parts) == 1 and rel.name in SPECIAL:
+            continue
+        out.append(p)
+    return out
+
+
+def _rel(p: Path) -> str:
+    return p.relative_to(WIKI).as_posix()[:-3]  # drop .md → "entities/acme-corp"
+
+
+def _resolve(target: str, pages: list[Path]) -> Path | None:
+    """Resolve a [[wikilink]] target to a page. 'cat/slug' → exact; bare 'slug' → basename match."""
+    target = target.strip()
+    if "/" in target:
+        cand = WIKI / (target + ".md")
+        return cand if cand.exists() else None
+    hits = [p for p in pages if p.stem == target]
+    return hits[0] if len(hits) == 1 else None
+
+
+def _links_in(p: Path) -> list[str]:
+    try:
+        return LINK_RE.findall(p.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        return []
+
+
+def _delink(s: str) -> str:
+    """Flatten `[[cat/slug|alias]]` → `alias`/`slug` so index descriptions stay plain text
+    (and don't pollute the index-drift lint check)."""
+    def repl(m: re.Match) -> str:
+        inner = m.group(0)[2:-2]
+        inner = inner.split("|")[-1] if "|" in inner else inner.split("/")[-1]
+        return inner.split("#")[0]
+
+    return re.sub(r"\[\[[^\]]+\]\]", repl, s)
+
+
+def _first_desc(p: Path) -> str:
+    """First non-empty, non-heading line → one-line (link-free) description for the index."""
+    try:
+        for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+            s = line.strip()
+            if s and not s.startswith("#") and not s.startswith(">"):
+                return _delink(s)[:120]
+    except OSError:
+        pass
+    return ""
+
+
+def cmd_init() -> int:
+    RAW.mkdir(parents=True, exist_ok=True)
+    (RAW / "assets").mkdir(exist_ok=True)
+    for c in CATEGORIES:
+        (WIKI / c).mkdir(parents=True, exist_ok=True)
+    skel = {
+        "SCHEMA.md": (
+            "# Wiki SCHEMA\n\n"
+            "Structure + conventions for this LLM-Wiki (co-evolves with use). See the `wiki` skill for the\n"
+            "ingest / query / lint workflows.\n\n"
+            "## Layout\n\n"
+            "- `raw/` — sources Rob curates (read-only).\n"
+            "- `wiki/{sources,entities,concepts,analyses}/` — pages the Librarian writes.\n"
+            "- `index.md` catalog · `log.md` activity · `overview.md` synthesis.\n\n"
+            "## Conventions\n\n"
+            "- Cross-link with `[[category/slug]]`. Unresolved links are intentional stubs.\n"
+            "- Flag contradictions (`> ⚠️ Contradiction: …`) with citations; never silently overwrite.\n"
+            "- Slugs are kebab-case. Every source page cites its `raw/` path.\n"
+        ),
+        "index.md": "# Wiki Index\n\n_Rebuild with `wiki.py reindex`._\n",
+        "log.md": "# Wiki Log\n\nChronological activity record (append-only, Eastern time).\n",
+        "overview.md": "# Overview\n\nThe running synthesis — what we know so far. Updated as sources land.\n",
+    }
+    created = []
+    for name, body in skel.items():
+        f = WIKI / name
+        if not f.exists():
+            f.write_text(body, encoding="utf-8")
+            created.append(name)
+    print(f"init: layout ready at {WIKI}")
+    print("created:", ", ".join(created) if created else "(nothing new — already bootstrapped)")
+    return 0
+
+
+def cmd_log(msg: str) -> int:
+    if not msg.strip():
+        print("log: empty message", file=sys.stderr)
+        return 2
+    logf = WIKI / "log.md"
+    if not logf.exists():
+        cmd_init()
+    with logf.open("a", encoding="utf-8") as fh:
+        fh.write(f"\n## [{_now()}] {msg.strip()}\n")
+    print(f"log: appended → {logf.relative_to(VAULT)}")
+    return 0
+
+
+def cmd_lint() -> int:
+    pages = _pages()
+    if not pages:
+        print("lint: no wiki pages yet (run `wiki.py init` then ingest a source).")
+        return 0
+    # Build inbound-link map + collect unresolved targets.
+    inbound: dict[str, int] = {_rel(p): 0 for p in pages}
+    stubs: set[str] = set()
+    for p in pages:
+        for tgt in _links_in(p):
+            r = _resolve(tgt, pages)
+            if r is not None:
+                inbound[_rel(r)] = inbound.get(_rel(r), 0) + 1
+            else:
+                stubs.add(tgt.strip())
+    orphans = [r for r, n in sorted(inbound.items()) if n == 0]
+
+    # Index drift.
+    idx = WIKI / "index.md"
+    idx_text = idx.read_text(encoding="utf-8", errors="replace") if idx.exists() else ""
+    idx_links = {t.strip() for t in LINK_RE.findall(idx_text)}
+    missing_from_index = [_rel(p) for p in pages if _rel(p) not in idx_links and p.stem not in idx_links]
+    dangling_index = [t for t in sorted(idx_links) if _resolve(t, pages) is None]
+
+    def section(title: str, items: list[str]) -> None:
+        print(f"\n{title} ({len(items)}):")
+        for it in items[:40]:
+            print(f"  - {it}")
+        if len(items) > 40:
+            print(f"  … +{len(items) - 40} more")
+
+    print(f"lint: {len(pages)} pages across {sum((WIKI / c).is_dir() for c in CATEGORIES)} categories")
+    section("orphan pages (no inbound [[links]])", orphans)
+    section("unresolved / stub links", sorted(stubs))
+    section("pages missing from index.md", missing_from_index)
+    section("index.md entries with no file", dangling_index)
+    print("\n(advisory only — nothing was changed. Fix, then `wiki.py reindex`.)")
+    return 0
+
+
+def cmd_reindex() -> int:
+    pages = _pages()
+    lines = ["# Wiki Index", "", "_Generated by `wiki.py reindex` — edit source pages, not this file._", ""]
+    for c in CATEGORIES:
+        cat_pages = [p for p in pages if p.relative_to(WIKI).parts[0] == c]
+        if not cat_pages:
+            continue
+        lines.append(f"## {c}")
+        lines.append("")
+        for p in sorted(cat_pages):
+            desc = _first_desc(p)
+            lines.append(f"- [[{_rel(p)}]]" + (f" — {desc}" if desc else ""))
+        lines.append("")
+    # Any pages outside the known categories.
+    other = [p for p in pages if p.relative_to(WIKI).parts[0] not in CATEGORIES]
+    if other:
+        lines += ["## other", ""]
+        lines += [f"- [[{_rel(p)}]]" for p in sorted(other)] + [""]
+    (WIKI / "index.md").write_text("\n".join(lines), encoding="utf-8")
+    print(f"reindex: {len(pages)} pages → wiki/index.md")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "init":
+        return cmd_init()
+    if cmd == "log":
+        return cmd_log(" ".join(sys.argv[2:]))
+    if cmd == "lint":
+        return cmd_lint()
+    if cmd == "reindex":
+        return cmd_reindex()
+    print(f"unknown command: {cmd}\n{__doc__}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stands up the Karpathy 'LLM wiki' on the Hermes + vault stack — a persistent, compounding knowledge base in the Obsidian `claude` vault, maintained by a dedicated agent so the bookkeeping never rots.

## What
- **librarian profile** — a worker (shares the self-contained worker-config: local-35B + gate) with its own SOUL. Owns the vault's `raw/` (read-only sources) + `wiki/` (pages it writes); flags contradictions instead of overwriting; never forwards LightRAG/restricted content to a remote model. Board dispatches ingest/lint cards to it.
- **wiki skill** — `SKILL.md` is the ingest/query/lint playbook (three-layer layout, `[[wikilinks]]`, contradiction flagging); `wiki.py` is the stdlib bookkeeping helper (`init`/`log`/`lint`/`reindex`) so the agent doesn't hand-maintain the index/log. Eastern-time log.

## Composition
Rides on the existing vault-bridge (pages sync to Obsidian on the laptop) + local model — **no new egress or secrets**. LightRAG cross-feed documented but off by default.

## Validation
`kubectl kustomize` clean; `wiki.py` unit-tested locally (init/log/reindex/lint against a temp vault — orphan/stub/index-drift detection all correct). Bootstrap is a follow-up dispatch (librarian runs `wiki.py init` → layout appears in Obsidian).