### PR TITLE
fix(hermes): dummy VLLM_API_KEY so context compression doesn't abort

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -127,6 +127,13 @@ spec:
               # The driver has no --api-key, so any non-empty value satisfies
               # the OpenAI client. Real secrets come via envFrom below.
               OPENAI_API_KEY: sk-noauth-local-vllm
+              # Same keyless-vLLM dummy for the `vllm` provider alias. The main
+              # inference loop resolves its key via OPENAI_API_KEY, but the
+              # auxiliary / context-compression client resolves the alias's OWN
+              # env var (VLLM_API_KEY) and hard-fails without it ("Provider
+              # 'vllm' is set but no API key was found") — which aborts context
+              # compression mid-session. Keyless endpoint ignores the value.
+              VLLM_API_KEY: sk-noauth-local-vllm
               # Kanban dashboard — the bundled s6 service (UI + /api/plugins/
               # kanban/* + /events WS) on :9119. It is already supervised by
               # /init; this flag brings it up. A non-loopback bind REQUIRES an


### PR DESCRIPTION
The `vllm` provider alias resolves its **own** key env var (`VLLM_API_KEY`) in the auxiliary / context-compression client, and hard-fails without it — *"Provider 'vllm' is set in config.yaml but no API key was found"* — which **aborts context compression mid-session**. Main inference is unaffected (it resolves the key via `OPENAI_API_KEY`, already a dummy).

The vLLM driver is keyless, so a non-empty dummy satisfies the check and the endpoint ignores the value. Spawned workers inherit the container env, so this one line covers gateway + orchestrator + every worker.

beast's interactive Hermes got the same key added to its `.env` out-of-band (its next TUI session is already fixed).

Reported live: a beast `hermes chat` session hit it at ~105k tokens ("Compression aborted: 22 messages preserved").