### PR TITLE
fix(media): force beets pyacoustid to HTTPS (unbreak AcoustID fingerprinting)

### DIFF
--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -84,6 +84,11 @@ spec:
                   echo "[$(date)] Beets failed (attempt $attempts/$max_attempts), retrying in 30s..."
                   sleep 30
                 done
+            env:
+              # Put the sitecustomize.py override (resources/sitecustomize.py,
+              # mounted below) on the import path so it runs at interpreter
+              # startup and forces pyacoustid to HTTPS. See that file for why.
+              PYTHONPATH: /pythonpath
             resources:
               requests:
                 cpu: 100m
@@ -139,6 +144,14 @@ spec:
         globalMounts:
           - path: /scripts/mbid-scrub.py
             subPath: mbid-scrub.py
+            readOnly: true
+
+      sitecustomize:
+        type: configMap
+        name: beets-sitecustomize
+        globalMounts:
+          - path: /pythonpath/sitecustomize.py
+            subPath: sitecustomize.py
             readOnly: true
 
       media:

--- a/kubernetes/apps/media/beets/app/kustomization.yaml
+++ b/kubernetes/apps/media/beets/app/kustomization.yaml
@@ -18,6 +18,9 @@ configMapGenerator:
   - name: beets-scripts
     files:
       - mbid-scrub.py=./resources/mbid-scrub.py
+  - name: beets-sitecustomize
+    files:
+      - sitecustomize.py=./resources/sitecustomize.py
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/media/beets/app/resources/sitecustomize.py
+++ b/kubernetes/apps/media/beets/app/resources/sitecustomize.py
@@ -1,0 +1,17 @@
+# Force the pyacoustid client to use HTTPS.
+#
+# pyacoustid's bundled default base URL is http://api.acoustid.org/v2/
+# (plain HTTP, port 80). This cluster's egress blocks outbound port 80
+# ([Errno 101] Network unreachable), while port 443 works fine — so every
+# beets `chroma` fingerprint lookup was silently failing and falling back
+# to tag-only MusicBrainz search, which cannot match poorly-tagged files.
+#
+# sitecustomize is auto-imported by CPython at interpreter startup (this
+# file's directory is placed on PYTHONPATH via the HelmRelease), so this
+# runs before beets loads the chroma plugin.
+#
+# Remove when the cluster permits outbound port 80, or when pyacoustid
+# defaults to HTTPS upstream.
+import acoustid
+
+acoustid.set_base_url("https://api.acoustid.org/v2/")


### PR DESCRIPTION
## Problem

beets' `chroma` (AcoustID fingerprint) matching has been **silently failing cluster-wide**. The bundled `pyacoustid` client defaults to `http://api.acoustid.org/v2/` — **plain HTTP, port 80** — and this cluster's egress blocks outbound port 80 (`[Errno 101] Network unreachable`), while port 443/HTTPS works fine.

Consequence: every fingerprint lookup errored out and beets fell back to **tag-only MusicBrainz search**, which can't identify poorly-tagged files. So the routine 12h beets CronJob has effectively been running without fingerprint matching for a long time.

## Fix

- Add `resources/sitecustomize.py` → calls `acoustid.set_base_url("https://api.acoustid.org/v2/")`.
- Expose it as the `beets-sitecustomize` ConfigMap and put its dir on `PYTHONPATH`, so CPython auto-imports it at interpreter startup, before beets loads the chroma plugin.

Config-only; no image or network change. (Forcing HTTPS is preferable to opening outbound port 80, which is blocked by design.)

## Verification

- A manual HTTPS AcoustID lookup returns the correct recording match (score 0.97, correct MBID).
- With `sitecustomize` active, `chroma` fingerprints and AcoustID returns recording MBIDs (confirmed in an ad-hoc Job); `kubectl kustomize` renders the ConfigMap + `PYTHONPATH` + mount correctly.

## Scope / non-goals

This un-breaks fingerprint matching for **normally-tagged** content going forward. It does **not** retag the existing poorly-tagged library buckets — even with fingerprinting fixed, beets' quiet-mode autotagger won't auto-apply matches when the file's existing tags are garbage (distance exceeds the accept threshold). That cleanup is deliberately out of scope here.

## Blast radius

Single app (`media/beets`), config-only, 1 CronJob. Reversible by removing the ConfigMap + `PYTHONPATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)