### PR TITLE
feat(container): update frigate ( 0.17.2 → 0.18.0 )

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
           app:
             image:
               repository: ghcr.io/blakeblackshear/frigate
-              tag: 0.17.2@sha256:d4351369984d4a9e2a49ac59736f6490856a7ea11f7790040746d21496967010
+              tag: 0.18.0@sha256:9678a83a76e4730ac7d9ea7428370e32ae656d6b312aaad30d6c69f3fef14d35
 
             env:
               # Semantic Search's jina-clip-v1 model is fully cached on the


### PR DESCRIPTION
Bumps Frigate `0.17.2` → `0.18.0` (pinned by digest).

Release: https://github.com/blakeblackshear/frigate/releases/tag/v0.18.0

## Major version — config auto-migrates on first start
0.18 rewrites the config on startup (zones/masks gain `enabled` +
`friendly_name`; global `genai` gains provider `roles`; `version: 0.17-0` →
`0.18-0`). The startup snapshot sidecar (`WAIT_BEFORE=120`) captures the
migrated config to git, and the config PVC is on Longhorn (backed up), so
the migration is recoverable.

## Pre-flight verified against the live config
| Breaking change | Applies here? |
|---|---|
| Removed opts: `sync_recordings`, `timelapse_args`, `ui.date_format`, `ui.time_format` | No — none present |
| DeGirum removed / DeepStack deprecated | No — detector is Coral edgetpu |
| ffmpeg 8 go2rtc hardware-transcode issue | No — no active go2rtc stream transcodes with `#hardware` |
| `/api/export` DELETE removed | No — snapshots go via git, not the export API |
| genai provider `roles` migration | Auto-migrated |
| zone/mask format change | Auto-migrated (many zones — captured by the snapshot sidecar) |

## Known behavior changes on this host
The Frigate node is Kaby Lake / CentOS Stream 9 / **kernel 5.14**.

- **Intel GPU stats need kernel ≥ 6.5.** In-UI GPU % will go blank. Per the
  release notes this affects **stats reporting only — hardware decode
  (vaapi/i965) is unaffected**. The Prometheus `intel-gpu-exporter` is a
  separate path and keeps working.
- **Snapshots are now clean WebP only** (no burned-in timestamp / bounding
  box). `genai use_snapshot` still works. Any consumer expecting the old
  annotated `.jpg` gets a clean image.

## Watch on first 0.18 start
- `HF_HUB_OFFLINE=1` is set. If 0.18 changes the semantic-search /
  face-rec model, the offline flag blocks the pull — flip to `0` for the
  first boot if search/face-rec errors on a model fetch, then back to `1`.
- Confirm hwaccel decode still initializes (global `preset-vaapi` + i965;
  `loryta_deck` uses `preset-intel-qsv-h264`) under ffmpeg 8.

## Rollout
Household-facing security service — **hold merge for the Tuesday
02:00–04:00 window**. Merging now triggers an immediate Flux rolling
restart + config migration during the day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)